### PR TITLE
Refactor Webhook project to use Microsoft.Extensions.Http.Resilience

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -40,7 +40,7 @@ The table below lists the key NuGet packages that each library brings in as tran
 | `Deveel.Events.Publisher.AzureServiceBus` | `Azure.Messaging.ServiceBus` ≥ 7.20 |
 | `Deveel.Events.Publisher.RabbitMq` | `RabbitMQ.Client` ≥ 7.2 · `Deveel.Events.Amqp.Annotations` |
 | `Deveel.Events.Publisher.MassTransit` | `MassTransit` ≥ 9.1 |
-| `Deveel.Events.Publisher.Webhook` | `Microsoft.Extensions.Http` · `Polly` ≥ 7.2 |
+| `Deveel.Events.Publisher.Webhook` | `Microsoft.Extensions.Http` · `Microsoft.Extensions.Http.Resilience` ≥ 9.6 |
 | `Deveel.Events.Schema` | `CloudNative.CloudEvents` |
 | `Deveel.Events.Schema.Yaml` | `YamlDotNet` ≥ 16.3 |
 | `Deveel.Events.Schema.AsyncApi` | `Saunter` ≥ 0.13 · `YamlDotNet` ≥ 16.3 · ASP.NET Core shared framework |

--- a/src/Deveel.Events.Publisher.Webhook/Deveel.Events.Publisher.Webhook.csproj
+++ b/src/Deveel.Events.Publisher.Webhook/Deveel.Events.Publisher.Webhook.csproj
@@ -6,23 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
-    <PackageReference Include="Polly" Version="7.2.4" />
-    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Deveel.Events.Publisher\Deveel.Events.Publisher.csproj" />

--- a/src/Deveel.Events.Publisher.Webhook/Events/WebhookEventPublishChannel.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/WebhookEventPublishChannel.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 using Polly;
-using Polly.Extensions.Http;
+using Polly.Retry;
 
 using System.Net.Http.Headers;
 
@@ -139,30 +139,55 @@ namespace Deveel.Events
             else
                 _logger.LogDeliveringBatch(deliveryId, eventCount, eff.Format, algorithm, eff.EndpointUrl);
 
-            // Build the Polly retry policy from the effective (possibly per-delivery-overridden) options.
-            var retryPolicy = HttpPolicyExtensions
-                .HandleTransientHttpError()
-                .Or<TaskCanceledException>(ex => !cancellationToken.IsCancellationRequested)
-                .Or<OperationCanceledException>(ex => !cancellationToken.IsCancellationRequested)
-                .OrResult(r => eff.RetryableStatusCodes.Contains((int)r.StatusCode))
-                .WaitAndRetryAsync(
-                    eff.MaxRetryCount,
-                    attempt => TimeSpan.FromMilliseconds(
-                        eff.RetryDelay.TotalMilliseconds * Math.Pow(eff.RetryBackoffMultiplier, attempt - 1)),
-                    onRetry: (outcome, delay, attempt, _) =>
+            // Build the resilience pipeline from the effective (possibly per-delivery-overridden) options.
+            var pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
+                .AddRetry(new RetryStrategyOptions<HttpResponseMessage>
+                {
+                    MaxRetryAttempts = eff.MaxRetryCount,
+                    UseJitter        = false,
+                    DelayGenerator   = args => ValueTask.FromResult<TimeSpan?>(
+                        TimeSpan.FromMilliseconds(
+                            eff.RetryDelay.TotalMilliseconds *
+                            Math.Pow(eff.RetryBackoffMultiplier, args.AttemptNumber))),
+                    ShouldHandle = args =>
                     {
-                        if (outcome.Exception != null)
+                        if (args.Outcome.Exception != null)
+                            return ValueTask.FromResult(
+                                args.Outcome.Exception is HttpRequestException ||
+                                ((args.Outcome.Exception is TaskCanceledException
+                                  or OperationCanceledException)
+                                 && !cancellationToken.IsCancellationRequested));
+
+                        if (args.Outcome.Result != null)
+                        {
+                            var code = (int)args.Outcome.Result.StatusCode;
+                            return ValueTask.FromResult(
+                                code is >= 500 or 408 ||
+                                eff.RetryableStatusCodes.Contains(code));
+                        }
+
+                        return ValueTask.FromResult(false);
+                    },
+                    OnRetry = args =>
+                    {
+                        if (args.Outcome.Exception != null)
                             _logger.LogRetryOnException(
-                                deliveryId, attempt, outcome.Exception.Message, delay.TotalMilliseconds);
+                                deliveryId, args.AttemptNumber + 1,
+                                args.Outcome.Exception.Message, args.RetryDelay.TotalMilliseconds);
                         else
                             _logger.LogRetryOnStatusCode(
-                                deliveryId, attempt, (int)outcome.Result.StatusCode, delay.TotalMilliseconds);
-                    });
+                                deliveryId, args.AttemptNumber + 1,
+                                (int)args.Outcome.Result!.StatusCode, args.RetryDelay.TotalMilliseconds);
+
+                        return ValueTask.CompletedTask;
+                    }
+                })
+                .Build();
 
             HttpResponseMessage response;
             try
             {
-                response = await retryPolicy.ExecuteAsync(async ct =>
+                response = await pipeline.ExecuteAsync(async ct =>
                 {
                     // HttpRequestMessage must be recreated per attempt.
                     using var request = BuildRequest(


### PR DESCRIPTION
This pull request updates the `Deveel.Events.Publisher.Webhook` library to use the new `Microsoft.Extensions.Http.Resilience` package for HTTP resilience and retry strategies, replacing the previous usage of Polly and related packages. The changes simplify dependency management and modernize the retry logic implementation.

**Dependency updates:**

* Replaced `Polly`, `Polly.Extensions.Http`, and version-specific `Microsoft.Extensions.Http` dependencies with a single dependency on `Microsoft.Extensions.Http.Resilience` version 9.6.0 in the `Deveel.Events.Publisher.Webhook.csproj` file.
* Updated documentation in `installation.md` to reflect the new dependency on `Microsoft.Extensions.Http.Resilience` ≥ 9.6 for the webhook publisher package.

**Code refactoring for retry logic:**

* Removed usage of `Polly` and `Polly.Extensions.Http` in favor of the new resilience pipeline API from `Microsoft.Extensions.Http.Resilience` in `WebhookEventPublishChannel.cs`.
* Refactored the retry policy construction in `DeliverAsync` to use `ResiliencePipelineBuilder` and `RetryStrategyOptions`, modernizing the way retry logic is defined and executed.…ttp.Resilience for improved retry handling