### PR TITLE
Update package references and CI workflows for .NET 8.0-10.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,9 +11,6 @@ on:
         description: 'Whether to restrict the build step to the matrix target framework (useful for PR builds)'
         type: boolean
         default: false
-    secrets:
-      CODECOV_TOKEN:
-        required: false
 
 jobs:
   build:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    name: Build & Test (.NET ${{ matrix.dotnet-version }} / ${{ matrix.os }})
+    name: Build & Test (.NET ${{ matrix.dotnet-version }} - ${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,87 @@
+name: Build and Test
+
+on:
+  workflow_call:
+    inputs:
+      collect-coverage:
+        description: 'Whether to collect and upload code coverage reports to Codecov'
+        type: boolean
+        default: false
+      restrict-build-to-tfm:
+        description: 'Whether to restrict the build step to the matrix target framework (useful for PR builds)'
+        type: boolean
+        default: false
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+jobs:
+  build:
+    name: Build & Test (.NET ${{ matrix.dotnet-version }} / ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        dotnet-version: ['8.0.x', '9.0.x', '10.0.x']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Derive Target Framework (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          VERSION=$(echo "${{ matrix.dotnet-version }}" | sed 's/[^0-9.]*//g')
+          VERSION=$(echo "${VERSION}" | sed 's/\.$//')
+          echo "DOTNET_TFM=net${VERSION}" >> $GITHUB_ENV
+
+      - name: Derive Target Framework (Windows)
+        if: startsWith(matrix.os, 'windows')
+        shell: pwsh
+        run: |
+          $VERSION = "${{ matrix.dotnet-version }}".Substring(0, "${{ matrix.dotnet-version }}".LastIndexOf('.'))
+          "DOTNET_TFM=net$VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Setup .NET ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build (framework-restricted)
+        if: inputs.restrict-build-to-tfm
+        run: dotnet build -c Release --no-restore --framework ${{ env.DOTNET_TFM }}
+
+      - name: Build
+        if: ${{ !inputs.restrict-build-to-tfm }}
+        run: dotnet build -c Release --no-restore
+
+      - name: Test (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: >
+          dotnet test -c Release --no-build --verbosity normal
+          --framework ${{ env.DOTNET_TFM }}
+          ${{ inputs.collect-coverage && '-- --coverage --coverage-output-format cobertura' || '' }}
+
+      - name: Test (Windows)
+        if: startsWith(matrix.os, 'windows')
+        run: >
+          dotnet test -c Release --no-build --verbosity normal
+          --framework ${{ env.DOTNET_TFM }}
+          -- --filter-not-trait "Channel=RabbitMQ"
+          ${{ inputs.collect-coverage && '--coverage --coverage-output-format cobertura' || '' }}
+
+      - name: Upload coverage to Codecov
+        if: inputs.collect-coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+
+

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,8 +14,7 @@ jobs:
     uses: ./.github/workflows/build-test.yml
     with:
       collect-coverage: true
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    secrets: inherit
 
   publish:
     name: Publish Packages
@@ -23,8 +22,7 @@ jobs:
     uses: ./.github/workflows/publish-packages.yml
     with:
       push-to-nuget-org: false
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    secrets: inherit
 
   clean:
     name: Clean Old Packages

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,92 +10,23 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        dotnet-version: [6.0.x, 7.0.x, 8.0.x]
-      fail-fast: false
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-         fetch-depth: 0
-
-      - name: Set the TFM in Ubuntu
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          VERSION=$(echo "${{ matrix.dotnet-version }}" | sed 's/[^0-9.]*//g')
-          VERSION=$(echo "${VERSION}" | sed 's/\.$//')
-          DOTNET_TFM="net${VERSION}"
-          echo "DOTNET_TFM=$DOTNET_TFM" >> $GITHUB_ENV
-
-      - name: Set the TFM in Windows
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          $VERSION = "${{ matrix.dotnet-version }}".Substring(0, "${{ matrix.dotnet-version }}".LastIndexOf('.'))
-          $DOTNET_TFM = "net$VERSION"
-          echo "DOTNET_TFM=$DOTNET_TFM" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Setup .NET ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-
-      - name: Install dependencies
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build -c Release --no-restore
-
-      - name: Test (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: dotnet test -c Release --no-build --verbosity normal --framework ${{ env.DOTNET_TFM }} /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-
-      - name: Test (Windows)
-        if: startsWith(matrix.os, 'windows')
-        run: dotnet test -c Release --no-build --verbosity normal --framework ${{ env.DOTNET_TFM }} /p:CollectCoverage=true /p:CoverletOutputFormat=opencover --filter Channel!=RabbitMQ
-
-      - name: Collect to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+    name: Build & Test
+    uses: ./.github/workflows/build-test.yml
+    with:
+      collect-coverage: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
-    name: Publish Events Packages
+    name: Publish Packages
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-
-    - name: Setup GitVersion
-      uses: gittools/actions/gitversion/setup@v1.1.1
-      with:
-       versionSpec: '5.x'
-
-    - name: Determine Version
-      uses: gittools/actions/gitversion/execute@v1.1.1
-      with:
-         updateAssemblyInfo: true
-
-    - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: 8.0.x
-
-    - name: Build
-      run: dotnet build -c Release /p:Version=${{ env.GitVersion_SemVer }} /p:AssemblyVersion=${{ env.GitVersion_AssemblySemVer }} /p:FileVersion=${{ env.GitVersion_AssemblySemFileVer }}
-
-    - name: Package Artifacts
-      run: dotnet pack -c Release --no-build --include-symbols --output ./pkgs -p:PackageVersion=${{ env.GitVersion_SemVer }}
-
-    - name: Publish Packages on GitHub
-      run: dotnet nuget push ./pkgs/*.nupkg --source "https://nuget.pkg.github.com/deveel/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+    uses: ./.github/workflows/publish-packages.yml
+    with:
+      push-to-nuget-org: false
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   clean:
-    name: Clean Events Packages
+    name: Clean Old Packages
     needs: publish
     uses: ./.github/workflows/clean-packages.yml

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -6,61 +6,8 @@ on:
 
 jobs:
   build:
-    strategy:
-        fail-fast: false
-        matrix:
-          os: [ubuntu-latest, windows-latest]
-          dotnet-version: [6.0.x, 7.0.x, 8.0.x]
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-  
-      - name: Set the TFM in Ubuntu
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          VERSION=$(echo "${{ matrix.dotnet-version }}" | sed 's/[^0-9.]*//g')
-          VERSION=$(echo "${VERSION}" | sed 's/\.$//')
-          DOTNET_TFM="net${VERSION}"
-          echo "DOTNET_TFM=$DOTNET_TFM" >> $GITHUB_ENV
-
-      - name: Set the TFM in Windows
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          $VERSION = "${{ matrix.dotnet-version }}".Substring(0, "${{ matrix.dotnet-version }}".LastIndexOf('.'))
-          $DOTNET_TFM = "net$VERSION"
-          echo "DOTNET_TFM=$DOTNET_TFM" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Setup GitVsion
-        uses: gittools/actions/gitversion/setup@v1.1.1
-        with:
-          versionSpec: '5.x'
-
-      - name: Determine GitVersion
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v1.1.1
-        with:
-          updateAssemblyInfo: true
-    
-      - name: Setup .NET ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-    
-      - name: Install dependencies
-        run: dotnet restore
-    
-      - name: Build
-        run: dotnet build -c Release --no-restore -f ${{ env.DOTNET_TFM }}
-    
-      - name: Test (Ubuntu))
-        if: startsWith(matrix.os, 'ubuntu')
-        run: dotnet test -c Release --no-build --verbosity normal --framework ${{ env.DOTNET_TFM }}
-
-      - name: Test (Windows)
-        if: startsWith(matrix.os, 'windows')
-        run: dotnet test -c Release --no-build --verbosity normal --framework ${{ env.DOTNET_TFM }} --filter Channel!=RabbitMQ
-    
+    name: Build & Test
+    uses: ./.github/workflows/build-test.yml
+    with:
+      collect-coverage: false
+      restrict-build-to-tfm: true

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,11 +7,6 @@ on:
         description: 'Whether to also push packages to the public NuGet.org feed (in addition to GitHub Packages)'
         type: boolean
         default: false
-    secrets:
-      GITHUB_TOKEN:
-        required: true
-      NUGET_API_KEY:
-        required: false
 
 jobs:
   publish:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,69 @@
+name: Publish NuGet Packages
+
+on:
+  workflow_call:
+    inputs:
+      push-to-nuget-org:
+        description: 'Whether to also push packages to the public NuGet.org feed (in addition to GitHub Packages)'
+        type: boolean
+        default: false
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      NUGET_API_KEY:
+        required: false
+
+jobs:
+  publish:
+    name: Pack & Publish NuGet Packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup GitVersion
+        uses: gittools/actions/gitversion/setup@v1.1.1
+        with:
+          versionSpec: '5.x'
+
+      - name: Determine Version
+        uses: gittools/actions/gitversion/execute@v1.1.1
+        with:
+          updateAssemblyInfo: true
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build
+        run: >
+          dotnet build -c Release
+          /p:Version=${{ env.GitVersion_SemVer }}
+          /p:AssemblyVersion=${{ env.GitVersion_AssemblySemVer }}
+          /p:FileVersion=${{ env.GitVersion_AssemblySemFileVer }}
+
+      - name: Pack
+        run: >
+          dotnet pack -c Release --no-build --include-symbols --include-source
+          --output ./nuget
+          -p:PackageVersion=${{ env.GitVersion_SemVer }}
+
+      - name: Push to GitHub Packages
+        run: >
+          dotnet nuget push ./nuget/*.nupkg
+          --source "https://nuget.pkg.github.com/deveel/index.json"
+          --api-key ${{ secrets.GITHUB_TOKEN }}
+          --skip-duplicate
+
+      - name: Push to NuGet.org
+        if: inputs.push-to-nuget-org
+        run: >
+          dotnet nuget push ./nuget/*.nupkg
+          --source https://api.nuget.org/v3/index.json
+          --api-key ${{ secrets.NUGET_API_KEY }}
+          --skip-duplicate
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,81 +10,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
-        dotnet-version: [ '6.0.x', '7.0.x', '8.0.x' ]
-
-    steps:
-    - uses: actions/checkout@v5
-  
-    - name: Set the TFM in Ubuntu
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-          VERSION=$(echo "${{ matrix.dotnet-version }}" | sed 's/[^0-9.]*//g')
-          VERSION=$(echo "${VERSION}" | sed 's/\.$//')
-          DOTNET_TFM="net${VERSION}"
-          echo "DOTNET_TFM=$DOTNET_TFM" >> $GITHUB_ENV
-
-    - name: Set the TFM in Windows
-      if: startsWith(matrix.os, 'windows')
-      run: |
-          $VERSION = "${{ matrix.dotnet-version }}".Substring(0, "${{ matrix.dotnet-version }}".LastIndexOf('.'))
-          $DOTNET_TFM = "net$VERSION"
-          echo "DOTNET_TFM=$DOTNET_TFM" | Out-File -FilePath $env:GITHUB_ENV -Append
-    
-    - name: Setup .NET ${{ matrix.dotnet-version }} Framework
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: ${{ matrix.dotnet-version }}
-              
-    - name: Restore dependencies
-      run: dotnet restore
-      
-    - name: Build
-      run: dotnet build --no-restore -c Release
-      
-    - name: Test (Ubuntu)
-      if: startsWith(matrix.os, 'ubuntu')
-      run: dotnet test --no-build --verbosity normal -c Release --framework ${{ env.DOTNET_TFM }} /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-
-    - name: Test (Windows)
-      if: startsWith(matrix.os, 'windows')
-      run: dotnet test --no-build --verbosity normal -c Release --framework ${{ env.DOTNET_TFM }} /p:CollectCoverage=true /p:CoverletOutputFormat=opencover --filter Channel!=RabbitMQ
-      
-    - name: Collect to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+  build:
+    name: Build & Test
+    uses: ./.github/workflows/build-test.yml
+    with:
+      collect-coverage: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-  
-    - name: Setup GitVsion
-      uses: gittools/actions/gitversion/setup@v1.1.1
-      with:
-        versionSpec: '5.x'
-
-    - name: Determine GitVersion
-      id: gitversion
-      uses: gittools/actions/gitversion/execute@v1.1.1
-      with:
-        updateAssemblyInfo: true
-
-
-    - name: Pack NuGet
-      run: dotnet pack -p:PackageVersion=${{ env.GitVersion_SemVer }} -c Release -o ./nuget -p:Version=${{ env.GitVersion_SemVer }} --include-symbols --include-source
-      
-    - name: Push Github Nuget
-      run: dotnet nuget push ./nuget/*.nupkg -s "https://nuget.pkg.github.com/deveel/index.json" --skip-duplicate --api-key ${{secrets.GITHUB_TOKEN}}
-
-    - name: Push to Github.org
-      run: dotnet nuget push ./nuget/**/*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+    name: Publish Packages
+    needs: build
+    uses: ./.github/workflows/publish-packages.yml
+    with:
+      push-to-nuget-org: true
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@ jobs:
     uses: ./.github/workflows/build-test.yml
     with:
       collect-coverage: true
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    secrets: inherit
 
   publish:
     name: Publish Packages
@@ -24,6 +23,4 @@ jobs:
     uses: ./.github/workflows/publish-packages.yml
     with:
       push-to-nuget-org: true
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    secrets: inherit

--- a/benchmarks/DeveelEventsBenchmarks/DeveelEventsBenchmarks.csproj
+++ b/benchmarks/DeveelEventsBenchmarks/DeveelEventsBenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Deveel.Events.Publisher.AzureServiceBus/Deveel.Events.Publisher.AzureServiceBus.csproj
+++ b/src/Deveel.Events.Publisher.AzureServiceBus/Deveel.Events.Publisher.AzureServiceBus.csproj
@@ -9,15 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
   </ItemGroup>
 </Project>

--- a/src/Deveel.Events.Publisher.MassTransit/Deveel.Events.Publisher.MassTransit.csproj
+++ b/src/Deveel.Events.Publisher.MassTransit/Deveel.Events.Publisher.MassTransit.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
-    <PackageReference Include="MassTransit" Version="8.3.6" />
+    <PackageReference Include="MassTransit" Version="9.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Deveel.Events.Publisher\Deveel.Events.Publisher.csproj" />

--- a/src/Deveel.Events.Publisher/Deveel.Events.Publisher.csproj
+++ b/src/Deveel.Events.Publisher/Deveel.Events.Publisher.csproj
@@ -6,17 +6,17 @@
     </Description>
     <PackageTags>event;events;ddd;publisher;channel;core</PackageTags>
   </PropertyGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-  </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.15" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />

--- a/src/Deveel.Events.Publisher/Events/EventPublisherBuilder.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublisherBuilder.cs
@@ -23,6 +23,7 @@ namespace Deveel.Events {
         public IServiceCollection Services { get; }
 
 		private void AddDefaultServices() {
+			Services.AddOptions<EventPublisherOptions>();
 			Services.TryAddSingleton<EventPublisher>();
 			Services.TryAddSingleton<IEventIdGenerator>(EventGuidGenerator.Default);
 			Services.TryAddSingleton<IEventSystemTime>(EventSystemTime.Instance);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Deveel</RootNamespace>
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <Authors>antonello</Authors>
     <Company>Deveel</Company>
-    <Copyright>Copyright (C) 2024 Antonello Provenzano</Copyright>
+    <Copyright>Copyright (C) 2024-2026 Antonello Provenzano</Copyright>
     <RepositoryUrl>https://github.com/deveel/deveel.events</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -28,8 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" Condition="$(TargetFramework) != 'net8.0'" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" Condition="$(TargetFramework) == 'net8.0'" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" Condition="$(TargetFramework) != 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/Deveel.Events.Publisher.AzureServiceBus.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/Deveel.Events.Publisher.AzureServiceBus.XUnit.csproj
@@ -1,14 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-  </ItemGroup>
-
+  
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/Deveel.Events.Publisher.AzureServiceBus.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/Deveel.Events.Publisher.AzureServiceBus.XUnit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" />
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>
 

--- a/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/Events/ServiceBusChannelTests.cs
+++ b/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/Events/ServiceBusChannelTests.cs
@@ -9,8 +9,6 @@ using CloudNative.CloudEvents;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-using Xunit.Abstractions;
-
 namespace Deveel.Events {
 	[Trait("Channel", "ServiceBus")]
 	[Trait("Function", "Publish")]

--- a/test/Deveel.Events.Publisher.MassTransit.XUnit/Deveel.Events.Publisher.MassTransit.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.MassTransit.XUnit/Deveel.Events.Publisher.MassTransit.XUnit.csproj
@@ -2,9 +2,9 @@
   <ItemGroup>
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" Condition="$(TargetFramework) == 'net6.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" Condition="$(TargetFramework) == 'net7.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" Condition="$(TargetFramework) == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="$(TargetFramework) == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" Condition="$(TargetFramework) == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" Condition="$(TargetFramework) == 'net10.0'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deveel.Events.Publisher.MassTransit\Deveel.Events.Publisher.MassTransit.csproj" />

--- a/test/Deveel.Events.Publisher.MassTransit.XUnit/Deveel.Events.Publisher.MassTransit.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.MassTransit.XUnit/Deveel.Events.Publisher.MassTransit.XUnit.csproj
@@ -4,6 +4,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="$(TargetFramework) == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" Condition="$(TargetFramework) == 'net9.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" Condition="$(TargetFramework) == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" Condition="$(TargetFramework) == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.15" Condition="$(TargetFramework) == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" Condition="$(TargetFramework) == 'net10.0'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deveel.Events.Publisher.MassTransit\Deveel.Events.Publisher.MassTransit.csproj" />

--- a/test/Deveel.Events.Publisher.MassTransit.XUnit/Deveel.Events.Publisher.MassTransit.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.MassTransit.XUnit/Deveel.Events.Publisher.MassTransit.XUnit.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="$(TargetFramework) == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" Condition="$(TargetFramework) == 'net9.0'" />

--- a/test/Deveel.Events.Publisher.MassTransit.XUnit/Events/MassTransitChannelPublishTests.cs
+++ b/test/Deveel.Events.Publisher.MassTransit.XUnit/Events/MassTransitChannelPublishTests.cs
@@ -16,8 +16,6 @@ using NSubstitute;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-using Xunit.Abstractions;
-
 namespace Deveel.Events
 {
     [Trait("Channel", "MassTransit")]

--- a/test/Deveel.Events.Publisher.MassTransit.XUnit/Events/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.MassTransit.XUnit/Events/ServiceRegistrationTests.cs
@@ -1,0 +1,79 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+namespace Deveel.Events
+{
+    [Trait("Channel", "MassTransit")]
+    [Trait("Function", "Registration")]
+    public static class ServiceRegistrationTests
+    {
+        [Fact]
+        public static void UseMassTransit_RegistersChannel()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseMassTransit();
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IEventPublishChannel) &&
+                d.ImplementationType == typeof(MassTransitEventPublishChannel));
+        }
+        [Fact]
+        public static void UseMassTransit_WithConfigureAction_ConfiguresOptions()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseMassTransit(options =>
+                {
+                    options.DestinationAddress = new Uri("rabbitmq://localhost/my-queue");
+                    options.MapAttributesToHeaders = false;
+                });
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IEventPublishChannel) &&
+                d.ImplementationType == typeof(MassTransitEventPublishChannel));
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<MassTransitEventPublishChannelOptions>>();
+            Assert.NotNull(options.Value);
+            Assert.Equal(new Uri("rabbitmq://localhost/my-queue"), options.Value.DestinationAddress);
+            Assert.False(options.Value.MapAttributesToHeaders);
+        }
+        [Fact]
+        public static void UseMassTransit_WithSectionPath_BindsOptionsFromConfiguration()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["MassTransit:DestinationAddress"] = "rabbitmq://localhost/my-queue",
+                    ["MassTransit:MapAttributesToHeaders"] = "false",
+                })
+                .Build();
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+            services.AddEventPublisher()
+                .UseMassTransit("MassTransit");
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IEventPublishChannel) &&
+                d.ImplementationType == typeof(MassTransitEventPublishChannel));
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<MassTransitEventPublishChannelOptions>>();
+            Assert.NotNull(options.Value);
+            Assert.Equal(new Uri("rabbitmq://localhost/my-queue"), options.Value.DestinationAddress);
+            Assert.False(options.Value.MapAttributesToHeaders);
+        }
+        [Fact]
+        public static void UseMassTransit_DefaultOptions_HasExpectedDefaults()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseMassTransit();
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<MassTransitEventPublishChannelOptions>>();
+            Assert.NotNull(options.Value);
+            Assert.Null(options.Value.DestinationAddress);
+            Assert.True(options.Value.MapAttributesToHeaders);
+        }
+    }
+}

