### PR TITLE
Add content type handling and cancellation token support in events

### DIFF
--- a/docs/concepts/event-annotations.md
+++ b/docs/concepts/event-annotations.md
@@ -39,7 +39,7 @@ public class OrderPlacedData
 | `DataVersion` | `string?` | SemVer version string (set when the second argument is not a URI). |
 | `DataSchema` | `Uri?` | Absolute URI to the schema (set when the second argument is a URI). |
 | `Description` | `string?` | Human-readable description for documentation purposes. |
-| `ContentType` | `string?` | MIME content type of the data payload (e.g. `"application/json"`). |
+| `ContentType` | `string?` | MIME content type of the data payload (e.g. `"application/json"`). When not set, publishing uses `EventPublisherOptions.DefaultContentType` (default: `"application/cloudevents+json"`), and schema generation defaults to `"object"`. |
 
 ## `[EventProperty]` attribute
 

--- a/docs/concepts/event-publisher.md
+++ b/docs/concepts/event-publisher.md
@@ -34,6 +34,7 @@ builder.Services.AddEventPublisher("Events:Publisher");
 | `JsonSerializerOptions` | `JsonSerializerOptions?` | default | Options used when serialising JSON payloads. |
 | `Attributes` | `Dictionary<string, object?>` | `{}` | Extra CloudEvent attributes added to every event. |
 | `DataSchemaBaseUri` | `Uri?` | `null` | Base URI prepended to the event type to form the `dataschema` when none is specified on the event. |
+| `DefaultContentType` | `string?` | `"application/cloudevents+json"` | Default MIME content type used when not specified on the event. |
 
 ### Example `appsettings.json`
 

--- a/src/Deveel.Events.Annotations/Events/EventAttribute.cs
+++ b/src/Deveel.Events.Annotations/Events/EventAttribute.cs
@@ -62,7 +62,14 @@ namespace Deveel.Events {
 
         /// <summary>
         /// The MIME content type (e.g. <c>"application/json"</c>) of the event data.
-        /// When not set, the factory defaults to <c>"object"</c>.
+        /// When not set, the default behavior depends on the context:
+        /// <para>
+        /// - For event publishing, defaults to <c>EventPublisherOptions.DefaultContentType</c> 
+        ///   (default value is <c>"application/cloudevents+json"</c>).
+        /// </para>
+        /// <para>
+        /// - For schema generation, defaults to <c>"object"</c>.
+        /// </para>
         /// </summary>
 		public string? ContentType { get; set; }
 	}

--- a/src/Deveel.Events.Publisher/Events/EventCreator.cs
+++ b/src/Deveel.Events.Publisher/Events/EventCreator.cs
@@ -32,6 +32,13 @@ namespace Deveel.Events
             var eventType = eventAttribute.EventType;
             var dataSchema = eventAttribute.DataSchema;
             var dataVersion = eventAttribute.DataVersion;
+            var contentType = eventAttribute.ContentType;
+            
+            if (String.IsNullOrWhiteSpace(contentType))
+                contentType = PublisherOptions.DefaultContentType;
+            
+            if (String.IsNullOrWhiteSpace(contentType))
+                throw new InvalidOperationException("The content type for the event is not set");
 
             Uri? schemaUri = null;
             if (dataSchema == null && String.IsNullOrWhiteSpace(dataVersion))
@@ -50,13 +57,11 @@ namespace Deveel.Events
                 schemaUri = schemaUriBuilder.Uri;
             }
 
-            // TODO: discover an optional content type attribute and 
-            //       use it to determine the content type of the data
             var @event = new CloudEvent
             {
                 Type = eventType,
                 DataSchema = schemaUri,
-                DataContentType = "application/cloudevents+json",
+                DataContentType = contentType,
                 Data = JsonSerializer.Serialize(data, PublisherOptions.JsonSerializerOptions)
             };
 

--- a/src/Deveel.Events.Publisher/Events/EventPublisherOptions.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublisherOptions.cs
@@ -44,5 +44,12 @@ namespace Deveel.Events {
         /// when the schema is not specified in the event.
         /// </summary>
 		public Uri? DataSchemaBaseUri { get; set; }
+        
+        /// <summary>
+        /// A default content type to use for the data of the events, when
+        /// the content type is not specified in the event.
+        /// The default value is "application/cloudevents+json".
+        /// </summary>
+        public string? DefaultContentType { get; set; } = "application/cloudevents+json";
 	}
 }

