### PR TITLE
Enhance error handling and validation for EventPublisherOptions

### DIFF
--- a/src/Deveel.Events.Publisher/Events/EventCreator.cs
+++ b/src/Deveel.Events.Publisher/Events/EventCreator.cs
@@ -50,7 +50,9 @@ namespace Deveel.Events
             } else if (!String.IsNullOrWhiteSpace(dataVersion))
             {
                 if (PublisherOptions.DataSchemaBaseUri == null)
-                    throw new InvalidOperationException("The base URI for the data schema is not set");
+                    throw new InvalidOperationException(
+                        $"The event type '{eventType}' uses [Event] DataVersion '{dataVersion}', but EventPublisherOptions.DataSchemaBaseUri is not configured. " +
+                        "Configure it via services.AddEventPublisher(options => options.DataSchemaBaseUri = new Uri(\"https://schemas.example.com/events\")).");
 
                 var schemaUriBuilder = new UriBuilder(PublisherOptions.DataSchemaBaseUri);
                 schemaUriBuilder.Path = $"{schemaUriBuilder.Path}/{eventType}/{dataVersion}";

--- a/src/Deveel.Events.Publisher/Events/EventPublisherBuilder.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublisherBuilder.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Deveel.Events {
     /// <summary>
@@ -23,7 +24,9 @@ namespace Deveel.Events {
         public IServiceCollection Services { get; }
 
 		private void AddDefaultServices() {
-			Services.AddOptions<EventPublisherOptions>();
+			Services.AddOptions<EventPublisherOptions>()
+				.ValidateOnStart();
+			Services.TryAddSingleton<IValidateOptions<EventPublisherOptions>>(_ => new EventPublisherOptionsValidator(Services));
 			Services.TryAddSingleton<EventPublisher>();
 			Services.TryAddSingleton<IEventIdGenerator>(EventGuidGenerator.Default);
 			Services.TryAddSingleton<IEventSystemTime>(EventSystemTime.Instance);

--- a/src/Deveel.Events.Publisher/Events/EventPublisherOptionsValidator.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublisherOptionsValidator.cs
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using System.Reflection;
+
+namespace Deveel.Events {
+    class EventPublisherOptionsValidator : IValidateOptions<EventPublisherOptions> {
+        private readonly IServiceCollection _services;
+
+        public EventPublisherOptionsValidator(IServiceCollection services) {
+            _services = services;
+        }
+
+        public ValidateOptionsResult Validate(string? name, EventPublisherOptions options) {
+            if (options.DataSchemaBaseUri != null)
+                return ValidateOptionsResult.Success;
+
+            var eventTypes = GetRegisteredEventTypesUsingDataVersion();
+            if (eventTypes.Count == 0)
+                return ValidateOptionsResult.Success;
+
+            var typeNames = String.Join(", ", eventTypes.Select(x => x.FullName ?? x.Name));
+            return ValidateOptionsResult.Fail(
+                $"EventPublisherOptions.DataSchemaBaseUri must be configured because the following registered event types use [Event] DataVersion: {typeNames}. "+
+                "Configure it via services.AddEventPublisher(options => options.DataSchemaBaseUri = new Uri(\"https://schemas.example.com/events\"));");
+        }
+
+        private IReadOnlyCollection<Type> GetRegisteredEventTypesUsingDataVersion() {
+            var eventTypes = new HashSet<Type>();
+
+            foreach (var descriptor in _services) {
+                AddIfVersionedEvent(eventTypes, descriptor.ServiceType);
+                AddIfVersionedEvent(eventTypes, descriptor.ImplementationType);
+
+                if (descriptor.ImplementationInstance != null)
+                    AddIfVersionedEvent(eventTypes, descriptor.ImplementationInstance.GetType());
+            }
+
+            return eventTypes;
+        }
+
+        private static void AddIfVersionedEvent(HashSet<Type> eventTypes, Type? type) {
+            if (type == null)
+                return;
+
+            var eventAttribute = type.GetCustomAttribute<EventAttribute>(false);
+            if (eventAttribute == null)
+                return;
+
+            if (eventAttribute.DataSchema != null || String.IsNullOrWhiteSpace(eventAttribute.DataVersion))
+                return;
+
+            eventTypes.Add(type);
+        }
+    }
+}
+

--- a/test/Deveel.Events.Publisher.XUnit/Events/EventCreatorTests.cs
+++ b/test/Deveel.Events.Publisher.XUnit/Events/EventCreatorTests.cs
@@ -95,8 +95,11 @@ namespace Deveel.Events
             services.AddEventPublisher();  // DataSchemaBaseUri not set
             var creator = services.BuildServiceProvider().GetRequiredService<IEventCreator>();
 
-            Assert.Throws<InvalidOperationException>(() =>
+            var ex = Assert.Throws<InvalidOperationException>(() =>
                 creator.CreateEventFromData(typeof(PersonCreatedByVersion), new PersonCreatedByVersion()));
+
+            Assert.Contains("EventPublisherOptions.DataSchemaBaseUri", ex.Message);
+            Assert.Contains("AddEventPublisher", ex.Message);
         }
 
         [Fact]

--- a/test/Deveel.Events.Publisher.XUnit/Events/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.XUnit/Events/ServiceRegistrationTests.cs
@@ -135,6 +135,39 @@ namespace Deveel.Events
             Assert.Empty(options.Value.Attributes);
         }
 
+        [Fact]
+        public static void AddEventPublisher_WithVersionedRegisteredEventType_WithoutDataSchemaBaseUri_FailsValidation()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<VersionedRegisteredEventData>();
+            services.AddEventPublisher();
+
+            var provider = services.BuildServiceProvider();
+
+            var ex = Assert.Throws<OptionsValidationException>(() =>
+                _ = provider.GetRequiredService<IOptions<EventPublisherOptions>>().Value);
+
+            Assert.Contains("EventPublisherOptions.DataSchemaBaseUri", ex.Message);
+            Assert.Contains(nameof(VersionedRegisteredEventData), ex.Message);
+        }
+
+        [Fact]
+        public static void AddEventPublisher_WithVersionedRegisteredEventType_AndDataSchemaBaseUri_PassesValidation()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<VersionedRegisteredEventData>();
+            services.AddEventPublisher(options =>
+            {
+                options.DataSchemaBaseUri = new Uri("https://schemas.example.com/events");
+            });
+
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<EventPublisherOptions>>();
+
+            Assert.NotNull(options.Value);
+            Assert.Equal(new Uri("https://schemas.example.com/events"), options.Value.DataSchemaBaseUri);
+        }
+
         private class CustomEventPublisher : EventPublisher
         {
             public CustomEventPublisher(
@@ -151,6 +184,11 @@ namespace Deveel.Events
         private class CustomSystemTime : IEventSystemTime
         {
             public DateTimeOffset UtcNow => new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        }
+
+        [Event("publisher.registration.versioned", "1.0")]
+        private class VersionedRegisteredEventData
+        {
         }
     }
 }


### PR DESCRIPTION
This pull request introduces validation to ensure that when event types with a `DataVersion` are registered, the `EventPublisherOptions.DataSchemaBaseUri` option must be configured. This helps prevent misconfiguration at startup and provides clearer error messages and guidance for setup. The changes include adding an options validator, updating service registration, improving exception messages, and adding new tests to verify the validation logic.

**Options Validation and Enforcement:**

* Added a new `EventPublisherOptionsValidator` class that implements `IValidateOptions<EventPublisherOptions>`. This validator checks for registered event types with a `DataVersion` and ensures `DataSchemaBaseUri` is set, failing validation with a detailed error message if not.
* Updated the `EventPublisherBuilder` to register the validator and enable options validation at startup using `.ValidateOnStart()`.

**Error Messaging Improvements:**

* Improved the exception message in `EventCreator.cs` to provide detailed guidance on how to configure `DataSchemaBaseUri` when missing.

**Testing Enhancements:**

* Added tests to verify that options validation fails if a versioned event type is registered without `DataSchemaBaseUri`, and passes when it is set. [[1]](diffhunk://#diff-059ba33d4b983d3ea0157b1246a9e207a49c193e73c86f0f78da3e373d2edf04R138-R170) [[2]](diffhunk://#diff-059ba33d4b983d3ea0157b1246a9e207a49c193e73c86f0f78da3e373d2edf04R188-R192)
* Updated existing tests to assert that the improved exception message contains relevant guidance.

**Dependency Updates:**

* Added missing `using Microsoft.Extensions.Options;` in `EventPublisherBuilder.cs` to support the new validation logic.…guration