--- a/test/Deveel.Events.Publisher.RabbitMq.XUnit/Deveel.Events.Publisher.RabbitMq.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.RabbitMq.XUnit/Deveel.Events.Publisher.RabbitMq.XUnit.csproj
@@ -3,6 +3,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="$(TargetFramework) == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" Condition="$(TargetFramework) == 'net9.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" Condition="$(TargetFramework) == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" Condition="$(TargetFramework) == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.15" Condition="$(TargetFramework) == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" Condition="$(TargetFramework) == 'net10.0'" />
     <PackageReference Include="Testcontainers.RabbitMq" Version="4.11.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Deveel.Events.Publisher.RabbitMq.XUnit/Deveel.Events.Publisher.RabbitMq.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.RabbitMq.XUnit/Deveel.Events.Publisher.RabbitMq.XUnit.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">  
   <ItemGroup>
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.10" Condition="$(TargetFramework) == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="$(TargetFramework) == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" Condition="$(TargetFramework) == 'net9.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" Condition="$(TargetFramework) == 'net10.0'" />
     <PackageReference Include="Testcontainers.RabbitMq" Version="4.11.0" />

--- a/test/Deveel.Events.Publisher.RabbitMq.XUnit/Deveel.Events.Publisher.RabbitMq.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.RabbitMq.XUnit/Deveel.Events.Publisher.RabbitMq.XUnit.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">  
   <ItemGroup>
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" Condition="$(TargetFramework) == 'net6.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" Condition="$(TargetFramework) == 'net7.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" Condition="$(TargetFramework) == 'net8.0'" />
-    <PackageReference Include="Testcontainers.RabbitMq" Version="3.10.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.10" Condition="$(TargetFramework) == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" Condition="$(TargetFramework) == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" Condition="$(TargetFramework) == 'net10.0'" />
+    <PackageReference Include="Testcontainers.RabbitMq" Version="4.11.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deveel.Events.Publisher.RabbitMq\Deveel.Events.Publisher.RabbitMq.csproj" />

