### PR TITLE
Add documentation structure with README and SUMMARY files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,460 +2,94 @@
 ![GitHub Release](https://img.shields.io/github/v/release/deveel/deveel.events) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/deveel/deveel.events/cicd.yml?logo=github)
 ![Codecov](https://img.shields.io/codecov/c/github/deveel/deveel.events?logo=codecov)
 
-
 # Deveel Events
 
-This project provides a simple and lightweight framework for publishing events to subscribers, using common channels and topics.
+**Deveel Events** is a lightweight, extensible framework for publishing domain events in .NET applications, built on top of the [CloudEvents](https://cloudevents.io/) standard.
 
-The ambition of this little framework is to implement a set of common patterns and practices that can be used to implement a simple and efficient event-driven architecture in a .NET application, using common approaches to create events and publish them.
+The ambition of this framework is to implement a set of common patterns and practices for a simple and efficient event-driven architecture in .NET, without reinventing the wheel every time a team needs to broadcast domain events.
 
-It is not in the scope of this project to provide a full-featured event storage system, nor a complex pub/sub application: if you need such a system, you should consider using a message broker or a message queue system (such as RabbitMQ, Kafka, or Azure Service Bus) to implement a more complex and scalable event-driven architecture).
+It is not in the scope of this project to provide a full-featured event storage system or a complex pub/sub platform. If you need those capabilities, consider pairing this library with a dedicated message broker — Deveel Events already ships channel adapters for the most popular ones.
+
+## Domain Events and DDD
+
+[Domain-Driven Design (DDD)](https://martinfowler.com/bliki/DomainDrivenDesign.html) treats **domain events** as first-class citizens of the model — facts about something that _happened_ inside the domain, named in the ubiquitous language of domain experts (`OrderPlaced`, `InvoiceIssued`, `UserRegistered`).
+
+Key properties of domain events:
+
+- **Immutable facts** — they describe what happened, not what should happen.
+- **Decoupled producers and consumers** — the producing bounded context does not need to know who is listening.
+- **Cross-context integration** — events are the preferred way to share information across bounded contexts without tight coupling.
+- **Temporal decoupling** — consumers can process events asynchronously, at their own pace.
+
+Deveel Events implements the **publishing side** of this pattern: a transport-agnostic layer that broadcasts domain events from a bounded context to any number of downstream consumers, without prescribing how you model aggregates or build read models.
+
+## Event Schemas as Async API Contracts
+
+Publishing an event is only half the story. Consumers need to know the **shape** of each event — its properties, types, and constraints — to deserialise it correctly and build reliable integrations. Without a formal contract, field renames silently break consumers and integration knowledge lives only in tribal memory.
+
+**Event schemas** fill the same role for asynchronous messaging that OpenAPI/Swagger fills for REST APIs. The `Deveel.Events.Schema` package can derive a schema automatically from annotated data classes and export it as:
+
+- **JSON Schema** — for schema-registry integration and tooling.
+- **YAML** — for human-readable, version-controlled contract documents.
+- **AsyncAPI 2.x** — a complete, machine-readable async API specification. AsyncAPI tooling can generate documentation sites, client SDKs, and mock servers from it.
+
+Treat schemas as public API contracts: version them, prefer additive changes, and communicate breaking changes in advance.
 
 ## Motivation
 
-Often when developing applications, it is necessary to implement a mechanism to notify other parts of the system about changes or events that occur in the application: several times the implementor ends up rewriting boilerplate code to manage the events and notifications.
+Applications frequently need to notify other parts of the system about domain events. Teams end up rewriting the same boilerplate — serialising payloads, constructing envelopes, wiring up transport clients — over and over again.
 
-At the present time, there are several ways to implement such a mechanism, such as using a message broker, a message queue, or a pub/sub system, but every organization should implement its own way to manage events and notifications.
-
-With this small effort, we aim to provide a simple and lightweight framework that can be used to implement a common way to publish events in a .NET application.
+Deveel Events provides a single, consistent way to publish events across any transport, so teams can focus on domain logic instead of infrastructure plumbing.
 
 ## CloudEvents Standard
 
-The framework is designed to be compliant with the [CloudEvents](https://cloudevents.io/) standard, making use of the `CloudEvent` class to represent the reference model for the event.
-
-This choice is made to ensure the maximum compatibility with other systems and services that are compliant with the standard, and to provide a simple and efficient way to serialize and deserialize events.
-
-## Installation
-
-The framework is available as a NuGet package, and can be installed using the `dotnet` cli.
-
-For example, to install the package that provides the publisher to the Azure Service Bus, you can run the following command:
-
-```bash
-dotnet add package Deveel.Events.Publisher.AzureServiceBus
-```
-
-Alternatively, you can use the NuGet package manager in Visual Studio to search and install the package.
-
-### Framework Packages
-
-Packages provided by the framework are:
-
-| Package | Description | NuGet Package | Pre-Release<br/>(GitHub Packages) |
-|---------|-------------|---------------|-------------------------------|
-| `Deveel.Events.Annotations` | A set of attributes used to describe the metadata of an event | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Annotations.svg)](https://www.nuget.org/packages/Deveel.Events.Annotations) | [![GitHub](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Annotations) |
-| `Deveel.Events.Publisher` | The core framework for publishing events | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher) | [![GitHub](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Publisher) |
-| `Deveel.Events.Publisher.AzureServiceBus` | An implementation of the publisher using Azure Service Bus | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.AzureServiceBus.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.AzureServiceBus) | [![GitHub](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Publisher.AzureServiceBus) |
-| `Deveel.Events.Amqp.Annotations` | A set of attributes used to describe the metadata of an event published in AMQP queues | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Amqp.Annotations.svg)](https://www.nuget.org/packages/Deveel.Events.Amqp.Annotations) | [![GitHub](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Amqp.Annotations) |
-| `Deveel.Events.Publisher.RabbitMq` | An implementation of the publisher using RabbitMQ as a channel | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.RabbitMq.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.RabbitMq) | [![GitHub](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Publisher.RabbitMq) |
-| `Deveel.Events.Schema` | Core schema model, fluent builder, JSON writer, and schema validation | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Schema.svg)](https://www.nuget.org/packages/Deveel.Events.Schema) | [![GitHub](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Schema) |
-| `Deveel.Events.Schema.Yaml` | Exports an event schema as a YAML document | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Schema.Yaml.svg)](https://www.nuget.org/packages/Deveel.Events.Schema.Yaml) | [![GitHub](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Schema.Yaml) |
-| `Deveel.Events.Schema.AsyncApi` | Exports one or more event schemas as an AsyncAPI 2.x document (JSON or YAML) | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Schema.AsyncApi.svg)](https://www.nuget.org/packages/Deveel.Events.Schema.AsyncApi) | [![GitHub](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Schema.AsyncApi) |
-
-## Usage
-
-The basic usage of the framework is to create an event, publish it to a channel, and subscribe to the channel to receive the event.
-
-The following example shows how to create an event, publish it to a channel, and subscribe to the channel to receive the event.
-
-To enable this capability, you must first register the publisher in the service collection of your application:
-
-```csharp
-using Deveel.Events;
-
-var builder = WebApplication.CreateBuilder(args);
-
-// ...
-
-builder.Services.AddEventPublisher();
-```
-
-Then, you can create an event and publish it to a channel:
-
-```csharp
-using Deveel.Events;
-
-public class MyService {
-    private readonly IEventPublisher publisher;
-
-    public MyService(IEventPublisher publisher) {
-        this.publisher = publisher;
-    }
-
-    public async Task PublishEventAsync() {
-        var @event = new CloudEvent("com.example.myevent", new Uri("http://example.com/events/123"), "Hello, World!") {
-            ContentType = "text/plain",
-            DataSchema = new Uri("http://example.com/schema"),
-            Source = new Uri("http://example.com"),
-            Data = "Hello, World!"
-        };
-
-        await publisher.PublishEventAsync(@event);
-    }
-}
-```
-
-Note that the above example will publish the event to all the channels that are registered in the publisher.
-
-### Publishing from Event Data
-
-If you have a class that represents the data of an event, you can use the `EventAttribute` to decorate such a class to describe the metadata of the event containing it.
-
-For example, consider the following class:
-
-```csharp
-using Deveel.Events.Annotations;
-
-[Event("com.example.myevent", "1.0")]
-public class MyEventData {
-    [Required]
-    public string Message { get; set; }
-}
-```
-
-You can then publish an event using the data class:
-
-```csharp
-using Deveel.Events;
-
-public class MyService {
-    private readonly IEventPublisher publisher;
-
-    public MyService(IEventPublisher publisher) {
-        this.publisher = publisher;
-    }
-    
-    public async Task PublishEventAsync() {
-        var data = new MyEventData {
-            Message = "Hello, World!"
-        };
-        
-        await publisher.PublishAsync(data);
-    }
-}
-```
-
-## Event Schema
-
-The `Deveel.Events.Schema` package provides a way to describe and validate the structure of events through schemas, ensuring that events conform to an expected contract.
-
-### Installation
-
-```bash
-dotnet add package Deveel.Events.Schema
-```
-
-### Creating a Schema with the Fluent Builder
-
-The `EventSchema.Build()` factory method returns an `EventSchemaBuilder` that allows you to describe every aspect of an event schema in a fluent, readable style:
-
-```csharp
-using Deveel.Events;
-
-var schema = EventSchema.Build("order.placed")
-    .WithVersion("1.0")
-    .WithContentType("application/json")
-    .WithDescription("Raised when a customer places an order")
-    .AddProperty("order_id",  "guid",   p => p.Required())
-    .AddProperty("amount",    "money",  p => p.Required().WithRange<decimal>(0m, 1_000_000m))
-    .AddProperty("currency",  "string", p => p.Required())
-    .AddProperty("notes",     "string", p => p.Nullable())
-    .Build();
-```
-
-You can also describe a property with a configure delegate for richer control:
-
-```csharp
-var schema = EventSchema.Build("user.registered")
-    .WithVersion("1.0")
-    .AddProperty("email", p => p
-        .OfType("string")
-        .Required()
-        .WithDescription("The email address of the new user"))
-    .AddProperty("age", p => p
-        .OfType("int")
-        .WithRange<int>(18, 120))
-    .AddProperty("nickname", p => p
-        .OfType("string")
-        .Nullable())
-    .Build();
-```
-
-### Generating a Schema from an Annotated Class
-
-If you already have a class decorated with `[Event]` and standard data-annotation attributes, you can derive the schema automatically without writing it by hand:
-
-```csharp
-using System.ComponentModel.DataAnnotations;
-using Deveel.Events.Annotations;
-
-[Event("order.placed", "1.0")]
-public class OrderPlacedData {
-    [Required]
-    public Guid OrderId { get; set; }
-
-    [Required]
-    [Range(0.0, 1_000_000.0)]
-    public decimal Amount { get; set; }
-
-    [Required]
-    public string Currency { get; set; } = default!;
-
-    public string? Notes { get; set; }
-}
-```
-
-Use the static helper to create the schema:
-
-```csharp
-// Via the static convenience method
-var schema = EventSchema.FromDataType<OrderPlacedData>();
-
-// Or via the injectable factory (preferred in DI scenarios)
-using Deveel.Events;
-
-public class MyService {
-    private readonly IEventSchemaFactory schemaFactory;
-
-    public MyService(IEventSchemaFactory schemaFactory) {
-        this.schemaFactory = schemaFactory;
-    }
-
-    public EventSchema GetSchema() => schemaFactory.CreateFromType<OrderPlacedData>();
-}
-```
-
-### Exporting the Schema as JSON
-
-A schema can be serialised to a JSON stream with `EventSchemaJsonWriter`:
-
-```csharp
-using Deveel.Events;
-using System.Text.Json;
-
-var schema = EventSchema.FromDataType<OrderPlacedData>();
-
-var writer = new EventSchemaJsonWriter(new JsonWriterOptions { Indented = true });
-
-await using var stream = File.OpenWrite("order-placed-schema.json");
-await writer.WriteToAsync(stream, schema);
-```
-
-The output will look similar to:
-
-```json
-{
-  "type": "order.placed",
-  "version": "1.0",
-  "contentType": "object",
-  "properties": {
-    "OrderId": { "dataType": "guid", "required": true },
-    "Amount":  { "dataType": "money", "required": true, "min": 0, "max": 1000000 },
-    "Currency":{ "dataType": "string", "required": true },
-    "Notes":   { "dataType": "string", "nullable": true }
-  }
-}
-```
-
-### Exporting the Schema as YAML
-
-Install the package:
-
-```bash
-dotnet add package Deveel.Events.Schema.Yaml
-```
-
-Use `EventSchemaYamlWriter` (which implements `IEventSchemaWriter`) to serialise a schema to a YAML stream:
-
-```csharp
-using Deveel.Events;
-
-var schema = EventSchema.FromDataType<OrderPlacedData>();
-
-var writer = new EventSchemaYamlWriter();   // uses camelCase by default
-
-await using var stream = File.OpenWrite("order-placed-schema.yaml");
-await writer.WriteToAsync(stream, schema);
-```
-
-The output will look similar to:
-
-```yaml
-type: order.placed
-version: 1.0
-contentType: object
-properties:
-  orderId:
-    dataType: guid
-    required: true
-  amount:
-    dataType: money
-    required: true
-    min: 0
-    max: 1000000
-  currency:
-    dataType: string
-    required: true
-  notes:
-    dataType: string
-    nullable: true
-```
-
-You can supply a custom `YamlDotNet.Serialization.ISerializer` to the constructor to control naming conventions, anchors, and other serialization options.
-
-### Exporting the Schema as AsyncAPI
-
-Install the package:
-
-```bash
-dotnet add package Deveel.Events.Schema.AsyncApi
-```
-
-#### Single schema → standalone AsyncAPI document
-
-`EventSchemaAsyncApiWriter` wraps a single `IEventSchema` in a fully valid AsyncAPI 2.x document. It exposes the schema under `components/schemas`, declares a corresponding message under `components/messages`, and wires a subscribe channel:
-
-```csharp
-using Deveel.Events;
-
-var schema = EventSchema.FromDataType<OrderPlacedData>();
-
-// Output as JSON (default)
-var writer = new EventSchemaAsyncApiWriter(
-    format: AsyncApiFormat.Json,
-    title: "Order Events",
-    documentVersion: "1.0");
-
-await using var stream = File.OpenWrite("order-placed-asyncapi.json");
-await writer.WriteToAsync(stream, schema);
-```
-
-To produce YAML instead, pass `AsyncApiFormat.Yaml`:
-
-```csharp
-var writer = new EventSchemaAsyncApiWriter(AsyncApiFormat.Yaml);
-
-await using var stream = File.OpenWrite("order-placed-asyncapi.yaml");
-await writer.WriteToAsync(stream, schema);
-```
-
-#### Multiple schemas → combined AsyncAPI document
-
-`EventSchemasAsyncApiWriter` merges several schemas into a single AsyncAPI document — useful for generating a service-wide contract file:
-
-```csharp
-using Deveel.Events;
-
-IEnumerable<IEventSchema> schemas = new[] {
-    EventSchema.FromDataType<OrderPlacedData>(),
-    EventSchema.FromDataType<OrderCancelledData>(),
-    EventSchema.FromDataType<UserRegisteredData>()
-};
-
-var writer = new EventSchemasAsyncApiWriter(
-    title: "My Service Events",
-    version: "2.0",
-    format: AsyncApiFormat.Yaml);
-
-await using var stream = File.OpenWrite("events-asyncapi.yaml");
-await writer.WriteToAsync(stream, schemas);
-```
-
-#### Using the extension methods directly
-
-The `EventSchemaAsyncApiExtensions` class exposes lower-level helpers when you need finer control:
-
-```csharp
-using Deveel.Events;
-using NJsonSchema;
-using Saunter.AsyncApiSchema.v2;
-
-var schema = EventSchema.FromDataType<OrderPlacedData>();
-
-// Convert to NJsonSchema
-JsonSchema jsonSchema = schema.ToJsonSchema();
-
-// Convert to an AsyncAPI Message
-Message message = schema.ToAsyncApiMessage();
-
-// Build a standalone AsyncApiDocument
-AsyncApiDocument document = schema.ToAsyncApiDocument(title: "Order Events", version: "1.0");
-
-// Or add to an existing document
-var existingDoc = new AsyncApiDocument { /* ... */ };
-existingDoc.AddSchema(schema);
-```
-
-### Validating an Event Against a Schema
-
-The `IEventSchemaValidator` service validates a `CloudEvent` instance against an `IEventSchema` and returns an asynchronous stream of `ValidationResult` objects — one per violated constraint.
-
-```csharp
-using CloudNative.CloudEvents;
-using Deveel.Events;
-using System.ComponentModel.DataAnnotations;
-
-public class OrderService {
-    private readonly IEventSchemaValidator validator;
-    private readonly IEventPublisher publisher;
-
-    public OrderService(IEventSchemaValidator validator, IEventPublisher publisher) {
-        this.validator = validator;
-        this.publisher = publisher;
-    }
-
-    public async Task PlaceOrderAsync(OrderPlacedData data) {
-        var schema = EventSchema.FromDataType<OrderPlacedData>();
-
-        var @event = new CloudEvent {
-            Type    = "order.placed",
-            Source  = new Uri("https://myapp.example.com/orders"),
-            Data    = data
-        };
-
-        // Collect all validation errors before publishing
-        var errors = new List<ValidationResult>();
-        await foreach (var result in validator.ValidateEventAsync(schema, @event)) {
-            errors.Add(result);
-        }
-
-        if (errors.Count > 0) {
-            var messages = string.Join(", ", errors.Select(e => e.ErrorMessage));
-            throw new InvalidOperationException($"Event is invalid: {messages}");
-        }
-
-        await publisher.PublishAsync(data);
-    }
-}
-```
-
-> **Tip:** Register the validator (and the schema factory) via the DI container by including the `Deveel.Events.Schema` services in your `IServiceCollection`.
+All events are modelled as [`CloudEvent`](https://cloudevents.io/) objects, ensuring maximum interoperability with cloud platforms and services that implement the CNCF CloudEvents specification.
+
+## Packages
+
+| Package | Description | NuGet |
+|---------|-------------|-------|
+| `Deveel.Events.Annotations` | Attributes for describing event metadata on data classes | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Annotations.svg)](https://www.nuget.org/packages/Deveel.Events.Annotations) |
+| `Deveel.Events.Publisher` | Core publisher infrastructure (`IEventPublisher`, DI helpers) | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher) |
+| `Deveel.Events.Publisher.AzureServiceBus` | Publish events to Azure Service Bus | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.AzureServiceBus.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.AzureServiceBus) |
+| `Deveel.Events.Amqp.Annotations` | AMQP-specific routing attributes (exchange, routing key) | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Amqp.Annotations.svg)](https://www.nuget.org/packages/Deveel.Events.Amqp.Annotations) |
+| `Deveel.Events.Publisher.RabbitMq` | Publish events to a RabbitMQ exchange | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.RabbitMq.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.RabbitMq) |
+| `Deveel.Events.Publisher.MassTransit` | Publish events through a MassTransit bus | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.MassTransit.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.MassTransit) |
+| `Deveel.Events.Publisher.Webhook` | Deliver events to HTTP webhook endpoints | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.Webhook.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.Webhook) |
+| `Deveel.Events.Schema` | Schema model, fluent builder, JSON writer, and validation | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Schema.svg)](https://www.nuget.org/packages/Deveel.Events.Schema) |
+| `Deveel.Events.Schema.Yaml` | Export an event schema as YAML | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Schema.Yaml.svg)](https://www.nuget.org/packages/Deveel.Events.Schema.Yaml) |
+| `Deveel.Events.Schema.AsyncApi` | Export schemas as an AsyncAPI 2.x document | [![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Schema.AsyncApi.svg)](https://www.nuget.org/packages/Deveel.Events.Schema.AsyncApi) |
+
+## Documentation
+
+Full documentation — installation, quick-start, concept guides, channel references, schema export, and testing — is available in the [`docs/`](docs/README.md) folder of this repository.
+
+| Section | Description |
+|---------|-------------|
+| [Getting Started](docs/getting-started/installation.md) | Installation and quick-start guide |
+| [Core Concepts](docs/concepts/README.md) | Publisher, channels, and event annotations |
+| [Publisher Channels](docs/publishers/README.md) | Azure Service Bus, RabbitMQ, MassTransit, Webhook |
+| [Event Schema](docs/schema/README.md) | Schema definition, export (JSON / YAML / AsyncAPI), and validation |
+| [Testing](docs/testing/README.md) | Unit-testing event publishing |
 
 ## Future Work
 
-The framework is still in its early stages, and there are several areas that need to be improved and extended.
+The framework is still evolving. Among the areas we plan to address:
 
-Some of the areas that we plan to work on in the future are:
+- Supporting custom event serialisers and deserialisers
+- Consumer-side support (deserialising events from channels)
+- Named-channel selection at publish time
 
-- Supporting custom event serializers and deserializers
-- Implementing more publishers for different messaging systems (eg. RabbitMQ, Kafka, etc.)
-- Supporting the deserialization of events from channels, to make consistent the published events are consumed
-- Allow the selection of the channel to publish an event among the registered ones (eg. with named channels)
-
-You can monitor the list of [open issues](https://github.com/deveel/deveel.events/issues) to see what we are working on and what we plan to do in the future.
+Monitor the [open issues](https://github.com/deveel/deveel.events/issues) to see what is being worked on.
 
 ## Contributing
 
-We welcome contributions to the project, and we encourage you to submit issues and pull requests to help us improve the framework.
-
-If you want to contribute to the project, please read the [Contributing Guidelines](CONTRIBUTING.md) file to understand how to contribute to the project.
+We welcome bug reports, feature requests, and pull requests. Please read the [Contributing Guidelines](docs/contributing.md) before submitting.
 
 ## License
 
-The project is released under the [MIT License](LICENSE), and it is free to use and distribute for any purpose.
-
-See the [License](LICENSE) file for more information.
+Released under the [MIT License](LICENSE).
 
 ## Authors
 
-The project is developed and maintained by the [Deveel](https://deveel.com) team, and it is released as an open-source project to the community.
+Developed and maintained by the [Deveel](https://deveel.com) team and released as an open-source project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,136 @@
+# Deveel Events
+
+![GitHub License](https://img.shields.io/github/license/deveel/deveel.events)
+![GitHub Release](https://img.shields.io/github/v/release/deveel/deveel.events)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/deveel/deveel.events/cicd.yml?logo=github)
+![Codecov](https://img.shields.io/codecov/c/github/deveel/deveel.events?logo=codecov)
+
+**Deveel Events** is a lightweight, extensible framework for publishing domain events in .NET applications, built on top of the [CloudEvents](https://cloudevents.io/) standard.
+
+## Domain Events in DDD
+
+[Domain-Driven Design (DDD)](https://martinfowler.com/bliki/DomainDrivenDesign.html) treats **domain events** as first-class citizens of the model. A domain event represents something that _happened_ inside the domain — something meaningful to domain experts and worth recording.
+
+> _"A domain event is a full-fledged part of the domain model, a representation of something that happened in the domain."_
+> — Eric Evans, _Domain-Driven Design Reference_
+
+### Why domain events matter
+
+| Property | Meaning |
+|----------|---------|
+| **Fact-based** | Events describe what _happened_, not what _should happen_. They are immutable after they occur. |
+| **Named in the ubiquitous language** | Event names (`OrderPlaced`, `InvoiceIssued`, `UserRegistered`) come directly from conversations with domain experts. |
+| **Loosely coupled** | Producers and consumers are decoupled: the producing bounded context does not need to know who is listening. |
+| **Bounded-context integration** | Events are the preferred mechanism for sharing information across bounded contexts without creating tight dependencies. |
+| **Temporal decoupling** | Consumers can process events asynchronously, at their own pace, enabling reliable and scalable integrations. |
+
+### Events vs. commands vs. queries
+
+| Concept | Intent | Direction | Example |
+|---------|--------|-----------|---------|
+| **Command** | Request an action | One sender → one receiver | `PlaceOrder` |
+| **Query** | Ask for data | One sender → one receiver | `GetOrderById` |
+| **Event** | Notify that something happened | One producer → many consumers | `OrderPlaced` |
+
+Events differ from commands in a subtle but important way: a command _could_ be rejected; an event is a statement of fact about the past — it already happened.
+
+### Where Deveel Events fits in
+
+Deveel Events implements the **publishing side** of domain events.  The framework is intentionally scoped: it does not dictate how you model your aggregates, store events, or rebuild read models.  What it does provide is a consistent, transport-agnostic way to broadcast domain events once they occur inside a bounded context.
+
+```
+Aggregate root raises event
+        │
+        ▼
+  IEventPublisher.PublishAsync(eventData)
+        │
+        ├──► Azure Service Bus queue
+        ├──► RabbitMQ exchange
+        ├──► Webhook endpoint
+        └──► (any IEventPublishChannel)
+```
+
+## Event Schemas and Async API Contracts
+
+Publishing an event is only half the story.  Consumers need to know the **shape** of the event — which properties it carries, their types, and which constraints apply — so they can deserialise it correctly and build reliable integrations.
+
+This is where **event schemas** play the same role for asynchronous messaging that OpenAPI/Swagger plays for synchronous REST APIs.
+
+### The problem without schemas
+
+- Consumers guess the payload structure from code examples or tribal knowledge.
+- A producer renames a field; consumers break silently.
+- There is no machine-readable contract to validate against or generate client code from.
+
+### Event schemas as async API contracts
+
+An event schema documents the contract between a producer and its consumers:
+
+```
+Producer                                     Consumer(s)
+───────                                      ─────────────
+[Event("order.placed", "1.0")]               Reads schema
+public class OrderPlacedData                 Validates payload
+{                                            Generates typed client
+    [Required] public Guid OrderId { get; set; }
+    [Required] public decimal Amount { get; set; }
+    [Required] public string Currency { get; set; }
+    public string? Notes { get; set; }
+}
+
+         ──► EventSchema.FromDataType<OrderPlacedData>()
+                      │
+                      ├──► JSON Schema
+                      ├──► YAML schema document
+                      └──► AsyncAPI 2.x document
+```
+
+The `Deveel.Events.Schema` package can derive a schema automatically from annotated data classes, or you can build one explicitly with the fluent `EventSchemaBuilder`.  Either way, the schema can then be:
+
+- **Exported as JSON** — for integration with schema registries or tooling.
+- **Exported as YAML** — for human-readable documentation or version-controlled contracts.
+- **Exported as an AsyncAPI document** — a complete, machine-readable API specification for asynchronous messaging, analogous to an OpenAPI document for REST.  AsyncAPI tooling can generate documentation sites, client SDKs, and mock servers from it.
+- **Used for validation** — the `IEventSchemaValidator` service can validate a `CloudEvent` instance against the schema before it is published, preventing malformed events from reaching consumers.
+
+### Schema versioning and stability
+
+Treat your event schemas the same way you treat public API contracts:
+
+- **Version them** using the `version` property (e.g. `"1.0"`, `"2.0"`).
+- **Prefer additive changes** — adding a new nullable property is backward-compatible; removing or renaming a required property is breaking.
+- **Communicate breaking changes** by incrementing the major version and publishing the new schema separately, giving consumers time to migrate.
+
+## What the Framework Provides
+
+- A **unified `IEventPublisher` interface** that fans out events to one or more registered channels.
+- **Channel implementations** for Azure Service Bus, RabbitMQ, MassTransit, and HTTP Webhooks — each installable as a separate NuGet package.
+- **Annotation attributes** (`[Event]`, `[EventProperty]`) to describe event metadata directly on your data classes, in the ubiquitous language of the domain.
+- **Schema support** — derive, build, and export event schemas to JSON, YAML, and AsyncAPI documents.
+- **Validation** — validate `CloudEvent` instances against a schema before publishing.
+- A **test channel** to make unit-testing event publishing straightforward.
+
+## Design Philosophy
+
+The framework intentionally does **not** aim to be a full event-sourcing or message-broker solution.  Its goal is a thin, opinionated layer that lets every team publish domain events in a consistent way without rewriting the same plumbing every time.
+
+> If you need durable event storage, complex routing, or consumer-side processing at scale, consider pairing this library with a dedicated message broker (RabbitMQ, Kafka, Azure Service Bus) — Deveel Events already ships channel adapters for the most popular ones.
+
+## CloudEvents Standard
+
+All events are modelled as [`CloudEvent`](https://github.com/cloudevents/spec) objects, ensuring maximum interoperability with cloud platforms and services that implement the CNCF CloudEvents specification.
+
+## Next Steps
+
+| Topic | Description |
+|-------|-------------|
+| [Installation](getting-started/installation.md) | How to install the packages |
+| [Quick Start](getting-started/quick-start.md) | Publish your first event in minutes |
+| [Core Concepts](concepts/README.md) | Understand the building blocks |
+| [Publisher Channels](publishers/README.md) | Configure a specific transport |
+| [Event Schema](schema/README.md) | Schema definition, export, and validation |
+| [Testing](testing/README.md) | Unit-test event publishing |
+
+## License
+
+Released under the [MIT License](https://github.com/deveel/deveel.events/blob/main/LICENSE).  
+Developed and maintained by the [Deveel](https://deveel.com) team.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,49 @@
+# Summary
+
+## Overview
+
+* [Introduction](README.md)
+* [Packages](packages.md)
+
+## Getting Started
+
+* [Installation](getting-started/installation.md)
+* [Quick Start](getting-started/quick-start.md)
+
+## Core Concepts
+
+* [Overview](concepts/README.md)
+* [CloudEvents Standard](concepts/cloudevents.md)
+* [Event Publisher](concepts/event-publisher.md)
+* [Publish Channels](concepts/publish-channels.md)
+* [Event Annotations](concepts/event-annotations.md)
+
+## Publisher Channels
+
+* [Overview](publishers/README.md)
+* [Azure Service Bus](publishers/azure-service-bus.md)
+* [RabbitMQ](publishers/rabbitmq.md)
+  * [AMQP Annotations](publishers/rabbitmq.md#amqp-annotations)
+* [MassTransit](publishers/masstransit.md)
+* [Webhook](publishers/webhook.md)
+
+## Event Schema
+
+* [Overview](schema/README.md)
+* [Fluent Builder](schema/fluent-builder.md)
+* [From Annotations](schema/from-annotations.md)
+* [Export as JSON](schema/export-json.md)
+* [Export as YAML](schema/export-yaml.md)
+* [Export as AsyncAPI](schema/export-asyncapi.md)
+* [Validation](schema/validation.md)
+
+## Testing
+
+* [Test Publisher](testing/README.md)
+
+## Contributing
+
+* [Contributing](contributing.md)
+
+
+

--- a/docs/amqp/README.md
+++ b/docs/amqp/README.md
@@ -1,0 +1,5 @@
+# AMQP Annotations
+
+> **This page has moved.**
+>
+> The AMQP Annotations documentation is now part of the [RabbitMQ Channel](../publishers/rabbitmq.md#amqp-annotations) page.

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,0 +1,46 @@
+# Core Concepts
+
+This section explains the fundamental building blocks of the Deveel Events framework.
+
+## Overview
+
+```
+┌──────────────────────────────────────────────────────┐
+│                   Your application                   │
+│                                                      │
+│   ┌──────────────┐      ┌──────────────────────────┐ │
+│   │  Event data  │─────▶│     IEventPublisher      │ │
+│   │  (annotated  │      └──────────┬───────────────┘ │
+│   │   classes)   │                 │ fan-out          │
+│   └──────────────┘        ┌────────┴────────┐         │
+│                           │                 │         │
+│                   ┌───────▼─────┐   ┌───────▼──────┐ │
+│                   │  Channel A  │   │  Channel B   │ │
+│                   │ (Azure SB)  │   │  (Webhook)   │ │
+│                   └─────────────┘   └──────────────┘ │
+└──────────────────────────────────────────────────────┘
+```
+
+1. You describe an event using an annotated data class (or construct a raw `CloudEvent`).
+2. You call `IEventPublisher.PublishAsync` (or `PublishEventAsync`).
+3. The publisher fans the event out to **every registered `IEventPublishChannel`**.
+4. Each channel serialises the event and dispatches it to the appropriate transport.
+
+## Key Abstractions
+
+| Abstraction | Role |
+|-------------|------|
+| `IEventPublisher` | The single entry point for publishing events |
+| `IEventPublishChannel` | One transport target (Azure Service Bus queue, RabbitMQ exchange, …) |
+| `IBatchEventPublishChannel<TOptions>` | A channel that supports per-call delivery options (e.g. webhook URL) |
+| `IEventCreator` | Converts an annotated data object into a `CloudEvent` |
+| `IEventIdGenerator` | Generates unique identifiers for events (default: GUID) |
+| `IEventSystemTime` | Supplies the event timestamp (replaceable for testing) |
+
+## Pages in this section
+
+- [CloudEvents Standard](cloudevents.md)
+- [Event Publisher](event-publisher.md)
+- [Publish Channels](publish-channels.md)
+- [Event Annotations](event-annotations.md)
+

--- a/docs/concepts/cloudevents.md
+++ b/docs/concepts/cloudevents.md
@@ -1,0 +1,67 @@
+# CloudEvents Standard
+
+Deveel Events uses the [CloudEvents](https://cloudevents.io/) specification as its event model.  Every event published through the framework is represented as a `CloudEvent` object from the [`CloudNative.CloudEvents`](https://github.com/cloudevents/sdk-csharp) SDK.
+
+## Why CloudEvents?
+
+- **Interoperability** — CloudEvents is a CNCF specification adopted by Azure, Google Cloud, AWS, and many other platforms.  Events can be consumed by any system that understands the standard.
+- **Schema-agnostic** — The envelope is fixed; the `data` payload can be any content type.
+- **Tooling ecosystem** — Schema registries, event bridges, and observability tools often natively support CloudEvents.
+
+## The CloudEvent Envelope
+
+A `CloudEvent` consists of a set of **required** and **optional** attributes:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `id` | `string` | Unique identifier for this specific event occurrence |
+| `source` | `Uri` | Identifies the context in which the event happened (e.g. your service URL) |
+| `specversion` | `string` | Always `"1.0"` |
+| `type` | `string` | Describes the kind of event (e.g. `"order.placed"`) |
+| `datacontenttype` | `string?` | MIME type of the `data` payload (e.g. `"application/json"`) |
+| `dataschema` | `Uri?` | URI of the schema that the `data` conforms to |
+| `subject` | `string?` | Additional context about the subject of the event |
+| `time` | `DateTimeOffset?` | Timestamp when the event occurred |
+| `data` | `object?` | The event payload |
+
+## How Deveel Events Populates the Envelope
+
+When you call `publisher.PublishAsync(data)` with an annotated data object, the `IEventCreator` service reads the `[Event]` attribute and populates the envelope as follows:
+
+| CloudEvent attribute | Source |
+|----------------------|--------|
+| `type` | `[Event]` attribute's `EventType` property |
+| `id` | `IEventIdGenerator` (default: new GUID) |
+| `source` | `EventPublisherOptions.Source` |
+| `time` | `IEventSystemTime.UtcNow` |
+| `dataschema` | `[Event]` attribute's `DataSchema`, or `EventPublisherOptions.DataSchemaBaseUri` + event type |
+| `datacontenttype` | `[Event]` attribute's `ContentType` |
+| `data` | The annotated object itself |
+
+Any additional CloudEvent attributes declared via `[EventAttributes]` (or AMQP-specific attributes) are merged in.
+
+## Working with CloudEvent Directly
+
+You can bypass the annotation system and construct a `CloudEvent` manually when you need full control:
+
+```csharp
+using CloudNative.CloudEvents;
+
+var @event = new CloudEvent
+{
+    Id      = Guid.NewGuid().ToString(),
+    Type    = "com.acme.order.shipped",
+    Source  = new Uri("https://orders.acme.com"),
+    Time    = DateTimeOffset.UtcNow,
+    DataContentType = "application/json",
+    Data    = new { OrderId = 42, TrackingNumber = "1Z999AA1" }
+};
+
+await publisher.PublishEventAsync(@event);
+```
+
+## Further Reading
+
+- [CloudEvents Specification v1.0](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md)
+- [CloudNative.CloudEvents SDK for .NET](https://github.com/cloudevents/sdk-csharp)
+

--- a/docs/concepts/event-annotations.md
+++ b/docs/concepts/event-annotations.md
@@ -1,0 +1,130 @@
+# Event Annotations
+
+The `Deveel.Events.Annotations` package provides attributes that let you embed event metadata directly on your data-transfer classes, removing the need to hard-code event types or versions at the call site.
+
+## Installation
+
+```bash
+dotnet add package Deveel.Events.Annotations
+```
+
+## `[Event]` attribute
+
+Applied at class level.  Describes the event type, version, and other envelope defaults.
+
+```csharp
+using Deveel.Events;
+
+[Event("order.placed", "1.0")]
+public class OrderPlacedData
+{
+    public Guid OrderId { get; set; }
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = default!;
+}
+```
+
+### Constructor overloads
+
+| Signature | When to use |
+|-----------|-------------|
+| `[Event("type", "version")]` | Most common — event type + semver string |
+| `[Event("type", "https://schemas.example.com/order.placed")]` | Event type + absolute URI to the JSON Schema |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `EventType` | `string` | Required. The `type` attribute of the CloudEvent. |
+| `DataVersion` | `string?` | SemVer version string (set when the second argument is not a URI). |
+| `DataSchema` | `Uri?` | Absolute URI to the schema (set when the second argument is a URI). |
+| `Description` | `string?` | Human-readable description for documentation purposes. |
+| `ContentType` | `string?` | MIME content type of the data payload (e.g. `"application/json"`). |
+
+## `[EventProperty]` attribute
+
+Applied at property or field level.  Marks a member as part of the event payload and optionally overrides its serialised name.
+
+```csharp
+[Event("order.placed", "1.0")]
+public class OrderPlacedData
+{
+    [EventProperty("order_id")]
+    public Guid OrderId { get; set; }
+
+    [EventProperty("amount")]
+    public decimal Amount { get; set; }
+}
+```
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Name` | `string?` | Overrides the property name used in the serialised payload. |
+| `Description` | `string?` | Human-readable description. |
+| `Version` | `string?` | The event version this property belongs to. |
+| `Schema` | `Uri?` | URI of the schema for this property's data. |
+
+## `[EventAttributes]` attribute
+
+A base class for attributes that inject arbitrary CloudEvent extension attributes into the envelope.  This is the foundation for things like `[AmqpExchange]` and `[AmqpRoutingKey]` (see [AMQP Annotations](../amqp/README.md)).
+
+```csharp
+// Inject a custom CloudEvent extension attribute
+[EventAttributes("x-tenant-id", "acme")]
+[Event("order.placed", "1.0")]
+public class OrderPlacedData { /* ... */ }
+```
+
+## Publishing from an annotated class
+
+```csharp
+var data = new OrderPlacedData
+{
+    OrderId  = Guid.NewGuid(),
+    Amount   = 99.95m,
+    Currency = "USD"
+};
+
+// The IEventCreator service reads [Event] and builds the CloudEvent automatically.
+await publisher.PublishAsync(data);
+```
+
+## Combining with Data Annotations
+
+Standard `System.ComponentModel.DataAnnotations` attributes (e.g. `[Required]`, `[Range]`) placed on the same class are recognised by the Schema package when generating event schemas:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Deveel.Events;
+
+[Event("order.placed", "1.0", Description = "Raised when a customer places an order")]
+public class OrderPlacedData
+{
+    [Required]
+    [EventProperty("order_id")]
+    public Guid OrderId { get; set; }
+
+    [Required]
+    [Range(0.01, 1_000_000.0)]
+    [EventProperty("amount")]
+    public decimal Amount { get; set; }
+
+    [Required]
+    [EventProperty("currency")]
+    public string Currency { get; set; } = default!;
+
+    public string? Notes { get; set; }
+}
+```
+
+→ See [Schema from Annotations](../schema/from-annotations.md) for how to derive a schema from this class.
+
+## Related pages
+
+- [Event Publisher](event-publisher.md)
+- [RabbitMQ Channel — AMQP Annotations](../publishers/rabbitmq.md#amqp-annotations)
+- [Schema from Annotations](../schema/from-annotations.md)
+
+

--- a/docs/concepts/event-publisher.md
+++ b/docs/concepts/event-publisher.md
@@ -1,0 +1,131 @@
+# Event Publisher
+
+The `IEventPublisher` interface is the single entry point for publishing events in your application.
+
+## Registration
+
+Register the publisher in your DI container using the `AddEventPublisher` extension method:
+
+```csharp
+using Deveel.Events;
+
+// Minimal registration
+builder.Services.AddEventPublisher();
+
+// With inline options
+builder.Services.AddEventPublisher(options =>
+{
+    options.Source = new Uri("https://myapp.example.com");
+    options.ThrowOnErrors = true;
+});
+
+// Bind options from appsettings.json
+builder.Services.AddEventPublisher("Events:Publisher");
+```
+
+`AddEventPublisher` returns an `EventPublisherBuilder` that you chain to register channels and other services.
+
+## `EventPublisherOptions`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Source` | `Uri?` | `null` | Default `source` attribute of every `CloudEvent`. Recommended to set globally. |
+| `ThrowOnErrors` | `bool` | `false` | Re-throws exceptions from channels instead of swallowing them. |
+| `JsonSerializerOptions` | `JsonSerializerOptions?` | default | Options used when serialising JSON payloads. |
+| `Attributes` | `Dictionary<string, object?>` | `{}` | Extra CloudEvent attributes added to every event. |
+| `DataSchemaBaseUri` | `Uri?` | `null` | Base URI prepended to the event type to form the `dataschema` when none is specified on the event. |
+
+### Example `appsettings.json`
+
+```json
+{
+  "Events": {
+    "Publisher": {
+      "Source": "https://myapp.example.com",
+      "ThrowOnErrors": true,
+      "DataSchemaBaseUri": "https://schemas.myapp.example.com/"
+    }
+  }
+}
+```
+
+## Publishing events
+
+### From an annotated data class
+
+```csharp
+public class OrderService
+{
+    private readonly IEventPublisher _publisher;
+
+    public OrderService(IEventPublisher publisher) => _publisher = publisher;
+
+    public async Task PlaceOrderAsync(OrderPlacedData data)
+    {
+        // IEventCreator reads [Event] on OrderPlacedData and builds the CloudEvent
+        await _publisher.PublishAsync(data);
+    }
+}
+```
+
+### From a raw `CloudEvent`
+
+```csharp
+var @event = new CloudEvent
+{
+    Type   = "order.placed",
+    Source = new Uri("https://myapp.example.com"),
+    Data   = orderPayload
+};
+
+await publisher.PublishEventAsync(@event);
+```
+
+### Fan-out behaviour
+
+Every call to `PublishEventAsync` dispatches the event to **all** registered `IEventPublishChannel` instances, one by one.  If `ThrowOnErrors` is `false` (the default), a failing channel is logged but does not prevent delivery to the remaining channels.
+
+## Extensibility
+
+### Custom publisher
+
+Replace the default `EventPublisher` with your own implementation:
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UsePublisher<MyCustomPublisher>();
+```
+
+### Custom ID generator
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseGuid("N");   // compact format without dashes
+```
+
+### Custom system time
+
+Useful in tests to control event timestamps:
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseSystemTime<FrozenSystemTime>();
+```
+
+`FrozenSystemTime` is any class implementing `IEventSystemTime`:
+
+```csharp
+public class FrozenSystemTime : IEventSystemTime
+{
+    public DateTimeOffset UtcNow { get; } = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+}
+```
+
+## Related pages
+
+- [Publish Channels](publish-channels.md)
+- [Event Annotations](event-annotations.md)
+

--- a/docs/concepts/publish-channels.md
+++ b/docs/concepts/publish-channels.md
@@ -1,0 +1,104 @@
+# Publish Channels
+
+A **publish channel** is responsible for taking a `CloudEvent` and delivering it to a specific transport (Azure Service Bus, RabbitMQ, HTTP, …).
+
+## Core interfaces
+
+### `IEventPublishChannel`
+
+```csharp
+public interface IEventPublishChannel
+{
+    Task PublishAsync(CloudEvent @event, CancellationToken cancellationToken = default);
+}
+```
+
+The `EventPublisher` resolves **all** registered `IEventPublishChannel` services and calls `PublishAsync` on each one in sequence for every outgoing event.
+
+### `IEventPublishChannel<TOptions>`
+
+An optional generic interface for channels that accept per-call delivery options (e.g. supplying a dynamic webhook URL):
+
+```csharp
+public interface IEventPublishChannel<TOptions> : IEventPublishChannel
+{
+    Task PublishAsync(CloudEvent @event, TOptions options, CancellationToken cancellationToken = default);
+}
+```
+
+### `IBatchEventPublishChannel<TOptions>`
+
+Extends the above to support publishing multiple events in a single call:
+
+```csharp
+public interface IBatchEventPublishChannel<TOptions>
+{
+    Task PublishBatchAsync(
+        IEnumerable<CloudEvent> events,
+        TOptions options,
+        CancellationToken cancellationToken = default);
+}
+```
+
+The Webhook channel implements both `IEventPublishChannel<WebhookPublishOptions>` and `IBatchEventPublishChannel<WebhookPublishOptions>`.
+
+## Built-in channels
+
+| Channel | Package | Registration method |
+|---------|---------|---------------------|
+| Azure Service Bus | `Deveel.Events.Publisher.AzureServiceBus` | `.AddServiceBusChannel(...)` |
+| RabbitMQ | `Deveel.Events.Publisher.RabbitMq` | `.UseRabbitMq(...)` |
+| MassTransit | `Deveel.Events.Publisher.MassTransit` | `.UseMassTransit(...)` |
+| Webhook (HTTP) | `Deveel.Events.Publisher.Webhook` | `.UseWebhook(...)` |
+| Test (in-memory) | `Deveel.Events.TestPublisher` | `.AddTestChannel(...)` |
+
+Multiple channels can be registered simultaneously — the publisher will deliver to all of them.
+
+## Implementing a custom channel
+
+To create your own channel, implement `IEventPublishChannel` and register it in DI:
+
+```csharp
+using CloudNative.CloudEvents;
+using Deveel.Events;
+
+public class KafkaEventPublishChannel : IEventPublishChannel
+{
+    private readonly KafkaProducerOptions _options;
+
+    public KafkaEventPublishChannel(IOptions<KafkaProducerOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public async Task PublishAsync(CloudEvent @event, CancellationToken cancellationToken = default)
+    {
+        // ... serialise and send via Confluent.Kafka
+    }
+}
+```
+
+Register it with the builder:
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .Services  // IServiceCollection
+        .AddSingleton<IEventPublishChannel, KafkaEventPublishChannel>();
+```
+
+Or use the builder's `Services` property:
+
+```csharp
+var publisherBuilder = builder.Services.AddEventPublisher();
+publisherBuilder.Services.AddSingleton<IEventPublishChannel, KafkaEventPublishChannel>();
+```
+
+## Related pages
+
+- [Azure Service Bus](../publishers/azure-service-bus.md)
+- [RabbitMQ](../publishers/rabbitmq.md)
+- [MassTransit](../publishers/masstransit.md)
+- [Webhook](../publishers/webhook.md)
+- [Test Publisher](../testing/README.md)
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,81 @@
+# Contributing to Deveel Events
+
+Thank you for your interest in contributing!  We welcome bug reports, feature requests, documentation improvements, and pull requests.
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions.  We follow the [Contributor Covenant](https://www.contributor-covenant.org/) code of conduct.
+
+## Getting Started
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your fork:
+   ```bash
+   git clone https://github.com/<your-username>/deveel.events.git
+   cd deveel.events
+   ```
+3. **Create a feature branch**:
+   ```bash
+   git checkout -b feature/my-new-feature
+   ```
+4. Make your changes and add or update tests as appropriate.
+5. **Build and test** before submitting:
+   ```bash
+   dotnet build
+   dotnet test
+   ```
+6. **Commit** with a clear, descriptive message.
+7. **Push** to your fork and open a **Pull Request** against the `main` branch.
+
+## Project Structure
+
+```
+.
+├── src/          # Production source code (one folder per NuGet package)
+├── test/         # Test projects (one per source package, using xUnit)
+├── benchmarks/   # BenchmarkDotNet projects
+├── docs/         # Documentation (this folder)
+└── .github/      # GitHub Actions workflows
+```
+
+## Building
+
+```bash
+dotnet restore
+dotnet build -c Release
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+dotnet test -c Release
+
+# Skip RabbitMQ tests (useful when no broker is running locally)
+dotnet test -c Release -- --filter-not-trait "Channel=RabbitMQ"
+```
+
+## Coding Guidelines
+
+- Follow the existing code style (C# 12, nullable reference types enabled).
+- All public types and members should have XML documentation comments.
+- Add `[Fact]` or `[Theory]` tests for any new behaviour.
+- Do not include breaking changes in minor or patch releases without discussion.
+
+## Reporting Issues
+
+Open a [GitHub Issue](https://github.com/deveel/deveel.events/issues) and include:
+
+- A clear title and description.
+- The package version affected.
+- A minimal repro (code snippet or test case).
+- Observed vs. expected behaviour.
+
+## Feature Requests
+
+Open a GitHub Issue labelled `enhancement`.  Describe the use-case and proposed API before submitting a pull request for large changes.
+
+## License
+
+By contributing you agree that your contributions will be licensed under the [MIT License](https://github.com/deveel/deveel.events/blob/main/LICENSE).
+

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,87 @@
+# Installation
+
+Deveel Events is distributed as a set of NuGet packages.  Install only the packages you actually need.
+
+## Prerequisites
+
+- .NET 8, 9, or 10
+- A project that uses Microsoft Dependency Injection (`Microsoft.Extensions.DependencyInjection`)
+
+## Core package
+
+Every application that publishes events needs the core publisher package:
+
+```bash
+dotnet add package Deveel.Events.Publisher
+```
+
+## Channel packages
+
+Add one or more channel packages depending on the transports you want to use:
+
+```bash
+# Azure Service Bus
+dotnet add package Deveel.Events.Publisher.AzureServiceBus
+
+# RabbitMQ
+dotnet add package Deveel.Events.Publisher.RabbitMq
+
+# MassTransit
+dotnet add package Deveel.Events.Publisher.MassTransit
+
+# HTTP Webhooks
+dotnet add package Deveel.Events.Publisher.Webhook
+```
+
+## Annotation package
+
+If you want to annotate your data-transfer classes with event metadata:
+
+```bash
+dotnet add package Deveel.Events.Annotations
+```
+
+For AMQP-specific routing metadata (exchange name, routing key):
+
+```bash
+dotnet add package Deveel.Events.Amqp.Annotations
+```
+
+## Schema packages
+
+```bash
+# Core schema model, builder, JSON writer, and validator
+dotnet add package Deveel.Events.Schema
+
+# Export schemas as YAML
+dotnet add package Deveel.Events.Schema.Yaml
+
+# Export schemas as AsyncAPI 2.x documents (JSON or YAML)
+dotnet add package Deveel.Events.Schema.AsyncApi
+```
+
+## Test package
+
+```bash
+dotnet add package Deveel.Events.TestPublisher
+```
+
+## Pre-release builds
+
+Pre-release packages are published to **GitHub Packages**.  To consume them, add the Deveel GitHub Packages feed to your NuGet sources:
+
+```xml
+<!-- nuget.config -->
+<configuration>
+  <packageSources>
+    <add key="deveel-github" value="https://nuget.pkg.github.com/deveel/index.json" />
+  </packageSources>
+</configuration>
+```
+
+You will also need a GitHub Personal Access Token (PAT) with `read:packages` scope and add it as a credential for the feed.
+
+## What's next?
+
+→ [Quick Start](quick-start.md) — publish your first event in minutes.
+

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,127 @@
+# Quick Start
+
+This guide walks you through publishing your first event in under five minutes.
+
+## 1. Install the packages
+
+```bash
+dotnet add package Deveel.Events.Publisher
+dotnet add package Deveel.Events.Annotations
+```
+
+Add a channel package for the transport you want to use, for example Azure Service Bus:
+
+```bash
+dotnet add package Deveel.Events.Publisher.AzureServiceBus
+```
+
+## 2. Annotate your event data class
+
+Create a class that represents the data payload of your event and decorate it with `[Event]`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Deveel.Events;
+
+[Event("order.placed", "1.0")]
+public class OrderPlacedData
+{
+    [Required]
+    public Guid OrderId { get; set; }
+
+    [Required]
+    [Range(0.01, 1_000_000.0)]
+    public decimal Amount { get; set; }
+
+    [Required]
+    public string Currency { get; set; } = default!;
+
+    public string? Notes { get; set; }
+}
+```
+
+The `[Event]` attribute records the **event type** string and its **version**.  The framework uses these values when constructing the `CloudEvent` envelope.
+
+## 3. Register the publisher
+
+In your `Program.cs` (or wherever you configure DI), register the event publisher and the Azure Service Bus channel:
+
+```csharp
+using Deveel.Events;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddEventPublisher(options =>
+    {
+        options.Source = new Uri("https://myapp.example.com");
+    })
+    .AddServiceBusChannel(options =>
+    {
+        options.ConnectionString = builder.Configuration["ServiceBus:ConnectionString"]!;
+        options.QueueName        = builder.Configuration["ServiceBus:QueueName"]!;
+    });
+```
+
+> **Tip:** You can also bind options from `appsettings.json` by passing a configuration-section path instead of a delegate — see [Azure Service Bus](../publishers/azure-service-bus.md).
+
+## 4. Inject and publish
+
+Inject `IEventPublisher` wherever you need it and call `PublishAsync`:
+
+```csharp
+using Deveel.Events;
+
+public class OrderService
+{
+    private readonly IEventPublisher _publisher;
+
+    public OrderService(IEventPublisher publisher)
+    {
+        _publisher = publisher;
+    }
+
+    public async Task PlaceOrderAsync(Guid orderId, decimal amount, string currency)
+    {
+        var data = new OrderPlacedData
+        {
+            OrderId  = orderId,
+            Amount   = amount,
+            Currency = currency
+        };
+
+        // The framework builds the CloudEvent envelope from the [Event] attribute
+        // and publishes it to all registered channels.
+        await _publisher.PublishAsync(data);
+    }
+}
+```
+
+## 5. Publishing a raw CloudEvent
+
+If you already have a `CloudEvent` instance you can publish it directly:
+
+```csharp
+using CloudNative.CloudEvents;
+using Deveel.Events;
+
+var @event = new CloudEvent
+{
+    Type    = "com.example.myevent",
+    Source  = new Uri("https://myapp.example.com"),
+    DataContentType = "application/json",
+    Data    = new { Message = "Hello, World!" }
+};
+
+await publisher.PublishEventAsync(@event);
+```
+
+## What's next?
+
+| Topic | Description |
+|-------|-------------|
+| [Core Concepts](../concepts/README.md) | Understand how the pieces fit together |
+| [Publisher Channels](../publishers/README.md) | Configure specific transports |
+| [Event Schema](../schema/README.md) | Validate events before publishing |
+| [Testing](../testing/README.md) | Unit-test your event publishing |
+

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,186 @@
+# Packages
+
+The framework is split into focused NuGet packages so you only take what you need.
+
+## Core packages
+
+| Package | Description |
+|---------|-------------|
+| [`Deveel.Events.Annotations`](#deveeleeventsannotations) | Attributes for describing event metadata on your data classes |
+| [`Deveel.Events.Publisher`](#deveeleventsublisher) | Core publisher infrastructure (`IEventPublisher`, `EventPublisherBuilder`, DI helpers) |
+
+## Channel packages
+
+| Package | Description |
+|---------|-------------|
+| [`Deveel.Events.Publisher.AzureServiceBus`](#deveeleventsublisherazureservicebus) | Publish events to an Azure Service Bus queue or topic |
+| [`Deveel.Events.Publisher.RabbitMq`](#deveeleventsublisherrabbitmq) | Publish events to a RabbitMQ exchange |
+| [`Deveel.Events.Publisher.MassTransit`](#deveeleventsublishermasstransit) | Publish events through a MassTransit bus |
+| [`Deveel.Events.Publisher.Webhook`](#deveeleventsublisherwebhook) | Deliver events to HTTP webhook endpoints |
+| [`Deveel.Events.Amqp.Annotations`](#deveeleventsampqannotations) | AMQP-specific attributes (exchange name, routing key) |
+
+## Schema packages
+
+| Package | Description |
+|---------|-------------|
+| [`Deveel.Events.Schema`](#deveeleventsschema) | Core schema model, fluent builder, JSON writer, and schema validation |
+| [`Deveel.Events.Schema.Yaml`](#deveeleventsschemayaml) | Export an event schema as a YAML document |
+| [`Deveel.Events.Schema.AsyncApi`](#deveeleventsschemaasynapi) | Export schemas as an AsyncAPI 2.x document (JSON or YAML) |
+
+## Test package
+
+| Package | Description |
+|---------|-------------|
+| [`Deveel.Events.TestPublisher`](#deveeleventsestpublisher) | In-memory test channel and helpers for unit tests |
+
+---
+
+## Package Details
+
+### `Deveel.Events.Annotations`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Annotations.svg)](https://www.nuget.org/packages/Deveel.Events.Annotations)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Annotations)
+
+Contains the `[Event]` and `[EventProperty]` attributes used to annotate data-transfer classes with event type metadata.  No dependencies except the .NET BCL.
+
+```bash
+dotnet add package Deveel.Events.Annotations
+```
+
+---
+
+### `Deveel.Events.Publisher`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Publisher)
+
+The heart of the framework.  Provides:
+
+- `IEventPublisher` / `EventPublisher`
+- `IEventPublishChannel` and `IBatchEventPublishChannel<TOptions>`
+- `EventPublisherBuilder` for fluent DI registration
+- `IEventCreator` and `IEventIdGenerator` extensibility points
+- `EventPublisherOptions` for global defaults
+
+```bash
+dotnet add package Deveel.Events.Publisher
+```
+
+---
+
+### `Deveel.Events.Publisher.AzureServiceBus`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.AzureServiceBus.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.AzureServiceBus)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Publisher.AzureServiceBus)
+
+Azure Service Bus channel implementation.  Serialises `CloudEvent` objects as `ServiceBusMessage` instances and sends them to a configured queue or topic.
+
+```bash
+dotnet add package Deveel.Events.Publisher.AzureServiceBus
+```
+
+---
+
+### `Deveel.Events.Publisher.RabbitMq`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.RabbitMq.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.RabbitMq)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Publisher.RabbitMq)
+
+RabbitMQ channel implementation using the official RabbitMQ.Client library.  Supports AMQP exchange/routing-key annotations, publisher confirms, and persistent messages.
+
+```bash
+dotnet add package Deveel.Events.Publisher.RabbitMq
+```
+
+---
+
+### `Deveel.Events.Publisher.MassTransit`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.MassTransit.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.MassTransit)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Publisher.MassTransit)
+
+Wraps MassTransit's `IPublishEndpoint` / `ISendEndpointProvider` so events can be routed through any MassTransit-supported transport.
+
+```bash
+dotnet add package Deveel.Events.Publisher.MassTransit
+```
+
+---
+
+### `Deveel.Events.Publisher.Webhook`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Publisher.Webhook.svg)](https://www.nuget.org/packages/Deveel.Events.Publisher.Webhook)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Publisher.Webhook)
+
+Delivers events over HTTP to a webhook endpoint.  Features HMAC signing (SHA-256/384/512), exponential-backoff retries, configurable headers, and pluggable serialisers.
+
+```bash
+dotnet add package Deveel.Events.Publisher.Webhook
+```
+
+---
+
+### `Deveel.Events.Amqp.Annotations`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Amqp.Annotations.svg)](https://www.nuget.org/packages/Deveel.Events.Amqp.Annotations)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Amqp.Annotations)
+
+Adds `[AmqpExchange]` and `[AmqpRoutingKey]` attributes to let you declare per-event-type AMQP routing metadata directly on your data classes. See [RabbitMQ — AMQP Annotations](publishers/rabbitmq.md#amqp-annotations) for usage details.
+
+```bash
+dotnet add package Deveel.Events.Amqp.Annotations
+```
+
+---
+
+### `Deveel.Events.Schema`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Schema.svg)](https://www.nuget.org/packages/Deveel.Events.Schema)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Schema)
+
+Core schema model.  Includes `EventSchema`, `EventSchemaBuilder` (fluent API), `EventSchemaCreator` (reflection-based), `IEventSchemaFactory`, `IEventSchemaWriter`, and `IEventSchemaValidator`.
+
+```bash
+dotnet add package Deveel.Events.Schema
+```
+
+---
+
+### `Deveel.Events.Schema.Yaml`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Schema.Yaml.svg)](https://www.nuget.org/packages/Deveel.Events.Schema.Yaml)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Schema.Yaml)
+
+Adds `EventSchemaYamlWriter`, which serialises an `IEventSchema` to a YAML stream using YamlDotNet.
+
+```bash
+dotnet add package Deveel.Events.Schema.Yaml
+```
+
+---
+
+### `Deveel.Events.Schema.AsyncApi`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.Schema.AsyncApi.svg)](https://www.nuget.org/packages/Deveel.Events.Schema.AsyncApi)
+[![GitHub pre-release](https://img.shields.io/badge/nuget-prerelease-yellow?logo=nuget)](https://github.com/deveel/deveel.events/pkgs/nuget/Deveel.Events.Schema.AsyncApi)
+
+Exports single or multiple event schemas as a complete AsyncAPI 2.x document (JSON or YAML).
+
+```bash
+dotnet add package Deveel.Events.Schema.AsyncApi
+```
+
+---
+
+### `Deveel.Events.TestPublisher`
+
+[![NuGet](https://img.shields.io/nuget/v/Deveel.Events.TestPublisher.svg)](https://www.nuget.org/packages/Deveel.Events.TestPublisher)
+
+An in-memory publish channel for use in unit and integration tests.  Invokes a user-supplied callback whenever an event is published, so you can assert on published events without a real transport.
+
+```bash
+dotnet add package Deveel.Events.TestPublisher
+```
+
+

--- a/docs/publishers/README.md
+++ b/docs/publishers/README.md
@@ -1,0 +1,37 @@
+# Publisher Channels Overview
+
+Deveel Events ships ready-made channel implementations for the most common messaging transports.  You install only what you need and register the channel(s) in the `EventPublisherBuilder` chain.
+
+## Available channels
+
+| Channel | Package | Best for |
+|---------|---------|----------|
+| [Azure Service Bus](azure-service-bus.md) | `Deveel.Events.Publisher.AzureServiceBus` | Cloud-native apps on Azure, reliable queue- or topic-based delivery |
+| [RabbitMQ](rabbitmq.md) | `Deveel.Events.Publisher.RabbitMq` | On-premise or self-hosted AMQP broker, fine-grained routing |
+| [MassTransit](masstransit.md) | `Deveel.Events.Publisher.MassTransit` | Projects already using MassTransit; broker-agnostic |
+| [Webhook](webhook.md) | `Deveel.Events.Publisher.Webhook` | Delivering events to external HTTP endpoints with HMAC signing |
+| [Test (in-memory)](../testing/README.md) | `Deveel.Events.TestPublisher` | Unit and integration tests |
+
+## Multiple channels
+
+You can register more than one channel at a time.  The publisher will fan every event out to **all** registered channels:
+
+```csharp
+builder.Services
+    .AddEventPublisher(options => options.Source = new Uri("https://myapp.example.com"))
+    .AddServiceBusChannel(options =>
+    {
+        options.ConnectionString = "...";
+        options.QueueName = "events";
+    })
+    .UseWebhook(options =>
+    {
+        options.EndpointUrl  = "https://partner.example.com/events";
+        options.SigningSecret = "s3cr3t";
+    });
+```
+
+## Implementing a custom channel
+
+See [Publish Channels](../concepts/publish-channels.md#implementing-a-custom-channel) for instructions on creating and registering your own `IEventPublishChannel`.
+

--- a/docs/publishers/azure-service-bus.md
+++ b/docs/publishers/azure-service-bus.md
@@ -1,0 +1,101 @@
+# Azure Service Bus Channel
+
+The `Deveel.Events.Publisher.AzureServiceBus` package adds a publish channel that serialises `CloudEvent` instances as `ServiceBusMessage` objects and delivers them to an Azure Service Bus queue or topic.
+
+## Installation
+
+```bash
+dotnet add package Deveel.Events.Publisher.AzureServiceBus
+```
+
+## Registration
+
+### Inline configuration
+
+```csharp
+using Deveel.Events;
+
+builder.Services
+    .AddEventPublisher()
+    .AddServiceBusChannel(options =>
+    {
+        options.ConnectionString = "<your-connection-string>";
+        options.QueueName        = "events";
+    });
+```
+
+### From `appsettings.json`
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .AddServiceBusChannel("Events:ServiceBus");
+```
+
+```json
+// appsettings.json
+{
+  "Events": {
+    "ServiceBus": {
+      "ConnectionString": "<your-connection-string>",
+      "QueueName": "events"
+    }
+  }
+}
+```
+
+## Options reference
+
+`ServiceBusEventPublishChannelOptions`
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `ConnectionString` | `string` | ✅ | Azure Service Bus connection string |
+| `QueueName` | `string` | ✅ | Name of the queue or topic to publish to |
+| `ClientOptions` | `ServiceBusClientOptions` | | Advanced client settings (see Azure SDK docs) |
+
+## How it works
+
+1. The channel resolves a `ServiceBusClient` via `IServiceBusClientFactory`.
+2. Each `CloudEvent` is serialised to JSON and wrapped in a `ServiceBusMessage`.
+3. CloudEvent attributes (`id`, `type`, `source`, `time`, `datacontenttype`) are mapped to message application properties so consumers can filter without parsing the body.
+4. The message is sent using a `ServiceBusSender` for the configured queue name.
+
+## Custom client factory
+
+If you need to control how the `ServiceBusClient` is created (e.g. for managed identity), implement `IServiceBusClientFactory`:
+
+```csharp
+using Azure.Identity;
+using Azure.Messaging.ServiceBus;
+using Deveel.Events;
+
+public class ManagedIdentityServiceBusClientFactory : IServiceBusClientFactory
+{
+    private readonly ServiceBusEventPublishChannelOptions _options;
+
+    public ManagedIdentityServiceBusClientFactory(IOptions<ServiceBusEventPublishChannelOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public ServiceBusClient CreateClient()
+        => new ServiceBusClient(_options.ConnectionString, new DefaultAzureCredential());
+}
+```
+
+Then register it (it will replace the built-in factory):
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .AddServiceBusChannel(options => options.QueueName = "events")
+    .Services
+        .AddSingleton<IServiceBusClientFactory, ManagedIdentityServiceBusClientFactory>();
+```
+
+## Related pages
+
+- [Publisher Channels Overview](README.md)
+- [Event Publisher](../concepts/event-publisher.md)
+

--- a/docs/publishers/masstransit.md
+++ b/docs/publishers/masstransit.md
@@ -1,0 +1,100 @@
+# MassTransit Channel
+
+The `Deveel.Events.Publisher.MassTransit` package adds a publish channel that routes `CloudEvent` instances through a MassTransit bus, making Deveel Events broker-agnostic — any MassTransit-supported transport (RabbitMQ, Azure Service Bus, Amazon SQS, Kafka, In-Memory, …) can be used transparently.
+
+## Installation
+
+```bash
+dotnet add package Deveel.Events.Publisher.MassTransit
+```
+
+> **Prerequisite:** MassTransit must already be configured in your application with at least one transport registered.  See the [MassTransit documentation](https://masstransit.io/documentation) for setup details.
+
+## Registration
+
+### Inline configuration
+
+```csharp
+using Deveel.Events;
+
+builder.Services
+    .AddEventPublisher()
+    .UseMassTransit(options =>
+    {
+        // Leave DestinationAddress null to publish (fan-out).
+        // Set it to send to a specific endpoint.
+        options.DestinationAddress  = new Uri("queue:order-events");
+        options.MapAttributesToHeaders = true;
+    });
+```
+
+### Minimal registration (no options)
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseMassTransit();
+```
+
+### From `appsettings.json`
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseMassTransit("Events:MassTransit");
+```
+
+```json
+// appsettings.json
+{
+  "Events": {
+    "MassTransit": {
+      "DestinationAddress": "queue:order-events",
+      "MapAttributesToHeaders": true
+    }
+  }
+}
+```
+
+## Options reference
+
+`MassTransitEventPublishChannelOptions`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `DestinationAddress` | `Uri?` | `null` | When `null`, the event is published via `IPublishEndpoint` (fan-out). When set, the event is sent to that specific queue/exchange via `ISendEndpointProvider`. |
+| `MapAttributesToHeaders` | `bool` | `true` | Maps CloudEvent attributes (`id`, `type`, `source`, `time`, `datacontenttype`, …) to MassTransit message headers. |
+
+## How it works
+
+1. The `MassTransitEventPublishChannel` wraps a `CloudEvent` in a `CloudEventMessage` — an `ICloudEventMessage` implementation that MassTransit can serialise.
+2. If `DestinationAddress` is set, the message is sent to that endpoint via `ISendEndpointProvider.GetSendEndpoint`.
+3. Otherwise, the message is published via `IPublishEndpoint.Publish`, allowing MassTransit's topology to route it.
+4. When `MapAttributesToHeaders` is `true`, CloudEvent attributes are written to the outgoing message headers so consumers can inspect them without deserialising the body.
+
+## Consuming CloudEvents with MassTransit
+
+On the consumer side, implement a MassTransit consumer for `ICloudEventMessage`:
+
+```csharp
+using MassTransit;
+using Deveel.Events;
+
+public class OrderPlacedConsumer : IConsumer<ICloudEventMessage>
+{
+    public Task Consume(ConsumeContext<ICloudEventMessage> context)
+    {
+        var cloudEvent = context.Message.CloudEvent;
+        Console.WriteLine($"Received: {cloudEvent.Type} ({cloudEvent.Id})");
+        return Task.CompletedTask;
+    }
+}
+```
+
+Register the consumer with MassTransit as you normally would.
+
+## Related pages
+
+- [Publisher Channels Overview](README.md)
+- [Event Publisher](../concepts/event-publisher.md)
+

--- a/docs/publishers/rabbitmq.md
+++ b/docs/publishers/rabbitmq.md
@@ -1,0 +1,216 @@
+# RabbitMQ Channel
+
+The `Deveel.Events.Publisher.RabbitMq` package adds a publish channel that delivers `CloudEvent` instances to a RabbitMQ exchange using the official `RabbitMQ.Client` library.
+
+## Installation
+
+```bash
+dotnet add package Deveel.Events.Publisher.RabbitMq
+```
+
+## Registration
+
+### Inline configuration
+
+```csharp
+using Deveel.Events;
+
+builder.Services
+    .AddEventPublisher()
+    .UseRabbitMq(options =>
+    {
+        options.ConnectionString = "amqp://guest:guest@localhost:5672";
+        options.ExchangeName     = "events";
+        options.RoutingKey       = "my.service";
+    });
+```
+
+### From `appsettings.json`
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseRabbitMq("Events:RabbitMq");
+```
+
+```json
+// appsettings.json
+{
+  "Events": {
+    "RabbitMq": {
+      "ConnectionString": "amqp://guest:guest@localhost:5672",
+      "ExchangeName": "events",
+      "RoutingKey": "my.service",
+      "QueueName": "my-service-events"
+    }
+  }
+}
+```
+
+## Options reference
+
+`RabbitMqEventPublishChannelOptions`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ConnectionString` | `string?` | `null` | AMQP connection URI |
+| `ExchangeName` | `string?` | `null` | Exchange to publish to (falls back to per-event `[AmqpExchange]` annotation) |
+| `RoutingKey` | `string?` | `null` | Default routing key (falls back to per-event `[AmqpRoutingKey]` annotation) |
+| `QueueName` | `string?` | `null` | Optional queue to bind the exchange to |
+| `ClientName` | `string?` | `"Deveel.Events"` | Client name shown in RabbitMQ management UI |
+| `MessageFormat` | `RabbitMqMessageFormat` | `Json` | Serialisation format: `Json` or `Xml` |
+| `MessageContent` | `RabbitMqMessageContent` | `CloudEvent` | Whether to send the full `CloudEvent` envelope or only the `data` payload |
+| `PersistentMessages` | `bool` | `true` | Delivery mode 2 (survives broker restarts) |
+| `PublisherConfirms` | `bool` | `true` | Wait for broker acknowledgement before returning |
+| `ConfirmTimeout` | `TimeSpan` | 5 s | Timeout for publisher confirms |
+| `Mandatory` | `bool` | `false` | Return unroutable messages instead of silently dropping them |
+| `JsonSerializerOptions` | `JsonSerializerOptions?` | default | Serialisation options when `MessageFormat = Json` |
+
+## AMQP Annotations
+
+Install the `Deveel.Events.Amqp.Annotations` package to declare routing metadata on individual event data classes, overriding the global channel defaults on a per-event-type basis.
+
+```bash
+dotnet add package Deveel.Events.Amqp.Annotations
+```
+
+### `[AmqpExchange]`
+
+Declares the AMQP exchange that events of this type should be published to.
+
+```csharp
+using Deveel.Events;
+
+[Event("order.placed", "1.0")]
+[AmqpExchange("orders")]
+public class OrderPlacedData
+{
+    public Guid OrderId { get; set; }
+    public decimal Amount { get; set; }
+}
+```
+
+When the RabbitMQ channel publishes an `OrderPlacedData` event, it targets the `"orders"` exchange, overriding any global `ExchangeName` set in `RabbitMqEventPublishChannelOptions`.
+
+### `[AmqpRoutingKey]`
+
+Declares the routing key to use when publishing an event to the exchange.
+
+```csharp
+[Event("order.placed", "1.0")]
+[AmqpExchange("orders")]
+[AmqpRoutingKey("order.placed")]
+public class OrderPlacedData
+{
+    public Guid OrderId { get; set; }
+    public decimal Amount { get; set; }
+}
+```
+
+### Priority rules
+
+When multiple sources of AMQP routing metadata exist, the following priority applies (highest to lowest):
+
+1. Per-event attributes (`[AmqpExchange]`, `[AmqpRoutingKey]`)
+2. `RabbitMqEventPublishChannelOptions.ExchangeName` / `.RoutingKey`
+
+### Complete example
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Deveel.Events;
+
+[Event("inventory.low-stock", "1.0", Description = "Raised when a product is running low on stock")]
+[AmqpExchange("inventory")]
+[AmqpRoutingKey("inventory.low-stock")]
+public class LowStockData
+{
+    [Required]
+    public string ProductId { get; set; } = default!;
+
+    [Required]
+    [Range(0, int.MaxValue)]
+    public int RemainingQuantity { get; set; }
+}
+```
+
+```csharp
+// Program.cs
+builder.Services
+    .AddEventPublisher()
+    .UseRabbitMq(options =>
+    {
+        options.ConnectionString = "amqp://guest:guest@localhost:5672";
+        // ExchangeName and RoutingKey are overridden per event by annotations
+    });
+```
+
+```csharp
+// Publishing
+await publisher.PublishAsync(new LowStockData
+{
+    ProductId         = "PROD-42",
+    RemainingQuantity = 3
+});
+// → Published to exchange "inventory" with routing key "inventory.low-stock"
+```
+
+### Internal implementation
+
+Both `[AmqpExchange]` and `[AmqpRoutingKey]` extend `EventAttributesAttribute`, which injects named CloudEvent extension attributes into the envelope:
+
+| Attribute | CloudEvent extension attribute |
+|-----------|-------------------------------|
+| `[AmqpExchange("orders")]` | `amqp-exchange-name = "orders"` |
+| `[AmqpRoutingKey("order.placed")]` | `amqp-routing-key = "order.placed"` |
+
+The RabbitMQ channel reads these extension attributes from the `CloudEvent` envelope at delivery time.
+
+## Message formats
+
+### `RabbitMqMessageFormat`
+
+| Value | Description |
+|-------|-------------|
+| `Json` | Serialise as JSON (default) |
+| `Xml` | Serialise as XML |
+
+### `RabbitMqMessageContent`
+
+| Value | Description |
+|-------|-------------|
+| `CloudEvent` | Send the full CloudEvent envelope (default) |
+| `DataOnly` | Send only the `data` portion of the CloudEvent |
+
+## Custom connection factory
+
+Implement `IRabbitMqConnectionFactory` to supply a custom `IConnection`:
+
+```csharp
+public class MyConnectionFactory : IRabbitMqConnectionFactory
+{
+    public async Task<IConnection> CreateConnectionAsync()
+    {
+        var factory = new ConnectionFactory { Uri = new Uri("amqp://guest:guest@localhost:5672") };
+        return await factory.CreateConnectionAsync();
+    }
+}
+```
+
+Register it after the channel:
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseRabbitMq(options => { /* ... */ })
+    .Services
+        .AddSingleton<IRabbitMqConnectionFactory, MyConnectionFactory>();
+```
+
+## Related pages
+
+- [Publisher Channels Overview](README.md)
+- [Event Annotations](../concepts/event-annotations.md)
+
+
+

--- a/docs/publishers/webhook.md
+++ b/docs/publishers/webhook.md
@@ -1,0 +1,164 @@
+# Webhook Channel
+
+The `Deveel.Events.Publisher.Webhook` package delivers `CloudEvent` instances over HTTP to a configured endpoint URL, with optional HMAC request signing, exponential-backoff retries, and pluggable serialisers.
+
+## Installation
+
+```bash
+dotnet add package Deveel.Events.Publisher.Webhook
+```
+
+## Registration
+
+### Inline configuration
+
+```csharp
+using Deveel.Events;
+
+builder.Services
+    .AddEventPublisher()
+    .UseWebhook(options =>
+    {
+        options.EndpointUrl      = "https://partner.example.com/events";
+        options.SigningSecret     = "s3cr3t";
+        options.SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha256;
+        options.MaxRetryCount     = 3;
+    });
+```
+
+### From `appsettings.json`
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseWebhook("Events:Webhook");
+```
+
+```json
+// appsettings.json
+{
+  "Events": {
+    "Webhook": {
+      "EndpointUrl": "https://partner.example.com/events",
+      "SigningSecret": "s3cr3t",
+      "SignatureAlgorithm": "HmacSha256",
+      "MaxRetryCount": 3,
+      "RetryDelay": "00:00:01",
+      "RetryBackoffMultiplier": 2.0,
+      "RequestTimeout": "00:00:30"
+    }
+  }
+}
+```
+
+## Options reference
+
+`WebhookEventPublishChannelOptions`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `EndpointUrl` | `string` | `""` | URL of the webhook endpoint |
+| `SigningSecret` | `string?` | `null` | Shared secret for HMAC signing; no signature header is sent when omitted |
+| `SignatureAlgorithm` | `WebhookSignatureAlgorithm` | `HmacSha256` | HMAC algorithm used to sign the body |
+| `SignatureHeaderName` | `string` | `X-Webhook-Signature` | HTTP header carrying the computed signature |
+| `SignatureAlgorithmHeaderName` | `string?` | `X-Webhook-Signature-Algorithm` | Header advertising the algorithm used; set to `null` to suppress |
+| `DeliveryIdHeaderName` | `string` | `X-Webhook-Delivery` | Header carrying a unique delivery identifier |
+| `EventTypeHeaderName` | `string` | `X-Webhook-Event` | Header carrying the event type |
+| `TimestampHeaderName` | `string` | `X-Webhook-Timestamp` | Unix-epoch timestamp header (used in signature payload to prevent replay attacks) |
+| `AdditionalHeaders` | `IDictionary<string, string>` | `{}` | Extra HTTP headers added to every request |
+| `MessageFormat` | `string` | `"json"` | Serialisation format: `"json"`, `"xml"`, `"cloudevents+json"`, `"cloudevents+xml"` |
+| `MaxRetryCount` | `int` | `3` | Maximum delivery attempts; `0` disables retries |
+| `RetryDelay` | `TimeSpan` | 1 s | Initial delay between retries |
+| `RetryBackoffMultiplier` | `double` | `2.0` | Multiplier for exponential backoff |
+| `RetryableStatusCodes` | `ISet<int>` | 429, 500, 502, 503, 504 | HTTP status codes that trigger a retry |
+| `RequestTimeout` | `TimeSpan` | 30 s | Timeout per individual HTTP request |
+| `HttpClientName` | `string?` | `null` | Named `HttpClient` resolved from `IHttpClientFactory`; defaults to the internal channel name |
+
+## Signature algorithms
+
+| Value | Algorithm | Note |
+|-------|-----------|------|
+| `HmacSha256` | HMAC-SHA256 | **Recommended** default |
+| `HmacSha384` | HMAC-SHA384 | |
+| `HmacSha512` | HMAC-SHA512 | |
+| `HmacSha1` | HMAC-SHA1 | Deprecated; included for legacy compatibility |
+
+The signature is computed over `<timestamp>.<body>` and sent in the configured signature header.
+
+## Message formats
+
+| `MessageFormat` value | Content-Type | Description |
+|-----------------------|--------------|-------------|
+| `"json"` | `application/json` | Plain JSON payload (default) |
+| `"xml"` | `application/xml` | Plain XML payload |
+| `"cloudevents+json"` | `application/cloudevents+json` | Full CloudEvents JSON envelope |
+| `"cloudevents+xml"` | `application/cloudevents+xml` | Full CloudEvents XML envelope |
+
+## Per-delivery options
+
+The channel also implements `IEventPublishChannel<WebhookPublishOptions>`, allowing you to override options per event:
+
+```csharp
+using Deveel.Events;
+
+// Resolve via DI
+var webhookChannel = serviceProvider.GetRequiredService<IEventPublishChannel<WebhookPublishOptions>>();
+
+await webhookChannel.PublishAsync(@event, new WebhookPublishOptions
+{
+    EndpointUrl       = "https://dynamic-endpoint.example.com/hook",
+    SigningSecret      = "per-tenant-secret",
+    SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha512
+});
+```
+
+## Batch delivery
+
+The channel implements `IBatchEventPublishChannel<WebhookPublishOptions>` for dispatching multiple events in a single HTTP call:
+
+```csharp
+var batchChannel = serviceProvider.GetRequiredService<IBatchEventPublishChannel<WebhookPublishOptions>>();
+
+await batchChannel.PublishBatchAsync(events, new WebhookPublishOptions
+{
+    EndpointUrl = "https://partner.example.com/events/batch"
+});
+```
+
+## Custom serialiser
+
+Register a custom `IEventSerializer` to support additional content types:
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseWebhook(options => options.MessageFormat = "application/x-protobuf")
+    .UseWebhookMessageSerializer<ProtobufEventSerializer>();
+```
+
+```csharp
+public class ProtobufEventSerializer : IEventSerializer
+{
+    public string Format => "application/x-protobuf";
+
+    public async Task<byte[]> SerializeAsync(CloudEvent @event, CancellationToken cancellationToken = default)
+    {
+        // ... protobuf serialisation
+    }
+}
+```
+
+## Custom signature provider
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseWebhook(options => { /* ... */ })
+    .UseWebhookSignatureProvider<Ed25519SignatureProvider>();
+```
+
+## Related pages
+
+- [Publisher Channels Overview](README.md)
+- [Event Publisher](../concepts/event-publisher.md)
+

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -1,0 +1,45 @@
+# Event Schema
+
+The `Deveel.Events.Schema` package adds the ability to formally describe the structure of your events — what properties they carry, their types, and constraints — and to validate `CloudEvent` instances against those descriptions before publishing.
+
+## Installation
+
+```bash
+dotnet add package Deveel.Events.Schema
+```
+
+## What's included
+
+| Type | Role |
+|------|------|
+| `IEventSchema` / `EventSchema` | The schema model |
+| `EventSchemaBuilder` | Fluent API for building a schema in code |
+| `EventSchemaCreator` | Derives a schema from an annotated class using reflection |
+| `IEventSchemaFactory` | DI-friendly factory wrapping `EventSchemaCreator` |
+| `IEventSchemaWriter` | Abstraction for schema serialisation (JSON, YAML, AsyncAPI) |
+| `EventSchemaJsonWriter` | Serialises a schema to JSON |
+| `IEventSchemaValidator` | Validates a `CloudEvent` against a schema |
+
+## Pages in this section
+
+| Page | Description |
+|------|-------------|
+| [Fluent Builder](fluent-builder.md) | Build a schema programmatically |
+| [From Annotations](from-annotations.md) | Derive a schema from `[Event]`-annotated classes |
+| [Export as JSON](export-json.md) | Serialise a schema to a JSON document |
+| [Export as YAML](export-yaml.md) | Serialise a schema to a YAML document |
+| [Export as AsyncAPI](export-asyncapi.md) | Generate complete AsyncAPI 2.x documents |
+| [Validation](validation.md) | Validate `CloudEvent` instances against a schema |
+
+## Schema model at a glance
+
+An `IEventSchema` carries:
+
+- **`Type`** — the event type string (e.g. `"order.placed"`)
+- **`Version`** — the SemVer version of the schema
+- **`ContentType`** — MIME type of the event data
+- **`Description`** — human-readable description
+- **`Properties`** — a collection of `IEventProperty` entries, each with:
+  - `Name`, `DataType`, `Description`
+  - Constraints: `Required`, `Nullable`, `Range<T>`, `Enum`
+

--- a/docs/schema/export-asyncapi.md
+++ b/docs/schema/export-asyncapi.md
@@ -1,0 +1,152 @@
+# Export Schema as AsyncAPI
+
+The `Deveel.Events.Schema.AsyncApi` package generates fully valid [AsyncAPI 2.x](https://www.asyncapi.com/) documents from one or more event schemas.
+
+## Installation
+
+```bash
+dotnet add package Deveel.Events.Schema.AsyncApi
+```
+
+## Single schema → standalone document
+
+`EventSchemaAsyncApiWriter` wraps a single `IEventSchema` in a complete AsyncAPI 2.x document.  It:
+
+- Declares the schema under `components/schemas`
+- Creates a matching message under `components/messages`
+- Wires a `subscribe` channel that references the message
+
+### JSON output (default)
+
+```csharp
+using Deveel.Events;
+
+var schema = EventSchema.FromDataType<OrderPlacedData>();
+
+var writer = new EventSchemaAsyncApiWriter(
+    format: AsyncApiFormat.Json,
+    title: "Order Events",
+    documentVersion: "1.0");
+
+await using var stream = File.OpenWrite("order-placed-asyncapi.json");
+await writer.WriteToAsync(stream, schema);
+```
+
+### YAML output
+
+```csharp
+var writer = new EventSchemaAsyncApiWriter(AsyncApiFormat.Yaml);
+
+await using var stream = File.OpenWrite("order-placed-asyncapi.yaml");
+await writer.WriteToAsync(stream, schema);
+```
+
+## Multiple schemas → combined document
+
+`EventSchemasAsyncApiWriter` merges several schemas into one document — useful for generating a service-wide contract file.
+
+```csharp
+using Deveel.Events;
+
+IEnumerable<IEventSchema> schemas =
+[
+    EventSchema.FromDataType<OrderPlacedData>(),
+    EventSchema.FromDataType<OrderCancelledData>(),
+    EventSchema.FromDataType<UserRegisteredData>()
+];
+
+var writer = new EventSchemasAsyncApiWriter(
+    title: "My Service Events",
+    version: "2.0",
+    format: AsyncApiFormat.Yaml);
+
+await using var stream = File.OpenWrite("events-asyncapi.yaml");
+await writer.WriteToAsync(stream, schemas);
+```
+
+## `AsyncApiFormat`
+
+| Value | Output |
+|-------|--------|
+| `AsyncApiFormat.Json` | JSON document |
+| `AsyncApiFormat.Yaml` | YAML document |
+
+## Low-level extension helpers
+
+`EventSchemaAsyncApiExtensions` exposes helpers for fine-grained control:
+
+```csharp
+using Deveel.Events;
+using NJsonSchema;
+using Saunter.AsyncApiSchema.v2;
+
+var schema = EventSchema.FromDataType<OrderPlacedData>();
+
+// Convert to NJsonSchema
+JsonSchema jsonSchema = schema.ToJsonSchema();
+
+// Convert to an AsyncAPI Message object
+Message message = schema.ToAsyncApiMessage();
+
+// Build a standalone AsyncApiDocument
+AsyncApiDocument document = schema.ToAsyncApiDocument(
+    title: "Order Events",
+    version: "1.0");
+
+// Or add the schema to an existing AsyncApiDocument
+var existingDoc = new AsyncApiDocument { /* ... */ };
+existingDoc.AddSchema(schema);
+```
+
+## Example YAML output
+
+```yaml
+asyncapi: 2.6.0
+info:
+  title: My Service Events
+  version: "2.0"
+channels:
+  order/placed:
+    subscribe:
+      message:
+        $ref: "#/components/messages/OrderPlaced"
+  order/cancelled:
+    subscribe:
+      message:
+        $ref: "#/components/messages/OrderCancelled"
+components:
+  schemas:
+    OrderPlacedData:
+      type: object
+      required:
+        - orderId
+        - amount
+        - currency
+      properties:
+        orderId:
+          type: string
+          format: uuid
+        amount:
+          type: number
+          minimum: 0.01
+          maximum: 1000000
+        currency:
+          type: string
+        notes:
+          type: string
+          nullable: true
+  messages:
+    OrderPlaced:
+      payload:
+        $ref: "#/components/schemas/OrderPlacedData"
+      name: order.placed
+      title: Order Placed
+```
+
+## Related pages
+
+- [Export as JSON](export-json.md)
+- [Export as YAML](export-yaml.md)
+- [From Annotations](from-annotations.md)
+- [Fluent Builder](fluent-builder.md)
+

--- a/docs/schema/export-json.md
+++ b/docs/schema/export-json.md
@@ -1,0 +1,86 @@
+# Export Schema as JSON
+
+`EventSchemaJsonWriter` serialises an `IEventSchema` to a JSON stream.  It is included in the `Deveel.Events.Schema` package — no extra installation required.
+
+## Usage
+
+```csharp
+using Deveel.Events;
+using System.Text.Json;
+
+var schema = EventSchema.FromDataType<OrderPlacedData>();
+
+var writer = new EventSchemaJsonWriter(new JsonWriterOptions { Indented = true });
+
+await using var stream = File.OpenWrite("order-placed-schema.json");
+await writer.WriteToAsync(stream, schema);
+```
+
+## `JsonWriterOptions`
+
+Pass a `System.Text.Json.JsonWriterOptions` instance to control formatting:
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `Indented` | `false` | Pretty-print the JSON output |
+| `Encoder` | `null` | Custom character encoder |
+
+## Output format
+
+```json
+{
+  "type": "order.placed",
+  "version": "1.0",
+  "contentType": "object",
+  "description": "Raised when a customer places an order",
+  "properties": {
+    "OrderId": {
+      "dataType": "guid",
+      "required": true
+    },
+    "Amount": {
+      "dataType": "money",
+      "required": true,
+      "min": 0.01,
+      "max": 1000000
+    },
+    "Currency": {
+      "dataType": "string",
+      "required": true
+    },
+    "Notes": {
+      "dataType": "string",
+      "nullable": true
+    }
+  }
+}
+```
+
+## Writing to a string
+
+```csharp
+await using var memStream = new MemoryStream();
+await writer.WriteToAsync(memStream, schema);
+var json = Encoding.UTF8.GetString(memStream.ToArray());
+```
+
+## `IEventSchemaWriter` interface
+
+`EventSchemaJsonWriter` implements `IEventSchemaWriter`:
+
+```csharp
+public interface IEventSchemaWriter
+{
+    Task WriteToAsync(Stream stream, IEventSchema schema, CancellationToken cancellationToken = default);
+}
+```
+
+You can register and resolve it via DI if you prefer not to instantiate it directly.
+
+## Related pages
+
+- [Export as YAML](export-yaml.md)
+- [Export as AsyncAPI](export-asyncapi.md)
+- [Fluent Builder](fluent-builder.md)
+- [From Annotations](from-annotations.md)
+

--- a/docs/schema/export-yaml.md
+++ b/docs/schema/export-yaml.md
@@ -1,0 +1,79 @@
+# Export Schema as YAML
+
+`EventSchemaYamlWriter` serialises an `IEventSchema` to a YAML stream using [YamlDotNet](https://github.com/aaubry/YamlDotNet).
+
+## Installation
+
+```bash
+dotnet add package Deveel.Events.Schema.Yaml
+```
+
+## Usage
+
+```csharp
+using Deveel.Events;
+
+var schema = EventSchema.FromDataType<OrderPlacedData>();
+
+var writer = new EventSchemaYamlWriter();   // camelCase property names by default
+
+await using var stream = File.OpenWrite("order-placed-schema.yaml");
+await writer.WriteToAsync(stream, schema);
+```
+
+## Output format
+
+```yaml
+type: order.placed
+version: "1.0"
+contentType: object
+description: Raised when a customer places an order
+properties:
+  orderId:
+    dataType: guid
+    required: true
+  amount:
+    dataType: money
+    required: true
+    min: 0.01
+    max: 1000000
+  currency:
+    dataType: string
+    required: true
+  notes:
+    dataType: string
+    nullable: true
+```
+
+Property names are converted to **camelCase** by default.
+
+## Custom serialiser
+
+Supply a custom `YamlDotNet.Serialization.ISerializer` to control naming conventions, anchors, and other output options:
+
+```csharp
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+var serializer = new SerializerBuilder()
+    .WithNamingConvention(UnderscoredNamingConvention.Instance)
+    .Build();
+
+var writer = new EventSchemaYamlWriter(serializer);
+```
+
+## Writing to a string
+
+```csharp
+await using var memStream = new MemoryStream();
+await writer.WriteToAsync(memStream, schema);
+var yaml = Encoding.UTF8.GetString(memStream.ToArray());
+```
+
+## Related pages
+
+- [Export as JSON](export-json.md)
+- [Export as AsyncAPI](export-asyncapi.md)
+- [Fluent Builder](fluent-builder.md)
+- [From Annotations](from-annotations.md)
+

--- a/docs/schema/fluent-builder.md
+++ b/docs/schema/fluent-builder.md
@@ -1,0 +1,97 @@
+# Fluent Schema Builder
+
+`EventSchemaBuilder` provides a readable, chainable API for defining an event schema entirely in code — no data classes required.
+
+## Basic usage
+
+```csharp
+using Deveel.Events;
+
+var schema = EventSchema.Build("order.placed")
+    .WithVersion("1.0")
+    .WithContentType("application/json")
+    .WithDescription("Raised when a customer places an order")
+    .AddProperty("order_id",  "guid",   p => p.Required())
+    .AddProperty("amount",    "money",  p => p.Required().WithRange<decimal>(0m, 1_000_000m))
+    .AddProperty("currency",  "string", p => p.Required())
+    .AddProperty("notes",     "string", p => p.Nullable())
+    .Build();
+```
+
+`EventSchema.Build(eventType)` returns an `EventSchemaBuilder`.  Call `.Build()` at the end to produce the immutable `EventSchema` object.
+
+## Builder methods
+
+### Schema-level
+
+| Method | Description |
+|--------|-------------|
+| `.WithVersion(string)` | Sets the schema version (SemVer recommended) |
+| `.WithContentType(string)` | Sets the MIME content type of the event data |
+| `.WithDescription(string)` | Sets a human-readable description |
+| `.AddProperty(name, type, configure?)` | Adds a property with the given name and data type |
+| `.AddProperty(name, configure)` | Adds a property using a full configure delegate |
+
+### Property-level (`EventPropertyBuilder`)
+
+| Method | Description |
+|--------|-------------|
+| `.OfType(string)` | Sets the data type of the property |
+| `.Required()` | Marks the property as required |
+| `.Nullable()` | Marks the property as nullable |
+| `.WithDescription(string)` | Sets a human-readable description |
+| `.WithRange<T>(min, max)` | Adds a range constraint |
+| `.WithEnum(values)` | Restricts the property to a set of allowed values |
+
+## Property data types
+
+The schema is type-system agnostic — `DataType` is a plain string.  The following values are used by convention and are recognised by the AsyncAPI exporter:
+
+| String value | Semantic |
+|---|---|
+| `"string"` | UTF-8 text |
+| `"int"` / `"integer"` | 32-bit signed integer |
+| `"long"` | 64-bit signed integer |
+| `"decimal"` / `"money"` | High-precision decimal number |
+| `"float"` / `"double"` | Floating-point number |
+| `"bool"` / `"boolean"` | Boolean |
+| `"guid"` / `"uuid"` | UUID / GUID |
+| `"datetime"` / `"date"` / `"time"` | Date/time value |
+| `"object"` | Embedded object |
+| `"array"` | Array/list |
+
+You may use any string for custom or domain-specific types.
+
+## Rich property configuration
+
+Use the delegate overload for more control:
+
+```csharp
+var schema = EventSchema.Build("user.registered")
+    .WithVersion("1.0")
+    .AddProperty("email", p => p
+        .OfType("string")
+        .Required()
+        .WithDescription("The email address of the new user"))
+    .AddProperty("age", p => p
+        .OfType("int")
+        .WithRange<int>(18, 120)
+        .WithDescription("Age of the user in years"))
+    .AddProperty("role", p => p
+        .OfType("string")
+        .Required()
+        .WithEnum("admin", "user", "guest"))
+    .AddProperty("nickname", p => p
+        .OfType("string")
+        .Nullable())
+    .Build();
+```
+
+## Related pages
+
+- [From Annotations](from-annotations.md) — derive a schema from existing data classes
+- [Export as JSON](export-json.md)
+- [Export as YAML](export-yaml.md)
+- [Export as AsyncAPI](export-asyncapi.md)
+- [Validation](validation.md)
+

--- a/docs/schema/from-annotations.md
+++ b/docs/schema/from-annotations.md
@@ -1,0 +1,127 @@
+# Schema from Annotations
+
+If you already have a data-transfer class decorated with `[Event]` and standard `System.ComponentModel.DataAnnotations` attributes, you can derive an `EventSchema` from it automatically — no need to write a schema by hand.
+
+## Prerequisites
+
+Install both the annotations and schema packages:
+
+```bash
+dotnet add package Deveel.Events.Annotations
+dotnet add package Deveel.Events.Schema
+```
+
+## Annotating your class
+
+Apply `[Event]` at class level and standard data-annotation attributes on properties:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Deveel.Events;
+
+[Event("order.placed", "1.0", Description = "Raised when a customer places an order")]
+public class OrderPlacedData
+{
+    [Required]
+    public Guid OrderId { get; set; }
+
+    [Required]
+    [Range(0.01, 1_000_000.0)]
+    public decimal Amount { get; set; }
+
+    [Required]
+    public string Currency { get; set; } = default!;
+
+    public string? Notes { get; set; }
+}
+```
+
+### Attribute mapping
+
+| Data annotation | Schema constraint |
+|-----------------|-------------------|
+| `[Required]` | `required: true` |
+| `[Range(min, max)]` | `min` / `max` constraints |
+| `[AllowedValues(...)]` / custom enum | `enum` constraint |
+| Nullable reference type (`T?`) | `nullable: true` |
+| `[EventProperty(name)]` | Overrides the property name in the schema |
+
+## Deriving a schema
+
+### Static helper
+
+```csharp
+using Deveel.Events;
+
+var schema = EventSchema.FromDataType<OrderPlacedData>();
+```
+
+### Via the injectable factory (preferred in DI scenarios)
+
+```csharp
+using Deveel.Events;
+
+// Register schema services
+builder.Services.AddEventPublisher(); // already registers IEventSchemaFactory when Schema is referenced
+
+public class MyService
+{
+    private readonly IEventSchemaFactory _schemaFactory;
+
+    public MyService(IEventSchemaFactory schemaFactory)
+    {
+        _schemaFactory = schemaFactory;
+    }
+
+    public IEventSchema GetOrderSchema()
+        => _schemaFactory.CreateFromType<OrderPlacedData>();
+}
+```
+
+### From a `Type` reference
+
+```csharp
+var schema = EventSchema.FromDataType(typeof(OrderPlacedData));
+```
+
+## Generated schema
+
+For the `OrderPlacedData` class above, the derived schema is equivalent to:
+
+```csharp
+EventSchema.Build("order.placed")
+    .WithVersion("1.0")
+    .WithDescription("Raised when a customer places an order")
+    .AddProperty("OrderId",   "guid",    p => p.Required())
+    .AddProperty("Amount",    "money",   p => p.Required().WithRange<decimal>(0.01m, 1_000_000m))
+    .AddProperty("Currency",  "string",  p => p.Required())
+    .AddProperty("Notes",     "string",  p => p.Nullable())
+    .Build();
+```
+
+## Exporting the derived schema
+
+Once you have an `IEventSchema`, you can export it in any supported format:
+
+```csharp
+// JSON
+var jsonWriter = new EventSchemaJsonWriter(new JsonWriterOptions { Indented = true });
+await jsonWriter.WriteToAsync(stream, schema);
+
+// YAML (requires Deveel.Events.Schema.Yaml)
+var yamlWriter = new EventSchemaYamlWriter();
+await yamlWriter.WriteToAsync(stream, schema);
+
+// AsyncAPI (requires Deveel.Events.Schema.AsyncApi)
+var asyncApiWriter = new EventSchemaAsyncApiWriter(AsyncApiFormat.Yaml);
+await asyncApiWriter.WriteToAsync(stream, schema);
+```
+
+## Related pages
+
+- [Fluent Builder](fluent-builder.md)
+- [Export as JSON](export-json.md)
+- [Export as YAML](export-yaml.md)
+- [Export as AsyncAPI](export-asyncapi.md)
+- [Validation](validation.md)
+

--- a/docs/schema/validation.md
+++ b/docs/schema/validation.md
@@ -1,0 +1,118 @@
+# Schema Validation
+
+`IEventSchemaValidator` validates a `CloudEvent` instance against an `IEventSchema` and reports constraint violations as an asynchronous stream of `ValidationResult` objects.
+
+## Prerequisites
+
+The validator is provided by the `Deveel.Events.Schema` package:
+
+```bash
+dotnet add package Deveel.Events.Schema
+```
+
+## Interface
+
+```csharp
+public interface IEventSchemaValidator
+{
+    IAsyncEnumerable<ValidationResult> ValidateEventAsync(
+        IEventSchema schema,
+        CloudEvent @event,
+        CancellationToken cancellationToken = default);
+}
+```
+
+## Registration
+
+Register the schema services alongside the publisher:
+
+```csharp
+using Deveel.Events;
+
+builder.Services
+    .AddEventPublisher()
+    // Schema services are automatically registered when
+    // Deveel.Events.Schema is referenced and the publisher builder is used.
+    // If you need them independently, call AddEventSchema():
+    .Services
+        .AddEventSchema();  // registers IEventSchemaFactory and IEventSchemaValidator
+```
+
+> **Note:** Exact registration method naming may vary with the package version.  Consult the XML docs on `IServiceCollection` extensions for the current API.
+
+## Validating before publishing
+
+```csharp
+using CloudNative.CloudEvents;
+using Deveel.Events;
+using System.ComponentModel.DataAnnotations;
+
+public class OrderService
+{
+    private readonly IEventSchemaValidator _validator;
+    private readonly IEventPublisher _publisher;
+
+    public OrderService(IEventSchemaValidator validator, IEventPublisher publisher)
+    {
+        _validator = validator;
+        _publisher = publisher;
+    }
+
+    public async Task PlaceOrderAsync(OrderPlacedData data, CancellationToken ct = default)
+    {
+        var schema = EventSchema.FromDataType<OrderPlacedData>();
+
+        var @event = new CloudEvent
+        {
+            Type   = "order.placed",
+            Source = new Uri("https://myapp.example.com/orders"),
+            Data   = data
+        };
+
+        // Collect all validation errors before publishing
+        var errors = new List<ValidationResult>();
+        await foreach (var result in _validator.ValidateEventAsync(schema, @event, ct))
+        {
+            errors.Add(result);
+        }
+
+        if (errors.Count > 0)
+        {
+            var messages = string.Join("; ", errors.Select(e => e.ErrorMessage));
+            throw new InvalidOperationException($"Event is invalid: {messages}");
+        }
+
+        await _publisher.PublishAsync(data, ct);
+    }
+}
+```
+
+## Validated constraints
+
+The validator checks the following constraints declared in the schema against the event's `data` payload:
+
+| Constraint | Checked when |
+|------------|--------------|
+| `Required` | The property is missing or `null` in the payload |
+| `Nullable: false` | The property is explicitly `null` |
+| `Range<T>(min, max)` | The value falls outside the range |
+| `Enum(values)` | The value is not in the allowed set |
+
+## Streaming results
+
+`ValidateEventAsync` returns `IAsyncEnumerable<ValidationResult>`, so you can process errors lazily or stop early on the first error:
+
+```csharp
+// Stop on first violation
+await foreach (var result in _validator.ValidateEventAsync(schema, @event))
+{
+    throw new InvalidOperationException(result.ErrorMessage);
+}
+```
+
+## Related pages
+
+- [Fluent Builder](fluent-builder.md)
+- [From Annotations](from-annotations.md)
+- [Event Publisher](../concepts/event-publisher.md)
+

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,135 @@
+# Test Publisher
+
+The `Deveel.Events.TestPublisher` package provides an in-memory publish channel (`TestEventPublishChannel`) that can be used in unit and integration tests to assert on published events without requiring a real messaging transport.
+
+## Installation
+
+```bash
+dotnet add package Deveel.Events.TestPublisher
+```
+
+## Registration
+
+Register a test channel using one of the `AddTestChannel` overloads on `EventPublisherBuilder`.
+
+### With a `Func<CloudEvent, Task>` callback
+
+```csharp
+using CloudNative.CloudEvents;
+using Deveel.Events;
+using Microsoft.Extensions.DependencyInjection;
+
+var publishedEvents = new List<CloudEvent>();
+
+var services = new ServiceCollection();
+services.AddEventPublisher()
+        .AddTestChannel(async @event =>
+        {
+            publishedEvents.Add(@event);
+            await Task.CompletedTask;
+        });
+
+var provider = services.BuildServiceProvider();
+```
+
+### With an `Action<CloudEvent>` callback (synchronous)
+
+```csharp
+var publishedEvents = new List<CloudEvent>();
+
+services.AddEventPublisher()
+        .AddTestChannel(@event => publishedEvents.Add(@event));
+```
+
+### With a custom `IEventPublishCallback`
+
+```csharp
+public class MyTestCallback : IEventPublishCallback
+{
+    public List<CloudEvent> Events { get; } = new();
+
+    public Task OnPublishedAsync(CloudEvent @event, CancellationToken cancellationToken = default)
+    {
+        Events.Add(@event);
+        return Task.CompletedTask;
+    }
+}
+
+var callback = new MyTestCallback();
+
+services.AddEventPublisher()
+        .AddTestChannel(callback);
+```
+
+## Usage in xUnit
+
+```csharp
+using CloudNative.CloudEvents;
+using Deveel.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+public class OrderServiceTests
+{
+    private readonly IEventPublisher _publisher;
+    private readonly List<CloudEvent> _published = new();
+
+    public OrderServiceTests()
+    {
+        var services = new ServiceCollection();
+        services.AddEventPublisher()
+                .AddTestChannel(@event => _published.Add(@event));
+        services.AddTransient<OrderService>();
+
+        var provider = services.BuildServiceProvider();
+        _publisher = provider.GetRequiredService<IEventPublisher>();
+    }
+
+    [Fact]
+    public async Task PlaceOrder_PublishesOrderPlacedEvent()
+    {
+        var service = new OrderService(_publisher);
+
+        await service.PlaceOrderAsync(Guid.NewGuid(), 99.95m, "USD");
+
+        Assert.Single(_published);
+        var @event = _published[0];
+        Assert.Equal("order.placed", @event.Type);
+        Assert.Equal("USD", ((OrderPlacedData)@event.Data!).Currency);
+    }
+}
+```
+
+## `IEventPublishCallback`
+
+```csharp
+public interface IEventPublishCallback
+{
+    Task OnPublishedAsync(CloudEvent @event, CancellationToken cancellationToken = default);
+}
+```
+
+Implement this interface when you need richer callback logic (e.g. recording timestamps, simulating failures, asserting within the callback).
+
+## Combining with `IEventSystemTime`
+
+Replace the system time to control event timestamps in tests:
+
+```csharp
+services.AddEventPublisher()
+        .UseSystemTime<FrozenSystemTime>()
+        .AddTestChannel(@event => _published.Add(@event));
+```
+
+```csharp
+public class FrozenSystemTime : IEventSystemTime
+{
+    public DateTimeOffset UtcNow { get; } = new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
+}
+```
+
+## Related pages
+
+- [Event Publisher](../concepts/event-publisher.md)
+- [Publish Channels](../concepts/publish-channels.md)
+


### PR DESCRIPTION
This pull request introduces the initial documentation structure and comprehensive content for the Deveel Events framework. It adds a detailed overview, core concepts, event schema explanation, and structured navigation for the documentation site. The changes focus on providing clear guidance on using the framework, its design philosophy, and its extensibility. The most important changes are grouped below:

**Major Documentation Additions:**

* Added a comprehensive `README.md` that explains the purpose, concepts, and features of Deveel Events, including its alignment with Domain-Driven Design and CloudEvents, event schemas, and supported publisher channels.
* Created a documentation summary and navigation in `SUMMARY.md`, outlining the structure and main topics of the documentation site.

**Core Concepts and Usage Guides:**

* Added core concept explanations in `concepts/README.md`, including diagrams and key abstractions such as `IEventPublisher` and `IEventPublishChannel`.
* Provided detailed guides for using the event publisher (`concepts/event-publisher.md`), CloudEvents standard integration (`concepts/cloudevents.md`), and event annotation attributes (`concepts/event-annotations.md`). [[1]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bR1-R131) [[2]](diffhunk://#diff-a94f88ac83ca7781126849ff551899549dde4c2d57c232c4c00a8f72b01e37dbR1-R67) [[3]](diffhunk://#diff-e87f3b77a874251d7c7b90f79197cc290370b12684d0f428202c5dc30aa08f7cR1-R130)

**Documentation Structure and Navigation:**

* Added a redirect notice for AMQP Annotations, consolidating documentation under the RabbitMQ channel section.

These changes lay the foundation for a well-organized and informative documentation site, making it easier for users to understand and adopt the Deveel Events framework.