--- a/test/Deveel.Events.Publisher.XUnit/Events/PublisherTests.cs
+++ b/test/Deveel.Events.Publisher.XUnit/Events/PublisherTests.cs
@@ -46,7 +46,7 @@ namespace Deveel.Events {
 
 			@event[CloudEventAttribute.CreateExtension("env", CloudEventAttributeType.String)] = "test";
 
-			await Publisher.PublishEventAsync(@event);
+			await Publisher.PublishEventAsync(@event, TestContext.Current.CancellationToken);
 
 			Assert.Single(Events);
 			Assert.Equal("person.created", Events[0].Type);
@@ -65,7 +65,7 @@ namespace Deveel.Events {
 				Id = "123",
 				FirstName = "John",
 				LastName = "Doe"
-			});
+			}, TestContext.Current.CancellationToken);
 
 			Assert.Single(Events);
 			Assert.Equal("person.created", Events[0].Type);
@@ -95,7 +95,7 @@ namespace Deveel.Events {
                 LastName = "Doe"
             };
 
-            await Publisher.PublishEventAsync(personDeleted);
+            await Publisher.PublishEventAsync(personDeleted, TestContext.Current.CancellationToken);
 
             Assert.Single(Events);
             Assert.Equal("person.deleted", Events[0].Type);
@@ -126,7 +126,7 @@ namespace Deveel.Events {
                 Source = new Uri("https://api.svc.deveel.com/test-service"),
             };
 
-            await Publisher.PublishEventAsync(@event);
+            await Publisher.PublishEventAsync(@event,  TestContext.Current.CancellationToken);
 
             Assert.Single(Events);
             Assert.Equal(existingId, Events[0].Id);
@@ -142,7 +142,7 @@ namespace Deveel.Events {
                 Source = customSource,
             };
 
-            await Publisher.PublishEventAsync(@event);
+            await Publisher.PublishEventAsync(@event, TestContext.Current.CancellationToken);
 
             Assert.Single(Events);
             Assert.Equal(customSource, Events[0].Source);
@@ -159,7 +159,7 @@ namespace Deveel.Events {
                 Time = fixedTime,
             };
 
-            await Publisher.PublishEventAsync(@event);
+            await Publisher.PublishEventAsync(@event, TestContext.Current.CancellationToken);
 
             Assert.Single(Events);
             Assert.Equal(fixedTime, Events[0].Time);
@@ -173,7 +173,7 @@ namespace Deveel.Events {
                 Type = "test.event",
             };
 
-            await Publisher.PublishEventAsync(@event);
+            await Publisher.PublishEventAsync(@event,  TestContext.Current.CancellationToken);
 
             Assert.Single(Events);
             Assert.Equal(new Uri("https://api.svc.deveel.com/test-service"), Events[0].Source);
@@ -188,7 +188,7 @@ namespace Deveel.Events {
                 Source = new Uri("https://api.svc.deveel.com"),
             };
 
-            await Publisher.PublishEventAsync(@event);
+            await Publisher.PublishEventAsync(@event, TestContext.Current.CancellationToken);
 
             Assert.Single(Events);
             Assert.NotNull(Events[0].Time);
@@ -203,7 +203,7 @@ namespace Deveel.Events {
                 Source = new Uri("https://api.svc.deveel.com"),
             };
 
-            await Publisher.PublishEventAsync(@event);
+            await Publisher.PublishEventAsync(@event,  TestContext.Current.CancellationToken);
 
             Assert.Single(Events);
             Assert.NotNull(Events[0].Id);
@@ -230,7 +230,7 @@ namespace Deveel.Events {
             {
                 Type = "test.event",
                 Source = new Uri("https://api.example.com"),
-            });
+            }, TestContext.Current.CancellationToken);
 
             Assert.Single(publishedEvents);
             // Just verify the event was published successfully with all attribute types
@@ -254,7 +254,7 @@ namespace Deveel.Events {
             {
                 Type = "test.event",
                 Source = new Uri("https://api.example.com"),
-            });
+            },TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -275,7 +275,7 @@ namespace Deveel.Events {
                 {
                     Type = "test.event",
                     Source = new Uri("https://api.example.com"),
-                }));
+                }, TestContext.Current.CancellationToken));
         }
 
         [Fact]
@@ -296,7 +296,7 @@ namespace Deveel.Events {
             );
 
             // ThrowOnErrors = false by default, should swallow