--- a/test/Deveel.Events.Publisher.RabbitMq.XUnit/Events/RabbitMqChannelPublishTests.cs
+++ b/test/Deveel.Events.Publisher.RabbitMq.XUnit/Events/RabbitMqChannelPublishTests.cs
@@ -10,8 +10,6 @@ using RabbitMQ.Client.Events;
 using System.Text;
 using System.Text.Json;
 
-using Xunit.Abstractions;
-
 namespace Deveel.Events
 {
     [Trait("Channel", "RabbitMq")]
@@ -46,7 +44,7 @@ namespace Deveel.Events
 
         private CloudEvent? ReceivedEvent { get; set; }
 
-        public async Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
             var connection = Services.GetRequiredService<IConnection>();
             _channel = await connection.CreateChannelAsync();
@@ -70,7 +68,7 @@ namespace Deveel.Events
             await _channel.BasicConsumeAsync("test.queue1", autoAck: true, consumer: consumer);
         }
 
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             if (_channel != null)
                 await _channel.DisposeAsync();

--- a/test/Deveel.Events.Publisher.RabbitMq.XUnit/Events/RabbitMqChannelPublishTests.cs
+++ b/test/Deveel.Events.Publisher.RabbitMq.XUnit/Events/RabbitMqChannelPublishTests.cs
@@ -12,7 +12,7 @@ using System.Text.Json;
 
 namespace Deveel.Events
 {
-    [Trait("Channel", "RabbitMq")]
+    [Trait("Channel", "RabbitMQ")]
     [Trait("Function", "Publish")]
     public class RabbitMqChannelPublishTests : IClassFixture<RabbitMqTestServer>, IAsyncLifetime
     {

--- a/test/Deveel.Events.Publisher.RabbitMq.XUnit/Events/RabbitMqTestServer.cs
+++ b/test/Deveel.Events.Publisher.RabbitMq.XUnit/Events/RabbitMqTestServer.cs
@@ -16,13 +16,13 @@ namespace Deveel.Events
         public string ConnectionString => rabbitMq.GetConnectionString();
 
 
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             await rabbitMq.StopAsync();
             await rabbitMq.DisposeAsync();
         }
 
-        public async Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
             await rabbitMq.StartAsync();
         }

