### PR TITLE
Fix variable name in PublishEventAsync for correct event reference

### DIFF
--- a/src/Deveel.Events.Publisher/Events/EventPublisher.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublisher.cs
@@ -222,7 +222,7 @@ namespace Deveel.Events {
 				_logger.TraceEventPublishing(@event.Type!, channel.GetType());
 
 				try {
-					await PublishEventAsync(channel, @event, cancellationToken);
+					await PublishEventAsync(channel, @eventToPublish, cancellationToken);
 
 					_logger.TraceEventPublished(@event.Type!, channel.GetType());
 				} catch (Exception ex) {


### PR DESCRIPTION
The dead variable `eventToPublish` was correctly used after normalization, published through the pipeline