-            await publisher.PublishAsync(typeof(PersonCreated), new PersonCreated { Id = "1" });
+            await publisher.PublishAsync(typeof(PersonCreated), new PersonCreated { Id = "1" }, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -317,7 +317,7 @@ namespace Deveel.Events {
             );
 
             await Assert.ThrowsAsync<EventPublishException>(() =>
-                publisher.PublishAsync(typeof(PersonCreated), new PersonCreated { Id = "1" }));
+                publisher.PublishAsync(typeof(PersonCreated), new PersonCreated { Id = "1" }, TestContext.Current.CancellationToken));
         }
 
         [Fact]
@@ -327,12 +327,12 @@ namespace Deveel.Events {
             services.AddEventPublisher(options =>
             {
                 options.ThrowOnErrors = false;
-            }).AddTestChannel(e => { });
+            }).AddTestChannel(_ => { });
 
             var publisher = services.BuildServiceProvider().GetRequiredService<EventPublisher>();
 
             // Should not throw
-            await publisher.PublishEventAsync(new BrokenFactory());
+            await publisher.PublishEventAsync(new BrokenFactory(), TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -342,12 +342,12 @@ namespace Deveel.Events {
             services.AddEventPublisher(options =>
             {
                 options.ThrowOnErrors = true;
-            }).AddTestChannel(e => { });
+            }).AddTestChannel(_ => { });
 
             var publisher = services.BuildServiceProvider().GetRequiredService<EventPublisher>();
 
             await Assert.ThrowsAsync<EventPublishException>(() =>
-                publisher.PublishEventAsync(new BrokenFactory()));
+                publisher.PublishEventAsync(new BrokenFactory(), TestContext.Current.CancellationToken));
         }
 
         [Fact]
@@ -358,7 +358,7 @@ namespace Deveel.Events {
                 Id = "generic-test",
                 FirstName = "Generic",
                 LastName = "Test"
-            });
+            }, TestContext.Current.CancellationToken);
 
             Assert.Single(Events);
             Assert.Equal("person.created", Events[0].Type);
@@ -368,7 +368,7 @@ namespace Deveel.Events {
         public async Task PublishEventFactory_NullFactory_Throws()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                Publisher.PublishEventAsync<PersonDeleted>(null!));
+                Publisher.PublishEventAsync<PersonDeleted>(null!, TestContext.Current.CancellationToken));
         }
 
         [Event("person.created", "https://example.com/events/person.created/1.0")]


### PR DESCRIPTION
This pull request introduces a default content type for event publishing, improving both the documentation and implementation to ensure consistent handling of event data content types. It also updates tests to use cancellation tokens, aligning with best practices for asynchronous operations.

**Default Content Type Handling:**

* Added `DefaultContentType` property to `EventPublisherOptions`, defaulting to `"application/cloudevents+json"`, and updated documentation to describe its usage when no content type is specified on an event. [[1]](diffhunk://#diff-266475971ead38490747421248a6a7ff171c0d14c296f3d58450cb8ed657f35aR47-R53) [[2]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bR37) [[3]](diffhunk://#diff-e87f3b77a874251d7c7b90f79197cc290370b12684d0f428202c5dc30aa08f7cL42-R42)
* Updated `EventAttribute.ContentType` documentation to clarify fallback behavior: publishing uses `DefaultContentType`, schema generation defaults to `"object"`.
* Modified `EventCreator` to use the event's `ContentType` if set, otherwise fallback to `PublisherOptions.DefaultContentType`, and throw if neither is set. This ensures all published events have a valid content type. [[1]](diffhunk://#diff-2eb3a1704f2cb010d9549cb8d962d192643af8be5b0297f068bc293ace18b51cR35-R41) [[2]](diffhunk://#diff-2eb3a1704f2cb010d9549cb8d962d192643af8be5b0297f068bc293ace18b51cL53-R64)

**Test Improvements:**

* Updated all test calls to `PublishEventAsync` and `PublishAsync` to include `TestContext.Current.CancellationToken`, improving test reliability and cancellation support. [[1]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL49-R49) [[2]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL68-R68) [[3]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL98-R98) [[4]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL129-R129) [[5]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL145-R145) [[6]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL162-R162) [[7]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL176-R176) [[8]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL191-R191) [[9]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL206-R206) [[10]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL233-R233) [[11]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL257-R257) [[12]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL278-R278) [[13]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL299-R299) [[14]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL320-R320) [[15]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL330-R335) [[16]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL345-R350) [[17]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL361-R361) [[18]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL371-R371)

**Other Minor Improvements:**

* Minor test lambda parameter renaming for clarity and consistency. [[1]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL330-R335) [[2]](diffhunk://#diff-bf7fac9419076e3adb088c1465a1d083a06151d427e6e7664cc069606280919fL345-R350)