--- a/test/Deveel.Events.Publisher.RabbitMq.XUnit/Events/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.RabbitMq.XUnit/Events/ServiceRegistrationTests.cs
@@ -1,0 +1,145 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+namespace Deveel.Events
+{
+    [Trait("Function", "Registration")]
+    public static class ServiceRegistrationTests
+    {
+        private const string ValidConnectionString = "amqp://guest:guest@localhost:5672/";
+        [Fact]
+        public static void UseRabbitMq_WithConfigureAction_RegistersServices()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseRabbitMq(options =>
+                {
+                    options.ConnectionString = ValidConnectionString;
+                    options.ExchangeName = "my-exchange";
+                    options.QueueName = "my-queue";
+                });
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IEventPublishChannel) &&
+                d.ImplementationType == typeof(RabbitMqEventPublishChannel));
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IRabbitMqConnectionFactory) &&
+                d.ImplementationType == typeof(RabbitMqConnectionFactory));
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IRabbitMqMessageFactory) &&
+                d.ImplementationType == typeof(RabbitMqMessageFactory));
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IConnection));
+        }
+        [Fact]
+        public static void UseRabbitMq_WithConfigureAction_ConfiguresOptions()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseRabbitMq(options =>
+                {
+                    options.ConnectionString = ValidConnectionString;
+                    options.ExchangeName = "my-exchange";
+                    options.QueueName = "my-queue";
+                    options.RoutingKey = "my-routing-key";
+                    options.ClientName = "TestClient";
+                    options.PersistentMessages = false;
+                    options.PublisherConfirms = false;
+                    options.Mandatory = true;
+                    options.MessageFormat = RabbitMqMessageFormat.Json;
+                    options.MessageContent = RabbitMqMessageContent.CloudEvent;
+                    options.ConfirmTimeout = TimeSpan.FromSeconds(10);
+                });
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<RabbitMqEventPublishChannelOptions>>();
+            Assert.NotNull(options.Value);
+            Assert.Equal(ValidConnectionString, options.Value.ConnectionString);
+            Assert.Equal("my-exchange", options.Value.ExchangeName);
+            Assert.Equal("my-queue", options.Value.QueueName);
+            Assert.Equal("my-routing-key", options.Value.RoutingKey);
+            Assert.Equal("TestClient", options.Value.ClientName);
+            Assert.False(options.Value.PersistentMessages);
+            Assert.False(options.Value.PublisherConfirms);
+            Assert.True(options.Value.Mandatory);
+            Assert.Equal(RabbitMqMessageFormat.Json, options.Value.MessageFormat);
+            Assert.Equal(RabbitMqMessageContent.CloudEvent, options.Value.MessageContent);
+            Assert.Equal(TimeSpan.FromSeconds(10), options.Value.ConfirmTimeout);
+        }
+        [Fact]
+        public static void UseRabbitMq_DefaultOptions_HasExpectedDefaults()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseRabbitMq(options =>
+                {
+                    options.ConnectionString = ValidConnectionString;
+                });
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<RabbitMqEventPublishChannelOptions>>();
+            Assert.NotNull(options.Value);
+            Assert.True(options.Value.PersistentMessages);
+            Assert.True(options.Value.PublisherConfirms);
+            Assert.False(options.Value.Mandatory);
+            Assert.Equal(TimeSpan.FromSeconds(5), options.Value.ConfirmTimeout);
+            Assert.Equal(RabbitMqMessageFormat.Json, options.Value.MessageFormat);
+            Assert.Equal(RabbitMqMessageContent.CloudEvent, options.Value.MessageContent);
+        }
+        [Fact]
+        public static void UseRabbitMq_WithSectionPath_BindsOptionsFromConfiguration()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["RabbitMq:ConnectionString"] = ValidConnectionString,
+                    ["RabbitMq:ExchangeName"] = "config-exchange",
+                    ["RabbitMq:QueueName"] = "config-queue",
+                    ["RabbitMq:RoutingKey"] = "config-routing-key",
+                    ["RabbitMq:ClientName"] = "ConfigClient",
+                    ["RabbitMq:PersistentMessages"] = "false",
+                    ["RabbitMq:PublisherConfirms"] = "false",
+                })
+                .Build();
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+            services.AddEventPublisher()
+                .UseRabbitMq("RabbitMq");
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IEventPublishChannel) &&
+                d.ImplementationType == typeof(RabbitMqEventPublishChannel));
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<RabbitMqEventPublishChannelOptions>>();
+            Assert.NotNull(options.Value);
+            Assert.Equal(ValidConnectionString, options.Value.ConnectionString);
+            Assert.Equal("config-exchange", options.Value.ExchangeName);
+            Assert.Equal("config-queue", options.Value.QueueName);
+            Assert.Equal("config-routing-key", options.Value.RoutingKey);
+            Assert.Equal("ConfigClient", options.Value.ClientName);
+            Assert.False(options.Value.PersistentMessages);
+            Assert.False(options.Value.PublisherConfirms);
+        }
+        [Fact]
+        public static void UseRabbitMq_CustomConnectionFactory_IsNotReplaced()
+        {
+            var services = new ServiceCollection();
+            var customFactory = new CustomRabbitMqConnectionFactory();
+            services.AddSingleton<IRabbitMqConnectionFactory>(customFactory);
+            services.AddEventPublisher()
+                .UseRabbitMq(options =>
+                {
+                    options.ConnectionString = ValidConnectionString;
+                });
+            var provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IRabbitMqConnectionFactory>();
+            Assert.Same(customFactory, factory);
+        }
+        private class CustomRabbitMqConnectionFactory : IRabbitMqConnectionFactory
+        {
+            public Task<IConnection> CreateConnectionAsync(CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Deveel.Events.Publisher.XUnit/Deveel.Events.Publisher.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.XUnit/Deveel.Events.Publisher.XUnit.csproj
@@ -11,10 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Deveel.Events.TestPublisher\Deveel.Events.TestPublisher.csproj" />
   </ItemGroup>
 

--- a/test/Deveel.Events.Publisher.XUnit/Deveel.Events.Publisher.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.XUnit/Deveel.Events.Publisher.XUnit.csproj
@@ -1,13 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.15" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Deveel.Events.Publisher.XUnit/Deveel.Events.Publisher.XUnit.csproj
+++ b/test/Deveel.Events.Publisher.XUnit/Deveel.Events.Publisher.XUnit.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Deveel.Events.Publisher.XUnit/Events/PublisherTests.cs
+++ b/test/Deveel.Events.Publisher.XUnit/Events/PublisherTests.cs
@@ -6,8 +6,6 @@ using CloudNative.CloudEvents;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-using Xunit.Abstractions;
-
 namespace Deveel.Events {
 	public class PublisherTests
     {

--- a/test/Deveel.Events.Publisher.XUnit/Events/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.XUnit/Events/ServiceRegistrationTests.cs
@@ -1,0 +1,125 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Deveel.Events
+{
+    [Trait("Function", "Registration")]
+    public static class ServiceRegistrationTests
+    {
+        [Fact]
+        public static void AddEventPublisher_RegistersDefaultServices()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher();
+
+            var provider = services.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<EventPublisher>());
+            Assert.NotNull(provider.GetService<IEventCreator>());
+            Assert.NotNull(provider.GetService<IEventIdGenerator>());
+            Assert.NotNull(provider.GetService<IEventSystemTime>());
+        }
+
+        [Fact]
+        public static void AddEventPublisher_WithConfigureAction_ConfiguresOptions()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher(options =>
+            {
+                options.Source = new Uri("https://api.example.com/my-service");
+                options.ThrowOnErrors = true;
+                options.DataSchemaBaseUri = new Uri("https://schemas.example.com/events");
+                options.Attributes["env"] = "test";
+            });
+
+            var provider = services.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<EventPublisher>());
+
+            var options = provider.GetRequiredService<IOptions<EventPublisherOptions>>();
+            Assert.NotNull(options.Value);
+            Assert.Equal(new Uri("https://api.example.com/my-service"), options.Value.Source);
+            Assert.True(options.Value.ThrowOnErrors);
+            Assert.Equal(new Uri("https://schemas.example.com/events"), options.Value.DataSchemaBaseUri);
+            Assert.Contains("env", options.Value.Attributes.Keys);
+            Assert.Equal("test", options.Value.Attributes["env"]);
+        }
+
+        [Fact]
+        public static void AddEventPublisher_WithSectionPath_BindsOptionsFromConfiguration()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Events:Source"] = "https://api.example.com/my-service",
+                    ["Events:ThrowOnErrors"] = "true",
+                    ["Events:DataSchemaBaseUri"] = "https://schemas.example.com/events",
+                })
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+            services.AddEventPublisher("Events");
+
+            var provider = services.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<EventPublisher>());
+
+            var options = provider.GetRequiredService<IOptions<EventPublisherOptions>>();
+            Assert.NotNull(options.Value);
+            Assert.Equal(new Uri("https://api.example.com/my-service"), options.Value.Source);
+            Assert.True(options.Value.ThrowOnErrors);
+            Assert.Equal(new Uri("https://schemas.example.com/events"), options.Value.DataSchemaBaseUri);
+        }
+
+        [Fact]
+        public static void UseGuid_ReplacesDefaultIdGenerator()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseGuid("N");
+
+            var provider = services.BuildServiceProvider();
+
+            var idGenerator = provider.GetRequiredService<IEventIdGenerator>();
+            Assert.IsType<EventGuidGenerator>(idGenerator);
+
+            var options = provider.GetRequiredService<IOptions<EventGuidGeneratorOptions>>();
+            Assert.Equal("N", options.Value.Format);
+        }
+
+        [Fact]
+        public static void UsePublisher_ReplacesDefaultPublisher()
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UsePublisher<CustomEventPublisher>();
+
+            var provider = services.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<EventPublisher>());
+            Assert.IsType<CustomEventPublisher>(provider.GetService<EventPublisher>());
+        }
+
+        private class CustomEventPublisher : EventPublisher
+        {
+            public CustomEventPublisher(
+                IOptions<EventPublisherOptions> options,
+                IEnumerable<IEventPublishChannel> channels,
+                IEventCreator? eventCreator = null,
+                IEventIdGenerator? idGenerator = null,
+                IEventSystemTime? systemTime = null)
+                : base(options, channels, eventCreator, idGenerator, systemTime)
+            {
+            }
+        }
+    }
+}
+
+

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Deveel</RootNamespace>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1"/>
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2"/>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -14,6 +14,7 @@
     
     <UseMicrosoftTestingPlatformRunner>True</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>True</TestingPlatformDotnetTestSupport>
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,19 +4,22 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Deveel</RootNamespace>
+    
+    <OutputType>Exe</OutputType>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 
     <NoWarn>$(NoWarn);CS8618</NoWarn>
+    
+    <UseMicrosoftTestingPlatformRunner>True</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>True</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1"/>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request modernizes the build, test, and packaging workflows for the project, updating CI/CD pipelines to use reusable workflow files, and upgrades the supported target frameworks and dependencies to .NET 8, 9, and 10. It also removes legacy framework support and streamlines package references for greater maintainability and future-proofing.

**CI/CD Pipeline Modernization:**

* Introduced reusable workflow files (`build-test.yml`, `publish-packages.yml`) and refactored `cicd.yml`, `pr-build.yml`, and `release.yml` to use them, reducing duplication and improving maintainability. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32R1-R84) [[2]](diffhunk://#diff-f649dfa0883378db13b96d378fbaedfaf99e75a92d0962d813575b79643dd01bR1-R64) [[3]](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L13-R28) [[4]](diffhunk://#diff-404033996c34f9971e0c112d8538b9063618fc85059a44df7d4db448974888caL9-R13) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L13-R26)
* Updated job matrices to target .NET 8.0, 9.0, and 10.0, and dropped support for .NET 6 and 7. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32R1-R84) [[2]](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L3-R3)

**Target Framework and Dependency Upgrades:**

* Updated all projects to target `net8.0`, `net9.0`, and `net10.0` only, removing legacy target frameworks. [[1]](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L3-R3) [[2]](diffhunk://#diff-5dc1ac8e767317a82b30b3bf142b0c2a92acbc842a06d118279cd0c46d9d8981L5-R5)
* Upgraded key dependencies (e.g., `Azure.Messaging.ServiceBus`, `MassTransit`, `Microsoft.Extensions.*`) to versions compatible with .NET 8/9/10. [[1]](diffhunk://#diff-8787086d0c340a10383060474c3950bba41777e48a8ef8b9f2abde3f3754b718L12-R12) [[2]](diffhunk://#diff-a95ea133b6ac2fe2b94b0a2205268e97d5e8b82752d9b7e05f7242b5404f3cd1L9-R9) [[3]](diffhunk://#diff-329a8bc99292dffa218fe47a69644377edefae58dc510874e9f5b2b98d700335L9-R19) [[4]](diffhunk://#diff-e0daa413581fc7e127e856cdff4c31f095041175bce3cb8d10215253206996ceL3-L15) [[5]](diffhunk://#diff-7dfacb2328d27f239a760b0734a77c197df8a66973428cdb2e1430bc2cfe91caL3-R6)
* Updated `Microsoft.SourceLink.GitHub` to version 10 for new frameworks.

**Other Improvements:**

* Updated copyright years.
* Removed unnecessary test package references and unused imports. [[1]](diffhunk://#diff-b3cfb45c3ba5e45b77d6c90cb4f531de674b575ac04a60231569ca740ba1cfe2L12-L13) [[2]](diffhunk://#diff-e35df7a32452f292698fa440af1db592302c9e8581aa9fda377ec79948da4099L19-L20)

These changes ensure the project is up-to-date with the latest .NET ecosystem and that the build and release process is more robust and easier to maintain.