### PR TITLE
Add named channel support and refactor publish options

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -27,6 +27,7 @@
 * [MassTransit](publishers/masstransit.md)
 * [Webhook](publishers/webhook.md)
 * [Typed Channels](publishers/typed-channels.md)
+* [Named Channels](publishers/named-channels.md)
 
 ## Event Schema
 

--- a/docs/concepts/event-publisher.md
+++ b/docs/concepts/event-publisher.md
@@ -135,6 +135,7 @@ PublishEventAsync(CloudEvent, options)
   │         → throws InvalidCloudEventException if any are missing
   │
   └─ 3. Dispatch (fan-out) ──────────────────────────────────────────────────
+          FilterChannelsByName(channels, options) → named-channel filter
           for each IEventPublishChannel:
             ResolveChannelOptions(channel, options) → per-channel options
             PublishEventAsync(channel, event, resolvedOptions)
@@ -191,17 +192,13 @@ catch (InvalidCloudEventException ex)
 
 ### Stage 3 — Dispatch
 
-The publisher iterates over every registered `IEventPublishChannel` in order:
+The publisher's dispatch stage has two steps before iterating channels:
 
-1. `ResolveChannelOptions` is called to extract the compatible `EventPublishOptions` entry 
-   for the current channel from the caller-supplied `options` argument 
-   (see [Per-call publish options](#per-call-publish-options)).
-2. `PublishEventAsync(IEventPublishChannel, CloudEvent, EventPublishOptions?)` forwards the 
-   call to `channel.PublishAsync`.
+1. **Name filtering** — `FilterChannelsByName` narrows the channel list when the caller-supplied `options` implement `INamedChannelFilter` with a non-empty `ChannelName`.  Only channels that implement `INamedEventPublishChannel` with a matching `Name` are kept; anonymous channels (those that do not implement `INamedEventPublishChannel`, or have a `null`/empty name) always pass through.  `CombinedPublishOptions` does not implement `INamedChannelFilter`; for combined options, name matching is done per bundled entry inside `ResolveChannelOptions`.
+2. For each remaining channel, `ResolveChannelOptions` is called to extract the compatible `EventPublishOptions` entry for the current channel from the caller-supplied `options` argument (see [Per-call publish options](#per-call-publish-options)).
+3. `PublishEventAsync(IEventPublishChannel, CloudEvent, EventPublishOptions?)` forwards the call to `channel.PublishAsync`.
 
-If a channel throws and `ThrowOnErrors` is `false` (the default), the error is logged and 
-delivery continues to the remaining channels.  When `ThrowOnErrors` is `true` the exception 
-is wrapped in `EventPublishException` and re-thrown, stopping fan-out.
+If a channel throws and `ThrowOnErrors` is `false` (the default), the error is logged and delivery continues to the remaining channels.  When `ThrowOnErrors` is `true` the exception is wrapped in `EventPublishException` and re-thrown, stopping fan-out.
 
 ---
 
@@ -267,6 +264,20 @@ var @event = new CloudEvent
 await publisher.PublishEventAsync(@event);
 ```
 
+### To a named channel
+
+When more than one channel of the same transport type is registered, identify the target by name using the `string channelName` convenience overloads:
+
+```csharp
+// Target a specific named channel by name — no channel-type knowledge needed.
+await publisher.PublishAsync(orderPlaced, channelName: "rabbit-orders");
+await publisher.PublishEventAsync(@event, channelName: "rabbit-notifications");
+```
+
+Channels declare their name through the `ChannelName` property on their options (which implement `INamedChannelFilter`).  Channels that have no name always receive every event regardless of any filter.
+
+See [Named Channels](../publishers/named-channels.md) for the full guide.
+
 ---
 
 ## Per-call publish options
@@ -292,7 +303,7 @@ await publisher.PublishEventAsync(@event, new RabbitMqPublishOptions
 To override a **typed** channel, pass the corresponding typed options class:
 
 ```csharp
-// Only RabbitMqEventPublishChannel<OrderPlaced> picks this up.
+// Only RabbitMqPublishChannel<OrderPlaced> picks this up.
 // The general RabbitMQ channel and all other channels use their defaults.
 await publisher.PublishEventAsync(@event, new RabbitMqPublishOptions<OrderPlaced>
 {
@@ -335,6 +346,8 @@ forwarding it to each channel:
 | A non-generic `XxxPublishOptions` instance | The override (if assignable to the channel's `TOptions`) | `null` → uses its defaults — general options are **not** forwarded to typed channels |
 | A generic `XxxPublishOptions<TEvent>` instance | `null` → typed options are **not** forwarded to general channels | The override if `TEvent` matches the channel; `null` otherwise |
 | `CombinedPublishOptions` | First non-typed bundled entry whose type is assignable to the channel's `TOptions`, or `null` | First bundled entry parameterised with this channel's `TEvent`, or `null` |
+| Any options with `ChannelName` set (implements `INamedChannelFilter`) | The override, **only if** the channel's `INamedEventPublishChannel.Name` matches (or the channel is anonymous) | As above, with the same name-match requirement |
+| `NamedChannelPublishOptions("my-channel")` | `null` — no type-specific override; only the name filter applies | `null` — only the name filter applies |
 
 The discriminator between "general" and "typed" options is the **runtime generic type 
 structure**: an options instance is considered *typed* when its actual type (or any type in 
@@ -375,6 +388,7 @@ override only the specific step they need to change.
 | `SetAttributes(CloudEvent)` | Enrichment | Inject tenant ID, correlation ID, or other context attributes |
 | `ValidateCloudEvent(CloudEvent)` | Validation | Add domain-specific attribute requirements |
 | `CreateEventFromData(Type, object?)` | Event creation | Customise how annotated data classes become `CloudEvent`s |
+| `FilterChannelsByName(IEnumerable<IEventPublishChannel>, EventPublishOptions?)` | Dispatch | Customise how named-channel filtering selects the target channel set |
 | `ResolveChannelOptions(IEventPublishChannel, EventPublishOptions?)` | Dispatch | Implement custom per-channel options matching logic |
 | `PublishEventAsync(IEventPublishChannel, CloudEvent, EventPublishOptions?, CancellationToken)` | Dispatch | Wrap individual channel calls (circuit-breaking, retries, metrics) |
 | `PublishEventAsync(CloudEvent, EventPublishOptions?, CancellationToken)` | Entry point | Intercept or pre-process every publish call before fan-out |
@@ -488,6 +502,7 @@ pipeline.  Typical cases:
 | Completely different fan-out strategy (e.g. priority queues, event sourcing) | Implement `IEventPublisher` directly |
 | Add custom enrichment / context stamping | **Extend `EventPublisher`**, override `SetAttributes` |
 | Stricter or relaxed validation | **Extend `EventPublisher`**, override `ValidateCloudEvent` |
+| Custom channel selection / name-based routing | **Extend `EventPublisher`**, override `FilterChannelsByName` |
 | Custom options matching per channel | **Extend `EventPublisher`**, override `ResolveChannelOptions` |
 | Retry / circuit-breaking around channel calls | **Extend `EventPublisher`**, override `PublishEventAsync(channel, …)` |
 
@@ -531,5 +546,7 @@ public class FrozenSystemTime : IEventSystemTime
 ## Related pages
 
 - [Publish Channels](publish-channels.md)
+- [Named Channels](../publishers/named-channels.md)
+- [Typed Channels](../publishers/typed-channels.md)
 - [Event Annotations](event-annotations.md)
 

--- a/docs/concepts/publish-channels.md
+++ b/docs/concepts/publish-channels.md
@@ -15,7 +15,7 @@ public interface IEventPublishChannel
 
 The `EventPublisher` resolves **all** registered `IEventPublishChannel` services and calls `PublishAsync` on each one in sequence for every outgoing event.
 
-The optional `options` parameter accepts any `EventPublishOptions` subclass and allows per-call delivery overrides.  All built-in channels extend `EventPublishChannelBase<TOptions>`, which performs a **property-level merge** of the per-call overrides with the channel-level defaults before delivery:
+The optional `options` parameter accepts any `EventPublishOptions` subclass and allows per-call delivery overrides.  All built-in channels extend `EventPublishChannel<TOptions>`, which performs a **property-level merge** of the per-call overrides with the channel-level defaults before delivery:
 
 - **Nullable reference-type properties** (`string?`, `Uri?`, `JsonSerializerOptions?`, …): a `null` value in the per-call options means *"leave this field at the channel default"*; a non-`null` value overrides it.
 - **Nullable value-type properties** (`bool?`, `TimeSpan?`, enum `?`, …): same rule — `null` inherits the channel default, any explicit value overrides it.
@@ -24,10 +24,27 @@ The optional `options` parameter accepts any `EventPublishOptions` subclass and 
 
 This design lets callers override only what they need — for example, changing the routing key or destination address for one delivery — without having to repeat every setting from the channel configuration.
 
+### `INamedEventPublishChannel`
+
+An optional interface that a channel implements to expose a **logical name**:
+
+```csharp
+public interface INamedEventPublishChannel : IEventPublishChannel
+{
+    string? Name { get; }
+}
+```
+
+Channels that do **not** implement `INamedEventPublishChannel` are treated as **anonymous** and always receive every event, regardless of any name filter supplied at publish time.
+
+`EventPublishChannel<TOptions>` implements `INamedEventPublishChannel` automatically: it reads `Name` from the channel-level options when those options implement `INamedChannelFilter` — you do not need to add anything to the channel class itself.
+
+See [Named Channels](../publishers/named-channels.md) for the full guide on registering and targeting named channel instances.
+
 ### `IEventPublishChannel<TEvent>`
 
-A generic marker interface for channels keyed against a specific **annotated event data class**.
-`EventPublisher` resolves `IEventPublishChannel<TEvent>` to find channels registered for a particular data class and routes the event exclusively to those channels instead of (or in addition to) the general-purpose ones.
+A generic marker interface for channels keyed against a specific **annotated event class**.
+`EventPublisher` resolves `IEventPublishChannel<TEvent>` to find channels registered for a particular event class and routes the event exclusively to those channels instead of (or in addition to) the general-purpose ones.
 
 ```csharp
 public interface IEventPublishChannel<TEvent> : IEventPublishChannel
@@ -36,7 +53,7 @@ public interface IEventPublishChannel<TEvent> : IEventPublishChannel
 }
 ```
 
-> ⚠️ The type argument `TEvent` must be the **event data class** (e.g. `OrderPlacedData`), not a channel options type.  Per-call delivery overrides are supplied as a typed `EventPublishOptions` subclass instance passed directly to `PublishAsync` — they do not require a separate typed channel registration.
+> ⚠️ The type argument `TEvent` must be the **event event class** (e.g. `OrderPlaced`), not a channel options type.  Per-call delivery overrides are supplied as a typed `EventPublishOptions` subclass instance passed directly to `PublishAsync` — they do not require a separate typed channel registration.
 
 ### `IBatchEventPublishChannel`
 
@@ -108,14 +125,14 @@ publisherBuilder.Services.AddSingleton<IEventPublishChannel, KafkaEventPublishCh
 
 ### Custom typed channel
 
-To restrict a channel to a single event data class, implement `IEventPublishChannel<TEvent>` and use `AddChannel<TChannel, TEvent>()`:
+To restrict a channel to a single event class, implement `IEventPublishChannel<TEvent>` and use `AddChannel<TChannel, TEvent>()`:
 
 ```csharp
-public class KafkaOrderChannel : IEventPublishChannel<OrderPlacedData>
+public class KafkaOrderChannel : IEventPublishChannel<OrderPlaced>
 {
     public async Task PublishAsync(CloudEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default)
     {
-        // ... send only OrderPlacedData events to Kafka
+        // ... send only OrderPlaced events to Kafka
     }
 }
 ```
@@ -123,10 +140,166 @@ public class KafkaOrderChannel : IEventPublishChannel<OrderPlacedData>
 ```csharp
 builder.Services
     .AddEventPublisher()
-    .AddChannel<KafkaOrderChannel, OrderPlacedData>();
+    .AddChannel<KafkaOrderChannel, OrderPlaced>();
 ```
 
-`AddChannel<TChannel, TEvent>()` registers the concrete type and exposes it as both `IEventPublishChannel` and `IEventPublishChannel<OrderPlacedData>`.
+`AddChannel<TChannel, TEvent>()` registers the concrete type and exposes it as both `IEventPublishChannel` and `IEventPublishChannel<OrderPlaced>`.
+
+### Custom named channel
+
+To participate in name-based routing, implement `INamedEventPublishChannel` alongside `IEventPublishChannel`:
+
+```csharp
+public class KafkaEventPublishChannel : IEventPublishChannel, INamedEventPublishChannel
+{
+    private readonly KafkaChannelOptions _options;
+
+    public KafkaEventPublishChannel(IOptions<KafkaChannelOptions> options)
+        => _options = options.Value;
+
+    public string? Name => _options.ChannelName;
+
+    public async Task PublishAsync(CloudEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        // ... deliver via Confluent.Kafka
+    }
+}
+```
+
+Channels that extend `EventPublishChannel<TOptions>` with options that implement `INamedChannelFilter` receive `INamedEventPublishChannel` support automatically — no extra code needed.
+
+## Related pages
+
+- [Named Channels](../publishers/named-channels.md)
+- [Typed Channels](../publishers/typed-channels.md)
+- [Azure Service Bus](../publishers/azure-service-bus.md)
+- [RabbitMQ](../publishers/rabbitmq.md)
+- [MassTransit](../publishers/masstransit.md)
+- [Webhook](../publishers/webhook.md)
+- [Test Publisher](../testing/README.md)
+
+
+```csharp
+public interface IEventPublishChannel
+{
+    Task PublishAsync(CloudEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default);
+}
+```
+
+The `EventPublisher` resolves **all** registered `IEventPublishChannel` services and calls `PublishAsync` on each one in sequence for every outgoing event.
+
+The optional `options` parameter accepts any `EventPublishOptions` subclass and allows per-call delivery overrides.  All built-in channels extend `EventPublishChannel<TOptions>`, which performs a **property-level merge** of the per-call overrides with the channel-level defaults before delivery:
+
+- **Nullable reference-type properties** (`string?`, `Uri?`, `JsonSerializerOptions?`, …): a `null` value in the per-call options means *"leave this field at the channel default"*; a non-`null` value overrides it.
+- **Nullable value-type properties** (`bool?`, `TimeSpan?`, enum `?`, …): same rule — `null` inherits the channel default, any explicit value overrides it.
+- **Non-nullable string properties** (`ConnectionString`, `QueueName` in the Service Bus channel): an empty or whitespace value falls back to the channel default; a non-empty value overrides it.
+- **Channel-structural fields** that are not meaningful to override per-call (e.g. `SignatureHeaderName`, `RetryableStatusCodes` in the Webhook channel) are always taken from the channel-level defaults and ignored in per-call overrides.
+
+This design lets callers override only what they need — for example, changing the routing key or destination address for one delivery — without having to repeat every setting from the channel configuration.
+
+### `IEventPublishChannel<TEvent>`
+
+A generic marker interface for channels keyed against a specific **annotated event class**.
+`EventPublisher` resolves `IEventPublishChannel<TEvent>` to find channels registered for a particular event class and routes the event exclusively to those channels instead of (or in addition to) the general-purpose ones.
+
+```csharp
+public interface IEventPublishChannel<TEvent> : IEventPublishChannel
+    where TEvent : class
+{
+}
+```
+
+> ⚠️ The type argument `TEvent` must be the **event class** (e.g. `OrderPlaced`), not a channel options type.  Per-call delivery overrides are supplied as a typed `EventPublishOptions` subclass instance passed directly to `PublishAsync` — they do not require a separate typed channel registration.
+
+### `IBatchEventPublishChannel`
+
+Extends `IEventPublishChannel` to support publishing multiple events in a single call:
+
+```csharp
+public interface IBatchEventPublishChannel : IEventPublishChannel
+{
+    Task PublishBatchAsync(
+        IReadOnlyList<CloudEvent> events,
+        EventPublishOptions? options = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+The Webhook channel implements both `IEventPublishChannel` and `IBatchEventPublishChannel`.
+
+## Built-in channels
+
+
+| Channel | Package | Registration method | Typed overload |
+|---------|---------|---------------------|----------------|
+| Azure Service Bus | `Deveel.Events.Publisher.AzureServiceBus` | `.AddServiceBus(...)` | `.AddServiceBus<TEvent>(...)` |
+| RabbitMQ | `Deveel.Events.Publisher.RabbitMq` | `.AddRabbitMq(...)` | `.AddRabbitMq<TEvent>(...)` |
+| MassTransit | `Deveel.Events.Publisher.MassTransit` | `.AddMassTransit(...)` | `.AddMassTransit<TEvent>(...)` |
+| Webhook (HTTP) | `Deveel.Events.Publisher.Webhook` | `.AddWebhooks(...)` | `.AddWebhooks<TEvent>(...)` |
+| Test (in-memory) | `Deveel.Events.TestPublisher` | `.AddTestChannel(...)` | — |
+
+Multiple channels can be registered simultaneously — the publisher will deliver to all of them.  When a typed channel exists for `TEvent`, **only typed channels** receive that event.
+
+## Implementing a custom channel
+
+To create your own channel, implement `IEventPublishChannel` and register it in DI:
+
+```csharp
+using CloudNative.CloudEvents;
+using Deveel.Events;
+
+public class KafkaEventPublishChannel : IEventPublishChannel
+{
+    private readonly KafkaProducerOptions _options;
+
+    public KafkaEventPublishChannel(IOptions<KafkaProducerOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public async Task PublishAsync(CloudEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        // ... serialise and send via Confluent.Kafka
+    }
+}
+```
+
+Register it with the builder's `AddChannel<TChannel>()` helper (which calls `TryAddSingleton` for the concrete type and `AddSingleton<IEventPublishChannel, TChannel>()`):
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .AddChannel<KafkaEventPublishChannel>();
+```
+
+Or register it directly on the `IServiceCollection`:
+
+```csharp
+var publisherBuilder = builder.Services.AddEventPublisher();
+publisherBuilder.Services.AddSingleton<IEventPublishChannel, KafkaEventPublishChannel>();
+```
+
+### Custom typed channel
+
+To restrict a channel to a single event class, implement `IEventPublishChannel<TEvent>` and use `AddChannel<TChannel, TEvent>()`:
+
+```csharp
+public class KafkaOrderChannel : IEventPublishChannel<OrderPlaced>
+{
+    public async Task PublishAsync(CloudEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        // ... send only OrderPlaced events to Kafka
+    }
+}
+```
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .AddChannel<KafkaOrderChannel, OrderPlaced>();
+```
+
+`AddChannel<TChannel, TEvent>()` registers the concrete type and exposes it as both `IEventPublishChannel` and `IEventPublishChannel<OrderPlaced>`.
 
 ## Related pages
 

--- a/docs/publishers/README.md
+++ b/docs/publishers/README.md
@@ -31,6 +31,22 @@ builder.Services
     });
 ```
 
+## Named channels
+
+When two or more channels of the same transport type are registered simultaneously, assign each a **logical name** via the `ChannelName` property on its options.  At publish time, target the right channel by name using the convenience extension methods or by setting `ChannelName` on the per-call options:
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .AddRabbitMq(opts => { opts.ChannelName = "rabbit-orders"; opts.ExchangeName = "orders"; })
+    .AddRabbitMq(opts => { opts.ChannelName = "rabbit-notifications"; opts.ExchangeName = "notifications"; });
+
+// Publish only to the "rabbit-orders" channel
+await publisher.PublishAsync(orderPlaced, channelName: "rabbit-orders");
+```
+
+See [Named Channels](named-channels.md) for the full guide.
+
 ## Typed channels
 
 Every built-in channel supports a **typed** registration variant (`AddRabbitMq<TEvent>()`, `AddServiceBus<TEvent>()`, `AddMassTransit<TEvent>()`, `AddWebhooks<TEvent>()`) that routes **only** events of the specified data class to that channel.  Typed channels also support a two-level options hierarchy — a base set of defaults merged with per-event-type overrides — so you can share common settings and specialise only what differs.

--- a/docs/publishers/azure-service-bus.md
+++ b/docs/publishers/azure-service-bus.md
@@ -56,7 +56,7 @@ builder.Services
 
 ## Typed channel
 
-Use `AddServiceBus<TEvent>()` to register a channel that receives **only** events whose data class is `TEvent`.  At construction time the typed channel (`ServiceBusEventPublishChannel<TEvent>`) merges the general `ServiceBusPublishOptions` with the type-specific `ServiceBusPublishOptions<TEvent>`: non-empty typed values win; empty or `null` values fall back to the base defaults.
+Use `AddServiceBus<TEvent>()` to register a channel that receives **only** events whose data class is `TEvent`.  At construction time the typed channel (`ServiceBusPublishChannel<TEvent>`) merges the general `ServiceBusPublishOptions` with the type-specific `ServiceBusPublishOptions<TEvent>`: non-empty typed values win; empty or `null` values fall back to the base defaults.
 
 > **Note:** `ServiceBusPublishOptions<TEvent>` re-declares `ConnectionString` and `QueueName` as nullable (`string?`) so that leaving them `null` is the unambiguous signal to inherit from the base options.  The required, non-nullable constraint from the base class is enforced only after merging.
 
@@ -115,7 +115,7 @@ Pass a `ServiceBusPublishOptions` instance as the second argument to `PublishAsy
 
 ```csharp
 // Resolve the concrete channel directly from DI.
-var channel = serviceProvider.GetRequiredService<ServiceBusEventPublishChannel>();
+var channel = serviceProvider.GetRequiredService<ServiceBusPublishChannel>();
 
 // Send this particular event to a different queue,
 // while inheriting ConnectionString and ClientOptions from the channel defaults.

--- a/docs/publishers/masstransit.md
+++ b/docs/publishers/masstransit.md
@@ -69,14 +69,14 @@ builder.Services
 
 ## How it works
 
-1. The `MassTransitEventPublishChannel` wraps a `CloudEvent` in a `CloudEventMessage` — an `ICloudEventMessage` implementation that MassTransit can serialise.
+1. The `MassTransitPublishChannel` wraps a `CloudEvent` in a `CloudEventMessage` — an `ICloudEventMessage` implementation that MassTransit can serialise.
 2. If `DestinationAddress` is set, the message is sent to that endpoint via `ISendEndpointProvider.GetSendEndpoint`.
 3. Otherwise, the message is published via `IPublishEndpoint.Publish`, allowing MassTransit's topology to route it.
 4. When `MapAttributesToHeaders` is `true` (or `null`, which defaults to `true`), CloudEvent attributes are written to the outgoing message headers so consumers can inspect them without deserialising the body.
 
 ## Typed channel
 
-Use `AddMassTransit<TEvent>()` to register a channel that receives **only** events whose data class is `TEvent`.  At construction time the typed channel (`MassTransitEventPublishChannel<TEvent>`) merges the general `MassTransitPublishOptions` with the type-specific `MassTransitPublishOptions<TEvent>`: non-`null` typed values win; `null` values fall back to the base defaults.
+Use `AddMassTransit<TEvent>()` to register a channel that receives **only** events whose data class is `TEvent`.  At construction time the typed channel (`MassTransitPublishChannel<TEvent>`) merges the general `MassTransitPublishOptions` with the type-specific `MassTransitPublishOptions<TEvent>`: non-`null` typed values win; `null` values fall back to the base defaults.
 
 ```csharp
 builder.Services
@@ -124,7 +124,7 @@ Pass a `MassTransitPublishOptions` instance as the second argument to `PublishAs
 
 ```csharp
 // Resolve the concrete channel directly from DI.
-var channel = serviceProvider.GetRequiredService<MassTransitEventPublishChannel>();
+var channel = serviceProvider.GetRequiredService<MassTransitPublishChannel>();
 
 // Send this event directly to a specific queue,
 // while still inheriting MapAttributesToHeaders from the channel default.

--- a/docs/publishers/named-channels.md
+++ b/docs/publishers/named-channels.md
@@ -1,0 +1,235 @@
+# Named Channels
+
+When multiple channels of the **same transport type** are registered simultaneously — for example two RabbitMQ channels pointing at different brokers, or two Webhook channels delivering to different partners — you need a way to target individual channel instances at publish time without knowing their concrete type.
+
+**Named channels** give each registered channel a logical string name.  You can then address that channel by name in per-call options or through convenience extension methods, independently of the channel type or the number of other channels registered for the same transport.
+
+---
+
+## How naming works
+
+### `INamedChannelFilter` — setting a name on options
+
+The `INamedChannelFilter` interface is implemented by any `EventPublishOptions` subclass that wants to participate in name-based routing:
+
+```csharp
+public interface INamedChannelFilter
+{
+    string? ChannelName { get; set; }
+}
+```
+
+When set on **channel-level options** at startup, `ChannelName` declares the channel's own logical identity.  When set on **per-call options**, it acts as a filter — only channels whose name matches will receive the event.
+
+All built-in options classes (`RabbitMqPublishOptions`, `ServiceBusPublishOptions`, `MassTransitPublishOptions`, `WebhookPublishOptions`) implement `INamedChannelFilter`.
+
+### `INamedEventPublishChannel` — exposing a name on channels
+
+Channels opt into naming by implementing `INamedEventPublishChannel`:
+
+```csharp
+public interface INamedEventPublishChannel : IEventPublishChannel
+{
+    string? Name { get; }
+}
+```
+
+Channels that **do not** implement this interface are treated as **anonymous** — they always receive every event regardless of any `ChannelName` filter.
+
+`EventPublishChannel<TOptions>` implements `INamedEventPublishChannel` automatically: it reads `Name` from the channel-level options when those options implement `INamedChannelFilter`.  You do not need to set anything extra on the channel class itself.
+
+---
+
+## Declaring a named channel at startup
+
+Set `ChannelName` in the channel's options during registration:
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    // First RabbitMQ channel — handles order events
+    .AddRabbitMq(opts =>
+    {
+        opts.ChannelName      = "rabbit-orders";
+        opts.ConnectionString = "amqp://guest:guest@broker1:5672";
+        opts.ExchangeName     = "orders";
+    })
+    // Second RabbitMQ channel — handles notification events
+    .AddRabbitMq(opts =>
+    {
+        opts.ChannelName      = "rabbit-notifications";
+        opts.ConnectionString = "amqp://guest:guest@broker2:5672";
+        opts.ExchangeName     = "notifications";
+    });
+```
+
+Both channels are registered as `IEventPublishChannel`.  At publish time the publisher checks each channel's `INamedEventPublishChannel.Name` and routes accordingly.
+
+From configuration:
+
+```json
+{
+  "Events": {
+    "RabbitMq": {
+      "Orders": {
+        "ChannelName": "rabbit-orders",
+        "ConnectionString": "amqp://guest:guest@broker1:5672",
+        "ExchangeName": "orders"
+      },
+      "Notifications": {
+        "ChannelName": "rabbit-notifications",
+        "ConnectionString": "amqp://guest:guest@broker2:5672",
+        "ExchangeName": "notifications"
+      }
+    }
+  }
+}
+```
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .AddRabbitMq("Events:RabbitMq:Orders")
+    .AddRabbitMq("Events:RabbitMq:Notifications");
+```
+
+---
+
+## Publishing to a named channel
+
+### Convenience extension methods
+
+The simplest approach — use the `string channelName` overloads on `IEventPublisher`:
+
+```csharp
+// Publish an annotated data object to a specific named channel
+await publisher.PublishAsync(orderPlaced, channelName: "rabbit-orders");
+
+// Publish a pre-built CloudEvent to a specific named channel
+await publisher.PublishEventAsync(@event, channelName: "rabbit-notifications");
+```
+
+These are extension methods on `IEventPublisher` and wrap the name in a `NamedChannelPublishOptions` internally, so no channel-specific knowledge is needed at the call site.
+
+### Per-call options with `ChannelName`
+
+To target a named channel **and** supply per-call overrides at the same time, set `ChannelName` directly on the concrete options instance:
+
+```csharp
+await publisher.PublishEventAsync(@event, new RabbitMqPublishOptions
+{
+    ChannelName  = "rabbit-orders",
+    RoutingKey   = "order.priority",
+});
+```
+
+The publisher first filters the channel list to those matching `"rabbit-orders"`, then forwards the full options object to the matching channel.
+
+### `NamedChannelPublishOptions`
+
+When you only need to target a channel by name without providing any transport-specific overrides, use `NamedChannelPublishOptions` directly:
+
+```csharp
+await publisher.PublishEventAsync(@event, new NamedChannelPublishOptions("rabbit-orders"));
+
+// Equivalent to the shorthand extension:
+await publisher.PublishEventAsync(@event, "rabbit-orders");
+```
+
+---
+
+## Filtering rules
+
+| Channel implements `INamedEventPublishChannel`? | Channel `Name` | Filter `ChannelName` in options | Result |
+|---|---|---|---|
+| No (anonymous) | — | any | **Receives the event** |
+| Yes | `null` or empty | any | **Receives the event** (treated as anonymous) |
+| Yes | `"rabbit-orders"` | `null` or absent | **Receives the event** (no filter) |
+| Yes | `"rabbit-orders"` | `"rabbit-orders"` | **Receives the event** ✓ |
+| Yes | `"rabbit-orders"` | `"rabbit-notifications"` | **Skipped** |
+
+> **No-match is a silent no-op.**  If the name filter matches no registered channel the event is simply not delivered (no exception is thrown).  Enable structured logging and set the log level to `Debug` or `Trace` to diagnose routing issues.
+
+---
+
+## Named channels with `CombinedPublishOptions`
+
+`CombinedPublishOptions` does **not** implement `INamedChannelFilter` — setting `ChannelName` on the combined wrapper itself would create ambiguity about which bundled entries it applies to.
+
+Instead, set `ChannelName` on **each individual bundled entry**.  The publisher uses it during per-entry resolution to match the entry to the correct named channel:
+
+```csharp
+var overrides = EventPublishOptions.Combine(
+    // → targets the "rabbit-orders" channel only
+    new RabbitMqPublishOptions
+    {
+        ChannelName  = "rabbit-orders",
+        RoutingKey   = "order.placed",
+    },
+    // → targets the "rabbit-notifications" channel only
+    new RabbitMqPublishOptions
+    {
+        ChannelName  = "rabbit-notifications",
+        RoutingKey   = "notification.sent",
+    });
+
+await publisher.PublishEventAsync(@event, overrides);
+```
+
+Each bundled entry is matched independently: type-assignability **and** name must both agree for an entry to be forwarded to a channel.
+
+---
+
+## Named test channels
+
+When testing code that uses named channels, pass the same name to `AddTestChannel`:
+
+```csharp
+var ordersEvents       = new List<CloudEvent>();
+var notificationEvents = new List<CloudEvent>();
+
+services.AddEventPublisher()
+        .AddTestChannel(@ev => ordersEvents.Add(@ev),       channelName: "rabbit-orders")
+        .AddTestChannel(@ev => notificationEvents.Add(@ev), channelName: "rabbit-notifications");
+```
+
+Each test channel will only fire for events whose per-call options carry the matching `ChannelName`.
+
+---
+
+## Implementing a custom named channel
+
+Any channel can participate in name-based routing by implementing `INamedEventPublishChannel`:
+
+```csharp
+public class KafkaEventPublishChannel : IEventPublishChannel, INamedEventPublishChannel
+{
+    private readonly KafkaChannelOptions _options;
+
+    public KafkaEventPublishChannel(IOptions<KafkaChannelOptions> options)
+        => _options = options.Value;
+
+    // Expose the name from channel-level options
+    public string? Name => _options.ChannelName;
+
+    public async Task PublishAsync(
+        CloudEvent @event,
+        EventPublishOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        // ... deliver via Confluent.Kafka
+    }
+}
+```
+
+Channels that extend `EventPublishChannel<TOptions>` get `INamedEventPublishChannel` for free as long as the options class implements `INamedChannelFilter`.
+
+---
+
+## Related pages
+
+- [Publish Channels](../concepts/publish-channels.md)
+- [Event Publisher](../concepts/event-publisher.md)
+- [Typed Channels](typed-channels.md)
+- [Test Publisher](../testing/README.md)
+

--- a/docs/publishers/rabbitmq.md
+++ b/docs/publishers/rabbitmq.md
@@ -74,7 +74,7 @@ Pass a `RabbitMqPublishOptions` instance as the second argument to `PublishAsync
 
 ```csharp
 // Resolve the concrete channel directly from DI.
-var channel = serviceProvider.GetRequiredService<RabbitMqEventPublishChannel>();
+var channel = serviceProvider.GetRequiredService<RabbitMqPublishChannel>();
 
 // Override only the routing key and make this one message non-persistent.
 // Everything else (ConnectionString, ExchangeName, PublisherConfirms, …)
@@ -88,7 +88,7 @@ await channel.PublishAsync(@event, new RabbitMqPublishOptions
 
 ## Typed channel
 
-Use `AddRabbitMq<TEvent>()` to register a channel that receives **only** events whose data class is `TEvent`.  The typed channel subclass (`RabbitMqEventPublishChannel<TEvent>`) merges the general `RabbitMqPublishOptions` with the type-specific `RabbitMqPublishOptions<TEvent>` at construction time: non-`null` typed values win; `null` values fall back to the base defaults.
+Use `AddRabbitMq<TEvent>()` to register a channel that receives **only** events whose data class is `TEvent`.  The typed channel subclass (`RabbitMqPublishChannel<TEvent>`) merges the general `RabbitMqPublishOptions` with the type-specific `RabbitMqPublishOptions<TEvent>` at construction time: non-`null` typed values win; `null` values fall back to the base defaults.
 
 ```csharp
 builder.Services

--- a/docs/publishers/webhook.md
+++ b/docs/publishers/webhook.md
@@ -83,7 +83,7 @@ Channel-structural settings (always taken from the channel-level defaults; ignor
 
 ## Typed channel
 
-Use `AddWebhooks<TEvent>()` to register a channel that receives **only** events whose data class is `TEvent`.  At construction time the typed channel (`WebhookEventPublishChannel<TEvent>`) merges the general `WebhookPublishOptions` with the type-specific `WebhookPublishOptions<TEvent>`: non-`null` typed values win; `null` values fall back to the base defaults.  `AdditionalHeaders` are merged at the dictionary level — typed entries win on key collision.  Channel-structural properties (`SignatureHeaderName`, `DeliveryIdHeaderName`, `RetryableStatusCodes`, …) are **always** taken from the base options and cannot be overridden per event type.
+Use `AddWebhooks<TEvent>()` to register a channel that receives **only** events whose data class is `TEvent`.  At construction time the typed channel (`WebhookPublishChannel<TEvent>`) merges the general `WebhookPublishOptions` with the type-specific `WebhookPublishOptions<TEvent>`: non-`null` typed values win; `null` values fall back to the base defaults.  `AdditionalHeaders` are merged at the dictionary level — typed entries win on key collision.  Channel-structural properties (`SignatureHeaderName`, `DeliveryIdHeaderName`, `RetryableStatusCodes`, …) are **always** taken from the base options and cannot be overridden per event type.
 
 ```csharp
 builder.Services
@@ -162,7 +162,7 @@ Pass a `WebhookPublishOptions` instance as the second argument to `PublishAsync`
 using Deveel.Events;
 
 // Resolve the concrete channel directly from DI.
-var webhookChannel = serviceProvider.GetRequiredService<WebhookEventPublishChannel>();
+var webhookChannel = serviceProvider.GetRequiredService<WebhookPublishChannel>();
 
 // Override endpoint and secret for this delivery only;
 // everything else (MaxRetryCount, SignatureAlgorithm, …) is inherited.
@@ -177,7 +177,7 @@ await webhookChannel.PublishAsync(@event, new WebhookPublishOptions
 You can also supply overrides through the non-generic `IEventPublishChannel` interface — casting the options to `EventPublishOptions` works because `WebhookPublishOptions` inherits from it:
 
 ```csharp
-IEventPublishChannel channel = serviceProvider.GetRequiredService<WebhookEventPublishChannel>();
+IEventPublishChannel channel = serviceProvider.GetRequiredService<WebhookPublishChannel>();
 await channel.PublishAsync(@event, new WebhookPublishOptions { EndpointUrl = "https://..." });
 ```
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -100,6 +100,21 @@ public class OrderServiceTests
 }
 ```
 
+## Named test channels
+
+When the code under test publishes to a **named channel**, register the test channel with the same name by passing the optional `channelName` parameter:
+
+```csharp
+var ordersEvents       = new List<CloudEvent>();
+var notificationEvents = new List<CloudEvent>();
+
+services.AddEventPublisher()
+        .AddTestChannel(@ev => ordersEvents.Add(@ev),       channelName: "rabbit-orders")
+        .AddTestChannel(@ev => notificationEvents.Add(@ev), channelName: "rabbit-notifications");
+```
+
+Each named test channel fires only for events whose per-call options carry the matching `ChannelName`.  A test channel registered without a name (or with `channelName: null`) is treated as anonymous and receives every event, just like any unnamed production channel.
+
 ## `IEventPublishCallback`
 
 ```csharp

--- a/src/Deveel.Events.Publisher.AzureServiceBus/Events/EventPublisherBuilderExtensions.cs
+++ b/src/Deveel.Events.Publisher.AzureServiceBus/Events/EventPublisherBuilderExtensions.cs
@@ -23,9 +23,9 @@ namespace Deveel.Events {
             builder.AddServiceBusInfrastructure();
             // Register the concrete channel once under its own type so callers can resolve it
             // directly and supply per-call option overrides.
-            builder.Services.TryAddSingleton<ServiceBusEventPublishChannel>();
+            builder.Services.TryAddSingleton<ServiceBusPublishChannel>();
             // Expose it as IEventPublishChannel (type-based so ImplementationType is preserved).
-			builder.Services.AddSingleton<IEventPublishChannel, ServiceBusEventPublishChannel>();
+			builder.Services.AddSingleton<IEventPublishChannel, ServiceBusPublishChannel>();
 			return builder;
 		}
 
@@ -107,7 +107,7 @@ namespace Deveel.Events {
                 .BindConfiguration(sectionPath)
                 .PostConfigure<IOptions<EventPublisherOptions>>(ConfigureIdentifierTyped<TEvent>);
 
-            return builder.AddChannel<ServiceBusEventPublishChannel<TEvent>, TEvent>();
+            return builder.AddChannel<ServiceBusPublishChannel<TEvent>, TEvent>();
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Deveel.Events {
                 .Configure(configure)
                 .PostConfigure<IOptions<EventPublisherOptions>>(ConfigureIdentifierTyped<TEvent>);
 
-            return builder.AddChannel<ServiceBusEventPublishChannel<TEvent>, TEvent>();
+            return builder.AddChannel<ServiceBusPublishChannel<TEvent>, TEvent>();
         }
 
 		private static void ConfigureIdentifier(ServiceBusPublishOptions channelOptions, IOptions<EventPublisherOptions> publisherOptions) { 

--- a/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishChannel.cs
+++ b/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishChannel.cs
@@ -17,7 +17,7 @@ namespace Deveel.Events {
     /// <summary>
     /// A channel that publishes events to an Azure Service Bus queue.
     /// </summary>
-    public class ServiceBusPublishChannel :
+    class ServiceBusPublishChannel :
         EventPublishChannel<ServiceBusPublishOptions>,
         IAsyncDisposable, IDisposable {
 		private ServiceBusSender? sender;

--- a/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishChannel.cs
+++ b/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishChannel.cs
@@ -17,8 +17,8 @@ namespace Deveel.Events {
     /// <summary>
     /// A channel that publishes events to an Azure Service Bus queue.
     /// </summary>
-    public class ServiceBusEventPublishChannel :
-        EventPublishChannelBase<ServiceBusPublishOptions>,
+    public class ServiceBusPublishChannel :
+        EventPublishChannel<ServiceBusPublishOptions>,
         IAsyncDisposable, IDisposable {
 		private ServiceBusSender? sender;
 		private ServiceBusClient? client;
@@ -48,12 +48,12 @@ namespace Deveel.Events {
         /// <param name="logger">
         /// A logger to record the operations of the channel.
         /// </param>
-        public ServiceBusEventPublishChannel(
+        public ServiceBusPublishChannel(
 			IOptions<ServiceBusPublishOptions> options,
 			IServiceBusClientFactory clientFactory,
 			ServiceBusMessageFactory messageCreator,
 			IEnumerable<IValidateOptions<ServiceBusPublishOptions>>? validators = null,
-			ILogger<ServiceBusEventPublishChannel>? logger = null)
+			ILogger<ServiceBusPublishChannel>? logger = null)
 			: base(options.Value, validators) {
 
 			var clientOptions = options.Value.ClientOptions ?? new ServiceBusClientOptions();
@@ -62,12 +62,12 @@ namespace Deveel.Events {
 
 			sender = client.CreateSender(options.Value.QueueName);
 			this.messageCreator = messageCreator;
-			this.logger = logger ?? NullLogger<ServiceBusEventPublishChannel>.Instance;
+			this.logger = logger ?? NullLogger<ServiceBusPublishChannel>.Instance;
 		}
 
 		private void ThrowIfDisposed() {
 			if (disposed)
-				throw new ObjectDisposedException(nameof(ServiceBusEventPublishChannel));
+				throw new ObjectDisposedException(nameof(ServiceBusPublishChannel));
 		}
 
         /// <inheritdoc/>

--- a/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishChannel`1.cs
+++ b/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishChannel`1.cs
@@ -11,7 +11,7 @@ using Azure.Messaging.ServiceBus;
 namespace Deveel.Events
 {
     /// <summary>
-    /// A <see cref="ServiceBusEventPublishChannel"/> subclass that also implements
+    /// A <see cref="ServiceBusPublishChannel"/> subclass that also implements
     /// <see cref="IEventPublishChannel{TEvent}"/>, so the <see cref="EventPublisher"/>
     /// routes events of type <typeparamref name="TEvent"/> exclusively to this channel.
     /// </summary>
@@ -24,8 +24,8 @@ namespace Deveel.Events
     /// <typeparam name="TEvent">
     /// The event data class this channel is keyed against.
     /// </typeparam>
-    class ServiceBusEventPublishChannel<TEvent> :
-        ServiceBusEventPublishChannel,
+    class ServiceBusPublishChannel<TEvent> :
+        ServiceBusPublishChannel,
         IEventPublishChannel<TEvent>
         where TEvent : class
     {
@@ -47,13 +47,13 @@ namespace Deveel.Events
         /// <param name="messageCreator">Factory that converts a CloudEvent into a Service Bus message.</param>
         /// <param name="validators">Optional DI-registered options validators.</param>
         /// <param name="logger">Optional logger; falls back to NullLogger when <c>null</c>.</param>
-        public ServiceBusEventPublishChannel(
+        public ServiceBusPublishChannel(
             IOptions<ServiceBusPublishOptions<TEvent>> typedOptions,
             IOptions<ServiceBusPublishOptions> baseOptions,
             IServiceBusClientFactory clientFactory,
             ServiceBusMessageFactory messageCreator,
             IEnumerable<IValidateOptions<ServiceBusPublishOptions>>? validators = null,
-            ILogger<ServiceBusEventPublishChannel>? logger = null)
+            ILogger<ServiceBusPublishChannel>? logger = null)
             : base(
                 Options.Create(ServiceBusPublishOptions<TEvent>.Merge(baseOptions.Value, typedOptions.Value)),
                 clientFactory,

--- a/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishOptions.cs
@@ -12,10 +12,7 @@ namespace Deveel.Events {
     /// The options for a channel that publishes events 
     /// to an Azure Service Bus.
     /// </summary>
-    public class ServiceBusPublishOptions : EventPublishOptions, INamedChannelFilter {
-        /// <inheritdoc/>
-        public string? ChannelName { get; set; }
-
+    public class ServiceBusPublishOptions : NamedChannelPublishOptions, INamedChannelFilter {
         /// <summary>
         /// Gets or sets the connection string to the Azure Service Bus
         /// instance that is used to publish the events.

--- a/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishOptions.cs
@@ -12,7 +12,10 @@ namespace Deveel.Events {
     /// The options for a channel that publishes events 
     /// to an Azure Service Bus.
     /// </summary>
-    public class ServiceBusPublishOptions : EventPublishOptions {
+    public class ServiceBusPublishOptions : EventPublishOptions, INamedChannelFilter {
+        /// <inheritdoc/>
+        public string? ChannelName { get; set; }
+
         /// <summary>
         /// Gets or sets the connection string to the Azure Service Bus
         /// instance that is used to publish the events.

--- a/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishOptions`1.cs
+++ b/src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishOptions`1.cs
@@ -8,7 +8,7 @@ using Azure.Messaging.ServiceBus;
 namespace Deveel.Events
 {
     /// <summary>
-    /// Type-specific publish options for a <see cref="ServiceBusEventPublishChannel{TEvent}"/>
+    /// Type-specific publish options for a <see cref="ServiceBusPublishChannel{TEvent}"/>
     /// that routes events of type <typeparamref name="TEvent"/> to an Azure Service Bus queue.
     /// </summary>
     /// <remarks>

--- a/src/Deveel.Events.Publisher.MassTransit/Events/EventPublisherBuilderExtensions.cs
+++ b/src/Deveel.Events.Publisher.MassTransit/Events/EventPublisherBuilderExtensions.cs
@@ -25,9 +25,9 @@ namespace Deveel.Events
             builder.AddMassTransitInfrastructure();
             // Register the concrete channel once under its own type so callers can resolve it
             // directly and supply per-call option overrides.
-            builder.Services.TryAddSingleton<MassTransitEventPublishChannel>();
+            builder.Services.TryAddSingleton<MassTransitPublishChannel>();
             // Expose it as IEventPublishChannel (type-based so ImplementationType is preserved).
-            builder.Services.AddSingleton<IEventPublishChannel, MassTransitEventPublishChannel>();
+            builder.Services.AddSingleton<IEventPublishChannel, MassTransitPublishChannel>();
             return builder;
         }
 
@@ -108,7 +108,7 @@ namespace Deveel.Events
                 optBuilder.Configure(configure);
 
             builder.AddMassTransitInfrastructure();
-            return builder.AddChannel<MassTransitEventPublishChannel<TEvent>, TEvent>();
+            return builder.AddChannel<MassTransitPublishChannel<TEvent>, TEvent>();
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Deveel.Events
                 .BindConfiguration(sectionPath);
 
             builder.AddMassTransitInfrastructure();
-            return builder.AddChannel<MassTransitEventPublishChannel<TEvent>, TEvent>();
+            return builder.AddChannel<MassTransitPublishChannel<TEvent>, TEvent>();
         }
     }
 }

--- a/src/Deveel.Events.Publisher.MassTransit/Events/ICloudEventMessage.cs
+++ b/src/Deveel.Events.Publisher.MassTransit/Events/ICloudEventMessage.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// The MassTransit message contract used to wrap a structured-mode
-    /// CloudEvent payload for publishing via <see cref="MassTransitEventPublishChannel"/>.
+    /// CloudEvent payload for publishing via <see cref="MassTransitPublishChannel"/>.
     /// </summary>
     /// <remarks>
     /// MassTransit uses this interface as the message type when calling

--- a/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishChannel.cs
+++ b/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishChannel.cs
@@ -18,7 +18,7 @@ namespace Deveel.Events
     /// An implementation of <see cref="IEventPublishChannel{TOptions}"/> that publishes
     /// CloudEvents via MassTransit.
     /// </summary>
-    public class MassTransitPublishChannel :
+    internal class MassTransitPublishChannel :
         EventPublishChannel<MassTransitPublishOptions>
     {
         private readonly IPublishEndpoint _publishEndpoint;

--- a/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishChannel.cs
+++ b/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishChannel.cs
@@ -18,8 +18,8 @@ namespace Deveel.Events
     /// An implementation of <see cref="IEventPublishChannel{TOptions}"/> that publishes
     /// CloudEvents via MassTransit.
     /// </summary>
-    public class MassTransitEventPublishChannel :
-        EventPublishChannelBase<MassTransitPublishOptions>
+    public class MassTransitPublishChannel :
+        EventPublishChannel<MassTransitPublishOptions>
     {
         private readonly IPublishEndpoint _publishEndpoint;
         private readonly ISendEndpointProvider _sendEndpointProvider;
@@ -48,17 +48,17 @@ namespace Deveel.Events
         /// <param name="logger">
         /// An optional logger; when <c>null</c> a <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger{T}"/> is used.
         /// </param>
-        public MassTransitEventPublishChannel(
+        public MassTransitPublishChannel(
             IOptions<MassTransitPublishOptions> options,
             IPublishEndpoint publishEndpoint,
             ISendEndpointProvider sendEndpointProvider,
             IEnumerable<IValidateOptions<MassTransitPublishOptions>>? validators = null,
-            ILogger<MassTransitEventPublishChannel>? logger = null)
+            ILogger<MassTransitPublishChannel>? logger = null)
             : base(options.Value, validators)
         {
             _publishEndpoint = publishEndpoint;
             _sendEndpointProvider = sendEndpointProvider;
-            _logger = logger ?? NullLogger<MassTransitEventPublishChannel>.Instance;
+            _logger = logger ?? NullLogger<MassTransitPublishChannel>.Instance;
         }
 
         /// <inheritdoc/>

--- a/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishChannel`1.cs
+++ b/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishChannel`1.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Options;
 namespace Deveel.Events
 {
     /// <summary>
-    /// A <see cref="MassTransitEventPublishChannel"/> subclass that also implements
+    /// A <see cref="MassTransitPublishChannel"/> subclass that also implements
     /// <see cref="IEventPublishChannel{TEvent}"/>, so the <see cref="EventPublisher"/>
     /// routes events of type <typeparamref name="TEvent"/> exclusively to this channel.
     /// </summary>
@@ -24,8 +24,8 @@ namespace Deveel.Events
     /// <typeparam name="TEvent">
     /// The event data class this channel is keyed against.
     /// </typeparam>
-    class MassTransitEventPublishChannel<TEvent> :
-        MassTransitEventPublishChannel,
+    class MassTransitPublishChannel<TEvent> :
+        MassTransitPublishChannel,
         IEventPublishChannel<TEvent>
         where TEvent : class
     {
@@ -44,13 +44,13 @@ namespace Deveel.Events
         /// <param name="sendEndpointProvider">MassTransit send-endpoint provider.</param>
         /// <param name="validators">Optional DI-registered options validators.</param>
         /// <param name="logger">Optional logger; falls back to NullLogger when <c>null</c>.</param>
-        public MassTransitEventPublishChannel(
+        public MassTransitPublishChannel(
             IOptions<MassTransitPublishOptions<TEvent>> typedOptions,
             IOptions<MassTransitPublishOptions> baseOptions,
             IPublishEndpoint publishEndpoint,
             ISendEndpointProvider sendEndpointProvider,
             IEnumerable<IValidateOptions<MassTransitPublishOptions>>? validators = null,
-            ILogger<MassTransitEventPublishChannel>? logger = null)
+            ILogger<MassTransitPublishChannel>? logger = null)
             : base(
                 Options.Create(MassTransitPublishOptions.Merge(baseOptions.Value, typedOptions.Value)),
                 publishEndpoint,

--- a/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishOptions.cs
@@ -8,7 +8,7 @@ namespace Deveel.Events
     /// <summary>
     /// Options that configure the <see cref="MassTransitEventPublishChannel"/>.
     /// </summary>
-    public class MassTransitPublishOptions : EventPublishOptions
+    public class MassTransitPublishOptions : EventPublishOptions, INamedChannelFilter
     {
         /// <summary>
         /// Merges <paramref name="baseOptions"/> with <paramref name="typedOptions"/>,
@@ -21,10 +21,14 @@ namespace Deveel.Events
         {
             return new MassTransitPublishOptions
             {
+                ChannelName            = typedOptions.ChannelName            ?? baseOptions.ChannelName,
                 DestinationAddress     = typedOptions.DestinationAddress     ?? baseOptions.DestinationAddress,
                 MapAttributesToHeaders = typedOptions.MapAttributesToHeaders ?? baseOptions.MapAttributesToHeaders,
             };
         }
+
+        /// <inheritdoc/>
+        public string? ChannelName { get; set; }
 
         /// <summary>
         /// Gets or sets the destination address to send the event to.

--- a/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishOptions.cs
@@ -8,7 +8,7 @@ namespace Deveel.Events
     /// <summary>
     /// Options that configure the <see cref="MassTransitEventPublishChannel"/>.
     /// </summary>
-    public class MassTransitPublishOptions : EventPublishOptions, INamedChannelFilter
+    public class MassTransitPublishOptions : NamedChannelPublishOptions, INamedChannelFilter
     {
         /// <summary>
         /// Merges <paramref name="baseOptions"/> with <paramref name="typedOptions"/>,
@@ -26,9 +26,6 @@ namespace Deveel.Events
                 MapAttributesToHeaders = typedOptions.MapAttributesToHeaders ?? baseOptions.MapAttributesToHeaders,
             };
         }
-
-        /// <inheritdoc/>
-        public string? ChannelName { get; set; }
 
         /// <summary>
         /// Gets or sets the destination address to send the event to.

--- a/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishOptions.cs
@@ -6,7 +6,7 @@
 namespace Deveel.Events
 {
     /// <summary>
-    /// Options that configure the <see cref="MassTransitEventPublishChannel"/>.
+    /// Options that configure the <see cref="MassTransitPublishChannel"/>.
     /// </summary>
     public class MassTransitPublishOptions : NamedChannelPublishOptions, INamedChannelFilter
     {

--- a/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishOptions`1.cs
+++ b/src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishOptions`1.cs
@@ -6,7 +6,7 @@
 namespace Deveel.Events
 {
     /// <summary>
-    /// Type-specific publish options for a <see cref="MassTransitEventPublishChannel{TEvent}"/>
+    /// Type-specific publish options for a <see cref="MassTransitPublishChannel{TEvent}"/>
     /// that routes events of type <typeparamref name="TEvent"/> via MassTransit.
     /// </summary>
     /// <remarks>

--- a/src/Deveel.Events.Publisher.RabbitMq/Events/EventPublisherBuilderExtensions.cs
+++ b/src/Deveel.Events.Publisher.RabbitMq/Events/EventPublisherBuilderExtensions.cs
@@ -35,9 +35,9 @@ namespace Deveel.Events
             builder.AddRabbitMqInfrastructure();
             // Register the concrete channel once under its own type so callers can resolve it
             // directly and supply per-call option overrides.
-            builder.Services.TryAddSingleton<RabbitMqEventPublishChannel>();
+            builder.Services.TryAddSingleton<RabbitMqPublishChannel>();
             // Expose it as IEventPublishChannel (type-based so ImplementationType is preserved).
-            builder.Services.AddSingleton<IEventPublishChannel, RabbitMqEventPublishChannel>();
+            builder.Services.AddSingleton<IEventPublishChannel, RabbitMqPublishChannel>();
             return builder;
         }
 
@@ -110,7 +110,7 @@ namespace Deveel.Events
                 .Configure(configure);
 
             builder.AddRabbitMqInfrastructure();
-            return builder.AddChannel<RabbitMqEventPublishChannel<TEvent>, TEvent>();
+            return builder.AddChannel<RabbitMqPublishChannel<TEvent>, TEvent>();
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Deveel.Events
                 .BindConfiguration(sectionPath);
 
             builder.AddRabbitMqInfrastructure();
-            return builder.AddChannel<RabbitMqEventPublishChannel<TEvent>, TEvent>();
+            return builder.AddChannel<RabbitMqPublishChannel<TEvent>, TEvent>();
         }
     }
 }

--- a/src/Deveel.Events.Publisher.RabbitMq/Events/IRabbitMqConnectionFactory.cs
+++ b/src/Deveel.Events.Publisher.RabbitMq/Events/IRabbitMqConnectionFactory.cs
@@ -11,7 +11,7 @@ namespace Deveel.Events
 {
     /// <summary>
     /// A factory to create a connection to a RabbitMQ server
-    /// to be used by the <see cref="RabbitMqEventPublishChannel"/>.
+    /// to be used by the <see cref="RabbitMqPublishChannel"/>.
     /// </summary>
     public interface IRabbitMqConnectionFactory
     {

--- a/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishChannel.cs
+++ b/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishChannel.cs
@@ -17,8 +17,8 @@ namespace Deveel.Events
     /// The implementation of the <see cref="IEventPublishChannel{TOptions}"/> that
     /// is used to publish events to a RabbitMQ exchange.
     /// </summary>
-    public class RabbitMqEventPublishChannel :
-        EventPublishChannelBase<RabbitMqPublishOptions>,
+    public class RabbitMqPublishChannel :
+        EventPublishChannel<RabbitMqPublishOptions>,
         IAsyncDisposable, IDisposable
     {
         private readonly IRabbitMqMessageFactory _messageFactory;
@@ -54,17 +54,17 @@ namespace Deveel.Events
         /// <param name="logger">
         /// An optional logger; when <c>null</c> a <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger{T}"/> is used.
         /// </param>
-        public RabbitMqEventPublishChannel(
+        public RabbitMqPublishChannel(
             IOptions<RabbitMqPublishOptions> options,
             IConnection connection,
             IRabbitMqMessageFactory messageFactory,
             IEnumerable<IValidateOptions<RabbitMqPublishOptions>>? validators = null,
-            ILogger<RabbitMqEventPublishChannel>? logger = null)
+            ILogger<RabbitMqPublishChannel>? logger = null)
             : base(options.Value, validators)
         {
             _connection = connection;
             _messageFactory = messageFactory;
-            _logger = logger ?? new NullLogger<RabbitMqEventPublishChannel>();
+            _logger = logger ?? new NullLogger<RabbitMqPublishChannel>();
         }
 
         // ── Effective defaults for nullable value-type properties ──────────────────
@@ -146,7 +146,7 @@ namespace Deveel.Events
             CancellationToken cancellationToken)
         {
             if (_disposed)
-                throw new ObjectDisposedException(nameof(RabbitMqEventPublishChannel));
+                throw new ObjectDisposedException(nameof(RabbitMqPublishChannel));
 
             _logger.TracePublishingEvent(@event.Type);
 

--- a/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishChannel.cs
+++ b/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishChannel.cs
@@ -17,7 +17,7 @@ namespace Deveel.Events
     /// The implementation of the <see cref="IEventPublishChannel{TOptions}"/> that
     /// is used to publish events to a RabbitMQ exchange.
     /// </summary>
-    public class RabbitMqPublishChannel :
+    class RabbitMqPublishChannel :
         EventPublishChannel<RabbitMqPublishOptions>,
         IAsyncDisposable, IDisposable
     {

--- a/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishChannel`1.cs
+++ b/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishChannel`1.cs
@@ -11,7 +11,7 @@ using RabbitMQ.Client;
 namespace Deveel.Events
 {
     /// <summary>
-    /// A <see cref="RabbitMqEventPublishChannel"/> subclass that also implements
+    /// A <see cref="RabbitMqPublishChannel"/> subclass that also implements
     /// <see cref="IEventPublishChannel{TEvent}"/>, so the <see cref="EventPublisher"/>
     /// routes events of type <typeparamref name="TEvent"/> exclusively to this channel.
     /// </summary>
@@ -24,8 +24,8 @@ namespace Deveel.Events
     /// <typeparam name="TEvent">
     /// The event data class this channel is keyed against.
     /// </typeparam>
-    class RabbitMqEventPublishChannel<TEvent> :
-        RabbitMqEventPublishChannel,
+    class RabbitMqPublishChannel<TEvent> :
+        RabbitMqPublishChannel,
         IEventPublishChannel<TEvent>
         where TEvent : class
     {
@@ -47,13 +47,13 @@ namespace Deveel.Events
         /// <param name="messageFactory">Factory that converts a CloudEvent into a RabbitMQ message.</param>
         /// <param name="validators">Optional DI-registered options validators.</param>
         /// <param name="logger">Optional logger; falls back to NullLogger when <c>null</c>.</param>
-        public RabbitMqEventPublishChannel(
+        public RabbitMqPublishChannel(
             IOptions<RabbitMqPublishOptions<TEvent>> typedOptions,
             IOptions<RabbitMqPublishOptions> baseOptions,
             IConnection connection,
             IRabbitMqMessageFactory messageFactory,
             IEnumerable<IValidateOptions<RabbitMqPublishOptions>>? validators = null,
-            ILogger<RabbitMqEventPublishChannel>? logger = null)
+            ILogger<RabbitMqPublishChannel>? logger = null)
             : base(
                 Options.Create(RabbitMqPublishOptions.Merge(baseOptions.Value, typedOptions.Value)),
                 connection,

--- a/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishOptions.cs
@@ -12,7 +12,7 @@ namespace Deveel.Events
     /// <summary>
     /// Configuration options for a <see cref="RabbitMqEventPublishChannel"/>.
     /// </summary>
-    public class RabbitMqPublishOptions : EventPublishOptions, INamedChannelFilter
+    public class RabbitMqPublishOptions : NamedChannelPublishOptions, INamedChannelFilter
     {
         /// <summary>
         /// Merges <paramref name="baseOptions"/> with <paramref name="typedOptions"/>,
@@ -40,11 +40,7 @@ namespace Deveel.Events
                 Mandatory             = typedOptions.Mandatory             ?? baseOptions.Mandatory,
             };
         }
-
-        /// <inheritdoc/>
-        public string? ChannelName { get; set; }
-
-
+        
         /// <summary>
         /// The name of the exchange to publish events to in the RabbitMQ broker.
         /// When <c>null</c> in a per-call override the channel default is used;

--- a/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishOptions.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 namespace Deveel.Events
 {
     /// <summary>
-    /// Configuration options for a <see cref="RabbitMqEventPublishChannel"/>.
+    /// Configuration options for a <see cref="RabbitMqPublishChannel"/>.
     /// </summary>
     public class RabbitMqPublishOptions : NamedChannelPublishOptions, INamedChannelFilter
     {

--- a/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishOptions.cs
@@ -12,7 +12,7 @@ namespace Deveel.Events
     /// <summary>
     /// Configuration options for a <see cref="RabbitMqEventPublishChannel"/>.
     /// </summary>
-    public class RabbitMqPublishOptions : EventPublishOptions
+    public class RabbitMqPublishOptions : EventPublishOptions, INamedChannelFilter
     {
         /// <summary>
         /// Merges <paramref name="baseOptions"/> with <paramref name="typedOptions"/>,
@@ -25,6 +25,7 @@ namespace Deveel.Events
         {
             return new RabbitMqPublishOptions
             {
+                ChannelName           = typedOptions.ChannelName           ?? baseOptions.ChannelName,
                 ConnectionString      = typedOptions.ConnectionString      ?? baseOptions.ConnectionString,
                 ExchangeName          = typedOptions.ExchangeName          ?? baseOptions.ExchangeName,
                 RoutingKey            = typedOptions.RoutingKey            ?? baseOptions.RoutingKey,
@@ -39,6 +40,9 @@ namespace Deveel.Events
                 Mandatory             = typedOptions.Mandatory             ?? baseOptions.Mandatory,
             };
         }
+
+        /// <inheritdoc/>
+        public string? ChannelName { get; set; }
 
 
         /// <summary>

--- a/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishOptions`1.cs
+++ b/src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishOptions`1.cs
@@ -6,7 +6,7 @@
 namespace Deveel.Events
 {
     /// <summary>
-    /// Type-specific publish options for a <see cref="RabbitMqEventPublishChannel{TEvent}"/>
+    /// Type-specific publish options for a <see cref="RabbitMqPublishChannel{TEvent}"/>
     /// that routes events of type <typeparamref name="TEvent"/> to a RabbitMQ exchange.
     /// </summary>
     /// <remarks>

--- a/src/Deveel.Events.Publisher.Webhook/Events/EventPublisherBuilderExtensions.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/EventPublisherBuilderExtensions.cs
@@ -50,11 +50,11 @@ namespace Deveel.Events
 
             // Register the concrete channel once under its own type so callers can resolve it
             // directly and supply per-call option overrides.
-            builder.Services.TryAddSingleton<WebhookEventPublishChannel>();
+            builder.Services.TryAddSingleton<WebhookPublishChannel>();
             // Expose it as IEventPublishChannel, IOptionsEventPublishChannel and IBatchEventPublishChannel
             // (type-based so ImplementationType is preserved for service-registration assertions).
-            builder.Services.AddSingleton<IEventPublishChannel, WebhookEventPublishChannel>();
-            builder.Services.AddSingleton<IBatchEventPublishChannel, WebhookEventPublishChannel>();
+            builder.Services.AddSingleton<IEventPublishChannel, WebhookPublishChannel>();
+            builder.Services.AddSingleton<IBatchEventPublishChannel, WebhookPublishChannel>();
 
             return builder;
         }
@@ -133,7 +133,7 @@ namespace Deveel.Events
             builder.Services.AddOptions<WebhookPublishOptions<TEvent>>()
                 .Configure(configure);
             builder.AddWebhookInfrastructure();
-            return builder.AddChannel<WebhookEventPublishChannel<TEvent>, TEvent>();
+            return builder.AddChannel<WebhookPublishChannel<TEvent>, TEvent>();
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Deveel.Events
             builder.Services.AddOptions<WebhookPublishOptions<TEvent>>()
                 .BindConfiguration(sectionPath);
             builder.AddWebhookInfrastructure();
-            return builder.AddChannel<WebhookEventPublishChannel<TEvent>, TEvent>();
+            return builder.AddChannel<WebhookPublishChannel<TEvent>, TEvent>();
         }
 
         /// <summary>

--- a/src/Deveel.Events.Publisher.Webhook/Events/HmacSha256SignatureProvider.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/HmacSha256SignatureProvider.cs
@@ -14,7 +14,7 @@ namespace Deveel.Events
     /// <remarks>
     /// This is the most widely supported algorithm across webhook providers
     /// (GitHub, Stripe, Slack, Twilio, Shopify, and many others) and is the default
-    /// for <see cref="WebhookEventPublishChannel"/>.
+    /// for <see cref="WebhookPublishChannel"/>.
     /// </remarks>
     public class HmacSha256SignatureProvider : HmacWebhookSignatureProvider
     {

--- a/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishChannel.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishChannel.cs
@@ -37,7 +37,7 @@ namespace Deveel.Events
     /// from the channel-level defaults and ignored in per-call overrides.
     /// </para>
     /// </remarks>
-    public class WebhookPublishChannel :
+    class WebhookPublishChannel :
         EventPublishChannel<WebhookPublishOptions>,
         IBatchEventPublishChannel
     {

--- a/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishChannel.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishChannel.cs
@@ -17,7 +17,7 @@ using System.Net.Http.Headers;
 namespace Deveel.Events
 {
     /// <summary>
-    /// An <see cref="EventPublishChannelBase{TOptions}"/> and
+    /// An <see cref="EventPublishChannel{TOptions}"/> and
     /// <see cref="IBatchEventPublishChannel"/> that delivers
     /// <see cref="CloudEvent"/> instances (individually or in batches) to a remote
     /// endpoint via HTTP POST, following webhook best practices.
@@ -28,7 +28,7 @@ namespace Deveel.Events
     /// for both the channel-level defaults and per-call overrides. On every
     /// <c>PublishAsync</c> / <c>PublishBatchAsync</c> call the per-call overrides are
     /// merged with the channel defaults via <see cref="MergeOptions"/> and the result
-    /// is validated by <see cref="EventPublishChannelBase{TOptions}.ValidateOptions"/>
+    /// is validated by <see cref="EventPublishChannel{TOptions}.ValidateOptions"/>
     /// before the HTTP delivery is attempted.
     /// </para>
     /// <para>
@@ -37,8 +37,8 @@ namespace Deveel.Events
     /// from the channel-level defaults and ignored in per-call overrides.
     /// </para>
     /// </remarks>
-    public class WebhookEventPublishChannel :
-        EventPublishChannelBase<WebhookPublishOptions>,
+    public class WebhookPublishChannel :
+        EventPublishChannel<WebhookPublishOptions>,
         IBatchEventPublishChannel
     {
         private readonly IHttpClientFactory _httpClientFactory;
@@ -76,17 +76,17 @@ namespace Deveel.Events
         /// An optional logger; when <c>null</c> a
         /// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger{T}"/> is used.
         /// </param>
-        public WebhookEventPublishChannel(
+        public WebhookPublishChannel(
             IOptions<WebhookPublishOptions> options,
             IHttpClientFactory httpClientFactory,
             IEnumerable<IWebhookSignatureProvider>? signatureProviders = null,
             IEnumerable<IEventSerializer>? serializers = null,
             IEnumerable<IValidateOptions<WebhookPublishOptions>>? validators = null,
-            ILogger<WebhookEventPublishChannel>? logger = null)
+            ILogger<WebhookPublishChannel>? logger = null)
             : base(options.Value, validators)
         {
             _httpClientFactory = httpClientFactory;
-            _logger            = logger ?? NullLogger<WebhookEventPublishChannel>.Instance;
+            _logger            = logger ?? NullLogger<WebhookPublishChannel>.Instance;
 
             // Signature providers
             _signatureProviders = new Dictionary<WebhookSignatureAlgorithm, IWebhookSignatureProvider>
@@ -115,7 +115,7 @@ namespace Deveel.Events
                     _serializers[s.Format] = s;
         }
 
-        // ── EventPublishChannelBase<WebhookPublishOptions> ──────────────────
+        // ── EventPublishChannel<WebhookPublishOptions> ──────────────────
 
         /// <summary>
         /// Performs a property-level merge: each nullable delivery field in

--- a/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishChannel`1.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishChannel`1.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 namespace Deveel.Events
 {
     /// <summary>
-    /// A <see cref="WebhookEventPublishChannel"/> subclass that also implements
+    /// A <see cref="WebhookPublishChannel"/> subclass that also implements
     /// <see cref="IEventPublishChannel{TEvent}"/>, so the <see cref="EventPublisher"/>
     /// routes events of type <typeparamref name="TEvent"/> exclusively to this channel.
     /// </summary>
@@ -23,8 +23,8 @@ namespace Deveel.Events
     /// <typeparam name="TEvent">
     /// The event data class this channel is keyed against.
     /// </typeparam>
-    class WebhookEventPublishChannel<TEvent> :
-        WebhookEventPublishChannel,
+    class WebhookPublishChannel<TEvent> :
+        WebhookPublishChannel,
         IEventPublishChannel<TEvent>
         where TEvent : class
     {
@@ -44,14 +44,14 @@ namespace Deveel.Events
         /// <param name="serializers">Optional event serializers.</param>
         /// <param name="validators">Optional DI-registered options validators.</param>
         /// <param name="logger">Optional logger; falls back to NullLogger when <c>null</c>.</param>
-        public WebhookEventPublishChannel(
+        public WebhookPublishChannel(
             IOptions<WebhookPublishOptions<TEvent>> typedOptions,
             IOptions<WebhookPublishOptions> baseOptions,
             IHttpClientFactory httpClientFactory,
             IEnumerable<IWebhookSignatureProvider>? signatureProviders = null,
             IEnumerable<IEventSerializer>? serializers = null,
             IEnumerable<IValidateOptions<WebhookPublishOptions>>? validators = null,
-            ILogger<WebhookEventPublishChannel>? logger = null)
+            ILogger<WebhookPublishChannel>? logger = null)
             : base(
                 Options.Create(WebhookPublishOptions.Merge(baseOptions.Value, typedOptions.Value)),
                 httpClientFactory,

--- a/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishOptions.cs
@@ -8,7 +8,7 @@ using System.ComponentModel.DataAnnotations;
 namespace Deveel.Events
 {
     /// <summary>
-    /// Options for the <see cref="WebhookEventPublishChannel"/>, used both as the
+    /// Options for the <see cref="WebhookPublishChannel"/>, used both as the
     /// channel-level configuration (injected via <see cref="Microsoft.Extensions.Options.IOptions{TOptions}"/>)
     /// and as per-delivery overrides passed directly to
     /// <see cref="IEventPublishChannel{TOptions}.PublishAsync"/>.

--- a/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishOptions.cs
@@ -21,7 +21,7 @@ namespace Deveel.Events
     /// are always taken from the channel-level defaults and ignored when supplied
     /// in a per-call override.
     /// </remarks>
-    public class WebhookPublishOptions : EventPublishOptions
+    public class WebhookPublishOptions : EventPublishOptions, INamedChannelFilter
     {
         /// <summary>
         /// Merges <paramref name="baseOptions"/> with <paramref name="typedOptions"/>,
@@ -41,6 +41,7 @@ namespace Deveel.Events
 
             return new WebhookPublishOptions
             {
+                ChannelName            = typedOptions.ChannelName            ?? baseOptions.ChannelName,
                 EndpointUrl            = typedOptions.EndpointUrl            ?? baseOptions.EndpointUrl,
                 SigningSecret          = typedOptions.SigningSecret          ?? baseOptions.SigningSecret,
                 MaxRetryCount          = typedOptions.MaxRetryCount          ?? baseOptions.MaxRetryCount,
@@ -60,6 +61,9 @@ namespace Deveel.Events
                 HttpClientName              = baseOptions.HttpClientName,
             };
         }
+
+        /// <inheritdoc/>
+        public string? ChannelName { get; set; }
 
 
         // ── Delivery settings — nullable so per-call overrides can be partial ──

--- a/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishOptions.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishOptions.cs
@@ -21,7 +21,7 @@ namespace Deveel.Events
     /// are always taken from the channel-level defaults and ignored when supplied
     /// in a per-call override.
     /// </remarks>
-    public class WebhookPublishOptions : EventPublishOptions, INamedChannelFilter
+    public class WebhookPublishOptions : NamedChannelPublishOptions, INamedChannelFilter
     {
         /// <summary>
         /// Merges <paramref name="baseOptions"/> with <paramref name="typedOptions"/>,
@@ -61,9 +61,6 @@ namespace Deveel.Events
                 HttpClientName              = baseOptions.HttpClientName,
             };
         }
-
-        /// <inheritdoc/>
-        public string? ChannelName { get; set; }
 
 
         // ── Delivery settings — nullable so per-call overrides can be partial ──

--- a/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishOptions`1.cs
+++ b/src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishOptions`1.cs
@@ -6,7 +6,7 @@
 namespace Deveel.Events
 {
     /// <summary>
-    /// Type-specific publish options for a <see cref="WebhookEventPublishChannel{TEvent}"/>
+    /// Type-specific publish options for a <see cref="WebhookPublishChannel{TEvent}"/>
     /// that routes events of type <typeparamref name="TEvent"/> to a webhook endpoint.
     /// </summary>
     /// <remarks>

--- a/src/Deveel.Events.Publisher/Events/CombinedPublishOptions.cs
+++ b/src/Deveel.Events.Publisher/Events/CombinedPublishOptions.cs
@@ -18,7 +18,7 @@ namespace Deveel.Events
     /// <see cref="CombinedPublishOptions"/> that method searches the bundled
     /// collection for the first entry whose concrete type is assignable to the options
     /// type declared by the target channel (i.e. the <c>TOptions</c> of
-    /// <see cref="EventPublishChannelBase{TOptions}"/>).  The matching entry is
+    /// <see cref="EventPublishChannel{TOptions}"/>).  The matching entry is
     /// forwarded; if none is found the channel falls back to its registered defaults.
     /// </para>
     /// <para>

--- a/src/Deveel.Events.Publisher/Events/EventPublishChannel.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublishChannel.cs
@@ -40,7 +40,7 @@ namespace Deveel.Events
     ///   </item>
     /// </list>
     /// </remarks>
-    public abstract class EventPublishChannelBase<TOptions> : IEventPublishChannel, INamedEventPublishChannel
+    public abstract class EventPublishChannel<TOptions> : INamedEventPublishChannel
         where TOptions : EventPublishOptions
     {
         private readonly TOptions _defaultOptions;
@@ -60,7 +60,7 @@ namespace Deveel.Events
         /// validation falls back to
         /// <see cref="Validator.ValidateObject(object, ValidationContext)"/> (DataAnnotations).
         /// </param>
-        protected EventPublishChannelBase(
+        protected EventPublishChannel(
             TOptions defaultOptions,
             IEnumerable<IValidateOptions<TOptions>>? validators = null)
         {
@@ -134,8 +134,8 @@ namespace Deveel.Events
         /// <typeparamref name="TOptions"/>; passing an options object of an incompatible
         /// type throws <see cref="ArgumentException"/>.
         /// </remarks>
-        Task IEventPublishChannel.PublishAsync(CloudEvent @event, EventPublishOptions? options = null,
-            CancellationToken cancellationToken = default)
+        Task IEventPublishChannel.PublishAsync(CloudEvent @event, EventPublishOptions? options,
+            CancellationToken cancellationToken)
         {
             if (options != null && options is not TOptions)
                 throw new ArgumentException($"Per-call options must be of type {typeof(TOptions).Name} or null.", nameof(options));

--- a/src/Deveel.Events.Publisher/Events/EventPublishChannelBase.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublishChannelBase.cs
@@ -40,7 +40,7 @@ namespace Deveel.Events
     ///   </item>
     /// </list>
     /// </remarks>
-    public abstract class EventPublishChannelBase<TOptions> : IEventPublishChannel
+    public abstract class EventPublishChannelBase<TOptions> : IEventPublishChannel, INamedEventPublishChannel
         where TOptions : EventPublishOptions
     {
         private readonly TOptions _defaultOptions;
@@ -68,6 +68,13 @@ namespace Deveel.Events
             _defaultOptions = defaultOptions;
             _validators = validators ?? [];
         }
+
+        /// <inheritdoc cref="INamedEventPublishChannel.Name"/>
+        /// <remarks>
+        /// The value is read from <see cref="DefaultOptions"/> when those options implement
+        /// <see cref="INamedChannelFilter"/>; otherwise <c>null</c>.
+        /// </remarks>
+        public string? Name => (_defaultOptions as INamedChannelFilter)?.ChannelName;
 
         /// <summary>Gets the channel-level default options.</summary>
         protected TOptions DefaultOptions => _defaultOptions;

--- a/src/Deveel.Events.Publisher/Events/EventPublishOptions.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublishOptions.cs
@@ -27,6 +27,32 @@ namespace Deveel.Events;
 /// </remarks>
 public abstract class EventPublishOptions
 {
-    public static CombinedPublishOptions Combine(params EventPublishOptions[] options) 
+    /// <summary>
+    /// Creates a <see cref="CombinedPublishOptions"/> that bundles multiple per-channel
+    /// options instances together so that a single call to
+    /// <see cref="IEventPublisher.PublishEventAsync"/> or
+    /// <see cref="IEventPublisher.PublishAsync"/> can carry heterogeneous overrides for
+    /// several channels simultaneously.
+    /// </summary>
+    /// <param name="options">
+    /// The per-channel options to bundle. The order of the elements is preserved; the
+    /// first compatible entry wins when <see cref="EventPublisher"/> resolves options for
+    /// a specific channel. Each entry may implement <see cref="INamedChannelFilter"/> to
+    /// restrict itself to a channel whose <see cref="INamedEventPublishChannel.Name"/>
+    /// matches <see cref="INamedChannelFilter.ChannelName"/>.
+    /// </param>
+    /// <returns>
+    /// A new <see cref="CombinedPublishOptions"/> containing all supplied entries.
+    /// </returns>
+    /// <example>
+    /// <code language="csharp">
+    /// var combined = EventPublishOptions.Combine(
+    ///     new RabbitMqPublishOptions { ChannelName = "rabbit-orders",  RoutingKey = "orders" },
+    ///     new ServiceBusPublishOptions { ChannelName = "sb-audit", QueueName  = "audit" });
+    ///
+    /// await publisher.PublishEventAsync(myEvent, combined);
+    /// </code>
+    /// </example>
+    public static CombinedPublishOptions Combine(params EventPublishOptions[] options)
         => new CombinedPublishOptions(options);
 }

--- a/src/Deveel.Events.Publisher/Events/EventPublishOptions.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublishOptions.cs
@@ -27,4 +27,6 @@ namespace Deveel.Events;
 /// </remarks>
 public abstract class EventPublishOptions
 {
+    public static CombinedPublishOptions Combine(params EventPublishOptions[] options) 
+        => new CombinedPublishOptions(options);
 }

--- a/src/Deveel.Events.Publisher/Events/EventPublisher.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublisher.cs
@@ -296,30 +296,88 @@ namespace Deveel.Events {
 				}
 			}
 
-			if (options is CombinedPublishOptions combined)
-			{
-				return channelEventType != null
-					// Typed channel: find the first bundled entry typed for this TEvent.
-					? combined.Options.FirstOrDefault(o =>
-						expectedOptionsType.IsAssignableFrom(o.GetType()) &&
-						IsTypedForEvent(o.GetType(), channelEventType))
-					// General channel: find the first non-typed bundled entry.
-					: combined.Options.FirstOrDefault(o =>
-						expectedOptionsType.IsAssignableFrom(o.GetType()) &&
-						!IsAnyTypedOptions(o.GetType()));
-			}
+		if (options is CombinedPublishOptions combined)
+		{
+			// For combined options each bundled entry may carry its own ChannelName.
+			// Only entries whose name matches the target channel (or carry no name) are eligible.
+			var compatibleEntries = combined.Options.Where(o =>
+				expectedOptionsType.IsInstanceOfType(o) &&
+				NameMatchesChannel(o, channel));
 
-			// Single options instance.
-			if (!expectedOptionsType.IsAssignableFrom(options.GetType()))
-				return null;
-
-			if (channelEventType != null)
-				// Typed channel: only accept options specifically typed for this TEvent.
-				return IsTypedForEvent(options.GetType(), channelEventType) ? options : null;
-
-			// General channel: only accept non-typed options instances.
-			return IsAnyTypedOptions(options.GetType()) ? null : options;
+			return channelEventType != null
+				// Typed channel: find the first bundled entry typed for this TEvent.
+				? compatibleEntries.FirstOrDefault(o => IsTypedForEvent(o.GetType(), channelEventType))
+				// General channel: find the first non-typed bundled entry.
+				: compatibleEntries.FirstOrDefault(o => !IsAnyTypedOptions(o.GetType()));
 		}
+
+		// Single options instance.
+		if (!expectedOptionsType.IsInstanceOfType(options))
+			return null;
+
+		// If the options carry a name filter, the channel must match.
+		if (!NameMatchesChannel(options, channel))
+			return null;
+
+		if (channelEventType != null)
+			// Typed channel: only accept options specifically typed for this TEvent.
+			return IsTypedForEvent(options.GetType(), channelEventType) ? options : null;
+
+		// General channel: only accept non-typed options instances.
+		return IsAnyTypedOptions(options.GetType()) ? null : options;
+	}
+
+	/// <summary>
+	/// Returns <c>true</c> when the <paramref name="options"/> carry no name filter,
+	/// when the <paramref name="channel"/> does not implement
+	/// <see cref="INamedEventPublishChannel"/>, or when their
+	/// <see cref="INamedChannelFilter.ChannelName"/> matches the channel's
+	/// <see cref="INamedEventPublishChannel.Name"/> (case-insensitive).
+	/// </summary>
+	private static bool NameMatchesChannel(EventPublishOptions options, IEventPublishChannel channel)
+	{
+		if (options is not INamedChannelFilter filter || string.IsNullOrEmpty(filter.ChannelName))
+			return true;
+
+		// Anonymous channels (non-INamedEventPublishChannel) receive everything.
+		if (channel is not INamedEventPublishChannel named)
+			return true;
+
+		// A named-channel implementation with a null/empty Name is treated as unnamed.
+		if (string.IsNullOrEmpty(named.Name))
+			return true;
+
+		return string.Equals(filter.ChannelName, named.Name, StringComparison.OrdinalIgnoreCase);
+	}
+
+	/// <summary>
+	/// Filters <paramref name="channels"/> to those whose
+	/// <see cref="INamedEventPublishChannel.Name"/> matches the
+	/// <see cref="INamedChannelFilter.ChannelName"/> specified in
+	/// <paramref name="options"/>.
+	/// </summary>
+	/// <remarks>
+	/// When <paramref name="options"/> is <c>null</c>, does not implement
+	/// <see cref="INamedChannelFilter"/>, or carries an empty/null channel name,
+	/// all channels are returned unchanged.
+	/// Channels that do not implement <see cref="INamedEventPublishChannel"/> are
+	/// treated as anonymous and always pass the filter.
+	/// <see cref="CombinedPublishOptions"/> intentionally does not implement
+	/// <see cref="INamedChannelFilter"/>; its per-entry name filtering is handled
+	/// inside <see cref="ResolveChannelOptions"/>.
+	/// </remarks>
+	protected virtual IEnumerable<IEventPublishChannel> FilterChannelsByName(
+		IEnumerable<IEventPublishChannel> channels,
+		EventPublishOptions? options)
+	{
+		if (options is not INamedChannelFilter { ChannelName: { Length: > 0 } name })
+			return channels;
+
+		return channels.Where(c =>
+			c is not INamedEventPublishChannel named ||
+			string.IsNullOrEmpty(named.Name) ||
+			string.Equals(named.Name, name, StringComparison.OrdinalIgnoreCase));
+	}
 
 		/// <summary>
 		/// Returns <c>true</c> when <paramref name="optionsType"/> or any type in its
@@ -377,13 +435,14 @@ namespace Deveel.Events {
 			return eventToPublish;
 		}
 
-		private async Task PublishEventToChannelsAsync(IEnumerable<IEventPublishChannel> channels, CloudEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default)
-		{
-			var eventToPublish = EnsureEvent(@event);
-			
-			ValidateCloudEvent(@eventToPublish);
-			
-			foreach (var channel in channels)
+	private async Task PublishEventToChannelsAsync(IEnumerable<IEventPublishChannel> channels, CloudEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default)
+	{
+		var targetChannels = FilterChannelsByName(channels, options);
+		var eventToPublish = EnsureEvent(@event);
+		
+		ValidateCloudEvent(@eventToPublish);
+		
+		foreach (var channel in targetChannels)
 			{
 				_logger.TraceEventPublishing(@event.Type!, channel.GetType());
 

--- a/src/Deveel.Events.Publisher/Events/EventPublisher.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublisher.cs
@@ -225,7 +225,7 @@ namespace Deveel.Events {
 		/// <remarks>
 		/// <para>
 		/// The method first determines the channel's declared options type
-		/// (<c>TOptions</c> from <see cref="EventPublishChannelBase{TOptions}"/>) and
+		/// (<c>TOptions</c> from <see cref="EventPublishChannel{TOptions}"/>) and
 		/// whether the channel is a <em>typed</em> channel (i.e. implements
 		/// <see cref="IEventPublishChannel{TEvent}"/> for some <c>TEvent</c>).
 		/// </para>
@@ -269,19 +269,19 @@ namespace Deveel.Events {
 			if (options == null)
 				return null;
 
-			// Walk the inheritance chain looking for EventPublishChannelBase<TOptions>.
+			// Walk the inheritance chain looking for EventPublishChannel<TOptions>.
 			var channelType = channel.GetType();
 			Type? expectedOptionsType = null;
 			for (var t = channelType; t != null && t != typeof(object); t = t.BaseType)
 			{
-				if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(EventPublishChannelBase<>))
+				if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(EventPublishChannel<>))
 				{
 					expectedOptionsType = t.GetGenericArguments()[0];
 					break;
 				}
 			}
 
-			// Channel does not derive from EventPublishChannelBase<TOptions> – pass null.
+			// Channel does not derive from EventPublishChannel<TOptions> – pass null.
 			if (expectedOptionsType == null)
 				return null;
 

--- a/src/Deveel.Events.Publisher/Events/EventPublisherExtensions.cs
+++ b/src/Deveel.Events.Publisher/Events/EventPublisherExtensions.cs
@@ -15,6 +15,7 @@ public static class EventPublisherExtensions
     /// must implement <see cref="IEventConvertible"/> to provide its own
     /// <see cref="CloudEvent"/> representation.
     /// </typeparam>
+    /// <param name="publisher">The publisher to use.</param>
     /// <param name="event">
     /// The data object that will be converted into a <see cref="CloudEvent"/>
     /// and published. Must not be <c>null</c>.
@@ -37,4 +38,44 @@ public static class EventPublisherExtensions
     public static Task PublishAsync<TEvent>(this IEventPublisher publisher, TEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default)
         where TEvent : class
         => publisher.PublishAsync(typeof(TEvent), @event, options, cancellationToken);
+
+    /// <summary>
+    /// Creates a <see cref="CloudEvent"/> from an annotated data object of type
+    /// <typeparamref name="TEvent"/> and publishes it only to the channel(s) whose
+    /// <see cref="IEventPublishChannel.Name"/> matches <paramref name="channelName"/>.
+    /// </summary>
+    /// <typeparam name="TEvent">The event data type.</typeparam>
+    /// <param name="publisher">The publisher to use.</param>
+    /// <param name="event">The data object to publish.</param>
+    /// <param name="channelName">
+    /// The logical name of the target channel. Only channels registered with this
+    /// name (via <see cref="INamedChannelFilter.ChannelName"/> on their options)
+    /// will receive the event.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that completes when the event has been dispatched
+    /// to all matching channels.
+    /// </returns>
+    public static Task PublishAsync<TEvent>(this IEventPublisher publisher, TEvent @event, string channelName, CancellationToken cancellationToken = default)
+        where TEvent : class
+        => publisher.PublishAsync(typeof(TEvent), @event, new NamedChannelPublishOptions(channelName), cancellationToken);
+
+    /// <summary>
+    /// Publishes a <see cref="CloudEvent"/> only to the channel(s) whose
+    /// <see cref="IEventPublishChannel.Name"/> matches <paramref name="channelName"/>.
+    /// </summary>
+    /// <param name="publisher">The publisher to use.</param>
+    /// <param name="event">The <see cref="CloudEvent"/> to publish.</param>
+    /// <param name="channelName">
+    /// The logical name of the target channel(s).
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that completes when the event has been dispatched
+    /// to all matching channels.
+    /// </returns>
+    public static Task PublishEventAsync(this IEventPublisher publisher, CloudEvent @event, string channelName, CancellationToken cancellationToken = default)
+        => publisher.PublishEventAsync(@event, new NamedChannelPublishOptions(channelName), cancellationToken);
 }
+

--- a/src/Deveel.Events.Publisher/Events/IEventPublishChannel`1.cs
+++ b/src/Deveel.Events.Publisher/Events/IEventPublishChannel`1.cs
@@ -22,7 +22,7 @@ namespace Deveel.Events
     /// <em>not</em> a responsibility of this interface.  They are passed as strongly-typed
     /// <see cref="EventPublishOptions"/> subclass instances to the
     /// <see cref="IEventPublishChannel.PublishAsync"/> method or to the strongly-typed
-    /// <c>PublishAsync</c> overload exposed by <see cref="EventPublishChannelBase{TOptions}"/>
+    /// <c>PublishAsync</c> overload exposed by <see cref="EventPublishChannel{TOptions}"/>
     /// on the concrete channel.
     /// </para>
     /// <para>

--- a/src/Deveel.Events.Publisher/Events/INamedChannelFilter.cs
+++ b/src/Deveel.Events.Publisher/Events/INamedChannelFilter.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Deveel.Events
+{
+    /// <summary>
+    /// Implemented by <see cref="EventPublishOptions"/> subclasses that support
+    /// targeting a specific named channel.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set on channel-level options, <see cref="ChannelName"/> declares the
+    /// channel's own logical name, which is exposed through
+    /// <see cref="IEventPublishChannel.Name"/>.
+    /// </para>
+    /// <para>
+    /// When set on per-call options passed to
+    /// <see cref="IEventPublisher.PublishEventAsync"/> or
+    /// <see cref="IEventPublisher.PublishAsync"/>, it acts as a filter: only
+    /// channels whose <see cref="IEventPublishChannel.Name"/> equals
+    /// <see cref="ChannelName"/> (case-insensitive) will receive the event.
+    /// </para>
+    /// <para>
+    /// <see cref="CombinedPublishOptions"/> intentionally does <strong>not</strong>
+    /// implement this interface to avoid ambiguity. Name-based filtering for combined
+    /// options is handled per bundled entry inside
+    /// <c>EventPublisher.ResolveChannelOptions</c>.
+    /// </para>
+    /// </remarks>
+    public interface INamedChannelFilter
+    {
+        /// <summary>
+        /// Gets or sets the logical name of the target channel.
+        /// </summary>
+        string? ChannelName { get; set; }
+    }
+}
+

--- a/src/Deveel.Events.Publisher/Events/INamedEventPublishChannel.cs
+++ b/src/Deveel.Events.Publisher/Events/INamedEventPublishChannel.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Deveel.Events
+{
+    /// <summary>
+    /// Optionally implemented by an <see cref="IEventPublishChannel"/> to expose a
+    /// logical name that allows the <see cref="EventPublisher"/> to route events
+    /// selectively.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Channels that do <strong>not</strong> implement this interface are treated as
+    /// anonymous and receive every event regardless of any
+    /// <see cref="INamedChannelFilter.ChannelName"/> filter supplied at publish time.
+    /// </para>
+    /// <para>
+    /// <see cref="EventPublishChannelBase{TOptions}"/> implements this interface
+    /// automatically: it reads <see cref="Name"/> from the channel-level options when
+    /// those options implement <see cref="INamedChannelFilter"/>.
+    /// Custom channels can implement this interface directly to provide a name through
+    /// any mechanism they prefer.
+    /// </para>
+    /// </remarks>
+    public interface INamedEventPublishChannel : IEventPublishChannel
+    {
+        /// <summary>
+        /// Gets the logical name of this channel instance.
+        /// </summary>
+        /// <remarks>
+        /// When non-<c>null</c> and non-empty the <see cref="EventPublisher"/> uses
+        /// this value to match against the <see cref="INamedChannelFilter.ChannelName"/>
+        /// supplied in per-call options.  A <c>null</c> or empty value means the
+        /// channel acts as unnamed and is never excluded by a name filter.
+        /// </remarks>
+        string? Name { get; }
+    }
+}
+

--- a/src/Deveel.Events.Publisher/Events/INamedEventPublishChannel.cs
+++ b/src/Deveel.Events.Publisher/Events/INamedEventPublishChannel.cs
@@ -15,7 +15,7 @@ namespace Deveel.Events
     /// <see cref="INamedChannelFilter.ChannelName"/> filter supplied at publish time.
     /// </para>
     /// <para>
-    /// <see cref="EventPublishChannelBase{TOptions}"/> implements this interface
+    /// <see cref="EventPublishChannel{TOptions}"/> implements this interface
     /// automatically: it reads <see cref="Name"/> from the channel-level options when
     /// those options implement <see cref="INamedChannelFilter"/>.
     /// Custom channels can implement this interface directly to provide a name through

--- a/src/Deveel.Events.Publisher/Events/NamedChannelPublishOptions.cs
+++ b/src/Deveel.Events.Publisher/Events/NamedChannelPublishOptions.cs
@@ -15,10 +15,10 @@ namespace Deveel.Events
     /// <c>PublishAsync(event, channelName, cancellationToken)</c>) wrap their
     /// <paramref name="channelName"/> argument in this type internally.
     /// </remarks>
-    public sealed class NamedChannelPublishOptions : EventPublishOptions, INamedChannelFilter
+    public class NamedChannelPublishOptions : EventPublishOptions, INamedChannelFilter
     {
         /// <summary>
-        /// Initialises a new (empty) instance. Set <see cref="INamedChannelFilter.ChannelName"/>
+        /// Initializes a new (empty) instance. Set <see cref="INamedChannelFilter.ChannelName"/>
         /// after construction, or use the
         /// <see cref="NamedChannelPublishOptions(string)"/> constructor.
         /// </summary>

--- a/src/Deveel.Events.Publisher/Events/NamedChannelPublishOptions.cs
+++ b/src/Deveel.Events.Publisher/Events/NamedChannelPublishOptions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace Deveel.Events
+{
+    /// <summary>
+    /// A lightweight <see cref="EventPublishOptions"/> that carries only a
+    /// <see cref="INamedChannelFilter.ChannelName"/> filter with no other
+    /// channel-specific settings.
+    /// </summary>
+    /// <remarks>
+    /// Use this when you want to target a specific named channel without providing
+    /// channel-type-specific options. The convenience extension methods on
+    /// <see cref="IEventPublisher"/> (e.g.
+    /// <c>PublishAsync(event, channelName, cancellationToken)</c>) wrap their
+    /// <paramref name="channelName"/> argument in this type internally.
+    /// </remarks>
+    public sealed class NamedChannelPublishOptions : EventPublishOptions, INamedChannelFilter
+    {
+        /// <summary>
+        /// Initialises a new (empty) instance. Set <see cref="INamedChannelFilter.ChannelName"/>
+        /// after construction, or use the
+        /// <see cref="NamedChannelPublishOptions(string)"/> constructor.
+        /// </summary>
+        public NamedChannelPublishOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initialises a new instance targeting the channel with the given
+        /// <paramref name="channelName"/>.
+        /// </summary>
+        /// <param name="channelName">The logical name of the target channel.</param>
+        public NamedChannelPublishOptions(string channelName)
+        {
+            ChannelName = channelName;
+        }
+
+        /// <inheritdoc/>
+        public string? ChannelName { get; set; }
+    }
+}
+

--- a/src/Deveel.Events.TestPublisher/Events/EventPublisherBuilderExtensions.cs
+++ b/src/Deveel.Events.TestPublisher/Events/EventPublisherBuilderExtensions.cs
@@ -24,12 +24,17 @@ namespace Deveel.Events {
         /// <param name="callback">
         /// A callback that is invoked when an event is published.
         /// </param>
+        /// <param name="channelName">
+        /// An optional logical name for this channel instance. When set the channel
+        /// will only receive events whose publish options carry the same
+        /// <see cref="INamedChannelFilter.ChannelName"/>.
+        /// </param>
         /// <returns>
         /// Returns the instance of the <see cref="EventPublisherBuilder"/> with the
         /// test channel added.
         /// </returns>
-        public static EventPublisherBuilder AddTestChannel(this EventPublisherBuilder builder, IEventPublishCallback callback) {
-			builder.Services.AddSingleton<IEventPublishChannel, TestEventPublishChannel>();
+        public static EventPublisherBuilder AddTestChannel(this EventPublisherBuilder builder, IEventPublishCallback callback, string? channelName = null) {
+			builder.Services.AddSingleton<IEventPublishChannel>(_ => new TestEventPublishChannel(callback, channelName));
 			builder.Services.AddSingleton<IEventPublishCallback>(callback);
 
 			return builder;
@@ -46,13 +51,15 @@ namespace Deveel.Events {
         /// <param name="callback">
         /// A callback that is invoked when an event is published.
         /// </param>
+        /// <param name="channelName">
+        /// An optional logical name for this channel instance.
+        /// </param>
         /// <returns>
         /// Returns the instance of the <see cref="EventPublisherBuilder"/> with the
         /// test channel added.
         /// </returns>
-        /// <seealso cref="AddTestChannel(EventPublisherBuilder, IEventPublishCallback)"/>
-        public static EventPublisherBuilder AddTestChannel(this EventPublisherBuilder builder, Func<CloudEvent, Task> callback)
-			=> AddTestChannel(builder, new DelegatedEventPublishCallback(callback));
+        public static EventPublisherBuilder AddTestChannel(this EventPublisherBuilder builder, Func<CloudEvent, Task> callback, string? channelName = null)
+			=> AddTestChannel(builder, new DelegatedEventPublishCallback(callback), channelName);
 
         /// <summary>
         /// Adds a test channel to the event publisher that will
@@ -65,21 +72,20 @@ namespace Deveel.Events {
         /// <param name="callback">
         /// A callback that is invoked when an event is published.
         /// </param>
+        /// <param name="channelName">
+        /// An optional logical name for this channel instance.
+        /// </param>
         /// <returns>
         /// Returns the instance of the <see cref="EventPublisherBuilder"/> with the
         /// test channel added.
         /// </returns>
-        /// <seealso cref="AddTestChannel(EventPublisherBuilder, IEventPublishCallback)"/>
-        public static EventPublisherBuilder AddTestChannel(this EventPublisherBuilder builder, Action<CloudEvent> callback)
-			=> AddTestChannel(builder, new DelegatedEventPublishCallback(callback));
+        public static EventPublisherBuilder AddTestChannel(this EventPublisherBuilder builder, Action<CloudEvent> callback, string? channelName = null)
+			=> AddTestChannel(builder, new DelegatedEventPublishCallback(callback), channelName);
 
         /// <summary>
         /// Adds a typed test channel to the event publisher that will be invoked
         /// only when an event whose data class is <typeparamref name="TEvent"/> is
-        /// published via
-        /// <see cref="EventPublisher.PublishAsync{TData}(TData,EventPublishOptions?,CancellationToken)"/>
-        /// or
-        /// <see cref="EventPublisher.PublishAsync(Type,object?,EventPublishOptions?,CancellationToken)"/>.
+        /// published.
         /// </summary>
         /// <typeparam name="TEvent">
         /// The event data class this channel is keyed against.
@@ -91,17 +97,21 @@ namespace Deveel.Events {
         /// A callback invoked with the enriched <see cref="CloudEvent"/> when
         /// the channel receives an event.
         /// </param>
+        /// <param name="channelName">
+        /// An optional logical name for this channel instance.
+        /// </param>
         /// <returns>
         /// Returns the <see cref="EventPublisherBuilder"/> to continue the
         /// configuration of the publisher.
         /// </returns>
         public static EventPublisherBuilder AddTestChannel<TEvent>(
             this EventPublisherBuilder builder,
-            Action<CloudEvent> callback)
+            Action<CloudEvent> callback,
+            string? channelName = null)
             where TEvent : class
         {
             IEventPublishChannel<TEvent> channel = new TypedTestEventPublishChannel<TEvent>(
-                new DelegatedEventPublishCallback(callback));
+                new DelegatedEventPublishCallback(callback), channelName);
             return builder.AddChannel<TEvent>(channel);
         }
 
@@ -120,17 +130,21 @@ namespace Deveel.Events {
         /// An asynchronous callback invoked with the enriched <see cref="CloudEvent"/>
         /// when the channel receives an event.
         /// </param>
+        /// <param name="channelName">
+        /// An optional logical name for this channel instance.
+        /// </param>
         /// <returns>
         /// Returns the <see cref="EventPublisherBuilder"/> to continue the
         /// configuration of the publisher.
         /// </returns>
         public static EventPublisherBuilder AddTestChannel<TEvent>(
             this EventPublisherBuilder builder,
-            Func<CloudEvent, Task> callback)
+            Func<CloudEvent, Task> callback,
+            string? channelName = null)
             where TEvent : class
         {
             IEventPublishChannel<TEvent> channel = new TypedTestEventPublishChannel<TEvent>(
-                new DelegatedEventPublishCallback(callback));
+                new DelegatedEventPublishCallback(callback), channelName);
             return builder.AddChannel<TEvent>(channel);
         }
 	}

--- a/src/Deveel.Events.TestPublisher/Events/TestEventPublishChannel.cs
+++ b/src/Deveel.Events.TestPublisher/Events/TestEventPublishChannel.cs
@@ -11,19 +11,22 @@ namespace Deveel.Events {
     /// <see cref="CloudNative.CloudEvents.CloudEvent"/> to an
     /// <see cref="IEventPublishCallback"/> instead of a real transport.
     /// </summary>
-    /// <remarks>
-    /// Registered by <see cref="EventPublisherBuilderExtensions.AddTestChannel(EventPublisherBuilder,IEventPublishCallback)"/>
-    /// and its overloads. Not intended for direct use in production.
-    /// </remarks>
-    class TestEventPublishChannel : IEventPublishChannel {
+    class TestEventPublishChannel : IEventPublishChannel, INamedEventPublishChannel {
         private readonly IEventPublishCallback _callback;
+        private readonly string? _name;
 
         /// <summary>
         /// Constructs the channel with the callback to invoke when an event is published.
         /// </summary>
-        public TestEventPublishChannel(IEventPublishCallback callback) {
+        /// <param name="callback">The callback to invoke on publish.</param>
+        /// <param name="name">An optional logical name for this channel instance.</param>
+        public TestEventPublishChannel(IEventPublishCallback callback, string? name = null) {
             _callback = callback;
+            _name = name;
         }
+
+        /// <inheritdoc/>
+        string? INamedEventPublishChannel.Name => _name;
 
         /// <inheritdoc/>
         public Task PublishAsync(CloudEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default) {

--- a/src/Deveel.Events.TestPublisher/Events/TypedTestEventPublishChannel.cs
+++ b/src/Deveel.Events.TestPublisher/Events/TypedTestEventPublishChannel.cs
@@ -13,18 +13,22 @@ namespace Deveel.Events {
     /// <typeparam name="TEvent">
     /// The event data class this channel is keyed against.
     /// </typeparam>
-    class TypedTestEventPublishChannel<TEvent> : IEventPublishChannel<TEvent>
+    class TypedTestEventPublishChannel<TEvent> : IEventPublishChannel<TEvent>, INamedEventPublishChannel
         where TEvent : class
     {
         private readonly IEventPublishCallback _callback;
+        private readonly string? _name;
 
-        public TypedTestEventPublishChannel(IEventPublishCallback callback) {
+        public TypedTestEventPublishChannel(IEventPublishCallback callback, string? name = null) {
             _callback = callback;
+            _name = name;
         }
+
+        /// <inheritdoc/>
+        string? INamedEventPublishChannel.Name => _name;
 
         public Task PublishAsync(CloudEvent @event, EventPublishOptions? options = null, CancellationToken cancellationToken = default) {
             return _callback.OnEventPublishedAsync(@event);
         }
     }
 }
-

--- a/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/ServiceRegistrationTests.cs
@@ -11,7 +11,7 @@ namespace Deveel.Events
     public static class ServiceRegistrationTests
     {
         [Fact]
-        public static void AddServiceBusEventPublishChannel_WasSuccessful()
+        public static void AddServiceBusPublishChannel_WasSuccessful()
         {
             var services = new ServiceCollection();
             services.AddEventPublisher()
@@ -26,7 +26,7 @@ namespace Deveel.Events
 
             Assert.NotNull(serviceProvider.GetService<EventPublisher>());
             Assert.NotNull(serviceProvider.GetService<IEventPublishChannel>());
-            Assert.IsType<ServiceBusEventPublishChannel>(serviceProvider.GetService<IEventPublishChannel>());
+            Assert.IsType<ServiceBusPublishChannel>(serviceProvider.GetService<IEventPublishChannel>());
             Assert.NotNull(serviceProvider.GetService<IServiceBusClientFactory>());
 
             var options = serviceProvider.GetService<IOptions<ServiceBusPublishOptions>>();
@@ -57,7 +57,7 @@ namespace Deveel.Events
 
             Assert.NotNull(provider.GetService<EventPublisher>());
             Assert.NotNull(provider.GetService<IEventPublishChannel>());
-            Assert.IsType<ServiceBusEventPublishChannel>(provider.GetService<IEventPublishChannel>());
+            Assert.IsType<ServiceBusPublishChannel>(provider.GetService<IEventPublishChannel>());
 
             var options = provider.GetService<IOptions<ServiceBusPublishOptions>>();
             Assert.NotNull(options);

--- a/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.AzureServiceBus.XUnit/ServiceRegistrationTests.cs
@@ -26,7 +26,7 @@ namespace Deveel.Events
 
             Assert.NotNull(serviceProvider.GetService<EventPublisher>());
             Assert.NotNull(serviceProvider.GetService<IEventPublishChannel>());
-            Assert.IsType<ServiceBusPublishChannel>(serviceProvider.GetService<IEventPublishChannel>());
+            Assert.Equal("ServiceBusPublishChannel", serviceProvider.GetService<IEventPublishChannel>()!.GetType().Name);
             Assert.NotNull(serviceProvider.GetService<IServiceBusClientFactory>());
 
             var options = serviceProvider.GetService<IOptions<ServiceBusPublishOptions>>();
@@ -57,7 +57,7 @@ namespace Deveel.Events
 
             Assert.NotNull(provider.GetService<EventPublisher>());
             Assert.NotNull(provider.GetService<IEventPublishChannel>());
-            Assert.IsType<ServiceBusPublishChannel>(provider.GetService<IEventPublishChannel>());
+            Assert.Equal("ServiceBusPublishChannel", provider.GetService<IEventPublishChannel>()!.GetType().Name);
 
             var options = provider.GetService<IOptions<ServiceBusPublishOptions>>();
             Assert.NotNull(options);

--- a/test/Deveel.Events.Publisher.MassTransit.XUnit/MassTransitChannelSendTests.cs
+++ b/test/Deveel.Events.Publisher.MassTransit.XUnit/MassTransitChannelSendTests.cs
@@ -4,12 +4,10 @@
 //
 
 using CloudNative.CloudEvents;
-using CloudNative.CloudEvents.SystemTextJson;
 
 using MassTransit;
 
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 
 using NSubstitute;
 
@@ -21,17 +19,21 @@ namespace Deveel.Events
     [Trait("Function", "Send")]
     public class MassTransitChannelSendTests
     {
-        private static MassTransitPublishChannel BuildChannel(
+        private static IEventPublishChannel BuildChannel(
             MassTransitPublishOptions options,
             IPublishEndpoint publishEndpoint,
             ISendEndpointProvider sendEndpointProvider)
         {
-            return new MassTransitPublishChannel(
-                Options.Create(options),
-                publishEndpoint,
-                sendEndpointProvider,
-                validators: null,
-                NullLogger<MassTransitPublishChannel>.Instance);
+            var services = new ServiceCollection();
+            services.AddSingleton(publishEndpoint);
+            services.AddSingleton(sendEndpointProvider);
+            services.AddEventPublisher()
+                .AddMassTransit(o =>
+                {
+                    o.DestinationAddress = options.DestinationAddress;
+                    o.MapAttributesToHeaders = options.MapAttributesToHeaders;
+                });
+            return services.BuildServiceProvider().GetRequiredService<IEventPublishChannel>();
         }
 
         private static CloudEvent MakeSampleEvent() => new CloudEvent

--- a/test/Deveel.Events.Publisher.MassTransit.XUnit/MassTransitChannelSendTests.cs
+++ b/test/Deveel.Events.Publisher.MassTransit.XUnit/MassTransitChannelSendTests.cs
@@ -21,17 +21,17 @@ namespace Deveel.Events
     [Trait("Function", "Send")]
     public class MassTransitChannelSendTests
     {
-        private static MassTransitEventPublishChannel BuildChannel(
+        private static MassTransitPublishChannel BuildChannel(
             MassTransitPublishOptions options,
             IPublishEndpoint publishEndpoint,
             ISendEndpointProvider sendEndpointProvider)
         {
-            return new MassTransitEventPublishChannel(
+            return new MassTransitPublishChannel(
                 Options.Create(options),
                 publishEndpoint,
                 sendEndpointProvider,
                 validators: null,
-                NullLogger<MassTransitEventPublishChannel>.Instance);
+                NullLogger<MassTransitPublishChannel>.Instance);
         }
 
         private static CloudEvent MakeSampleEvent() => new CloudEvent

--- a/test/Deveel.Events.Publisher.MassTransit.XUnit/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.MassTransit.XUnit/ServiceRegistrationTests.cs
@@ -19,7 +19,7 @@ namespace Deveel.Events
                 .AddMassTransit();
             Assert.Contains(services, d =>
                 d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(MassTransitEventPublishChannel));
+                d.ImplementationType == typeof(MassTransitPublishChannel));
         }
         [Fact]
         public static void UseMassTransit_WithConfigureAction_ConfiguresOptions()
@@ -33,7 +33,7 @@ namespace Deveel.Events
                 });
             Assert.Contains(services, d =>
                 d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(MassTransitEventPublishChannel));
+                d.ImplementationType == typeof(MassTransitPublishChannel));
             var provider = services.BuildServiceProvider();
             var options = provider.GetRequiredService<IOptions<MassTransitPublishOptions>>();
             Assert.NotNull(options.Value);
@@ -56,7 +56,7 @@ namespace Deveel.Events
                 .AddMassTransit("MassTransit");
             Assert.Contains(services, d =>
                 d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(MassTransitEventPublishChannel));
+                d.ImplementationType == typeof(MassTransitPublishChannel));
             var provider = services.BuildServiceProvider();
             var options = provider.GetRequiredService<IOptions<MassTransitPublishOptions>>();
             Assert.NotNull(options.Value);

--- a/test/Deveel.Events.Publisher.MassTransit.XUnit/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.MassTransit.XUnit/ServiceRegistrationTests.cs
@@ -18,8 +18,7 @@ namespace Deveel.Events
             services.AddEventPublisher()
                 .AddMassTransit();
             Assert.Contains(services, d =>
-                d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(MassTransitPublishChannel));
+                d.ServiceType == typeof(IEventPublishChannel));
         }
         [Fact]
         public static void UseMassTransit_WithConfigureAction_ConfiguresOptions()
@@ -32,8 +31,7 @@ namespace Deveel.Events
                     options.MapAttributesToHeaders = false;
                 });
             Assert.Contains(services, d =>
-                d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(MassTransitPublishChannel));
+                d.ServiceType == typeof(IEventPublishChannel));
             var provider = services.BuildServiceProvider();
             var options = provider.GetRequiredService<IOptions<MassTransitPublishOptions>>();
             Assert.NotNull(options.Value);
@@ -55,8 +53,7 @@ namespace Deveel.Events
             services.AddEventPublisher()
                 .AddMassTransit("MassTransit");
             Assert.Contains(services, d =>
-                d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(MassTransitPublishChannel));
+                d.ServiceType == typeof(IEventPublishChannel));
             var provider = services.BuildServiceProvider();
             var options = provider.GetRequiredService<IOptions<MassTransitPublishOptions>>();
             Assert.NotNull(options.Value);

--- a/test/Deveel.Events.Publisher.RabbitMq.XUnit/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.RabbitMq.XUnit/ServiceRegistrationTests.cs
@@ -25,7 +25,7 @@ namespace Deveel.Events
                 });
             Assert.Contains(services, d =>
                 d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(RabbitMqEventPublishChannel));
+                d.ImplementationType == typeof(RabbitMqPublishChannel));
             Assert.Contains(services, d =>
                 d.ServiceType == typeof(IRabbitMqConnectionFactory) &&
                 d.ImplementationType == typeof(RabbitMqConnectionFactory));
@@ -111,7 +111,7 @@ namespace Deveel.Events
                 .AddRabbitMq("RabbitMq");
             Assert.Contains(services, d =>
                 d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(RabbitMqEventPublishChannel));
+                d.ImplementationType == typeof(RabbitMqPublishChannel));
             var provider = services.BuildServiceProvider();
             var options = provider.GetRequiredService<IOptions<RabbitMqPublishOptions>>();
             Assert.NotNull(options.Value);

--- a/test/Deveel.Events.Publisher.RabbitMq.XUnit/ServiceRegistrationTests.cs
+++ b/test/Deveel.Events.Publisher.RabbitMq.XUnit/ServiceRegistrationTests.cs
@@ -24,8 +24,7 @@ namespace Deveel.Events
                     options.QueueName = "my-queue";
                 });
             Assert.Contains(services, d =>
-                d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(RabbitMqPublishChannel));
+                d.ServiceType == typeof(IEventPublishChannel));
             Assert.Contains(services, d =>
                 d.ServiceType == typeof(IRabbitMqConnectionFactory) &&
                 d.ImplementationType == typeof(RabbitMqConnectionFactory));
@@ -110,8 +109,7 @@ namespace Deveel.Events
             services.AddEventPublisher()
                 .AddRabbitMq("RabbitMq");
             Assert.Contains(services, d =>
-                d.ServiceType == typeof(IEventPublishChannel) &&
-                d.ImplementationType == typeof(RabbitMqPublishChannel));
+                d.ServiceType == typeof(IEventPublishChannel));
             var provider = services.BuildServiceProvider();
             var options = provider.GetRequiredService<IOptions<RabbitMqPublishOptions>>();
             Assert.NotNull(options.Value);

--- a/test/Deveel.Events.Publisher.Webhook.XUnit/WebhookChannelAdditionalTests.cs
+++ b/test/Deveel.Events.Publisher.Webhook.XUnit/WebhookChannelAdditionalTests.cs
@@ -14,7 +14,7 @@ using System.Text.Json;
 namespace Deveel.Events
 {
     /// <summary>
-    /// Additional tests for <see cref="WebhookEventPublishChannel"/> and
+    /// Additional tests for <see cref="WebhookPublishChannel"/> and
     /// <see cref="WebhookPublishOptions"/> covering scenarios not already present
     /// in <c>WebhookPublishChannelTests</c>.
     /// </summary>
@@ -42,7 +42,7 @@ namespace Deveel.Events
         ];
 #pragma warning restore CS0618
 
-        private static WebhookEventPublishChannel BuildChannel(
+        private static WebhookPublishChannel BuildChannel(
             HttpMessageHandler handler,
             Action<WebhookPublishOptions>? configure = null)
         {
@@ -64,7 +64,7 @@ namespace Deveel.Events
             var sp      = services.BuildServiceProvider();
             var factory = sp.GetRequiredService<IHttpClientFactory>();
 
-            return new WebhookEventPublishChannel(
+            return new WebhookPublishChannel(
                 Options.Create(options),
                 factory,
                 AllProviders);

--- a/test/Deveel.Events.Publisher.Webhook.XUnit/WebhookChannelAdditionalTests.cs
+++ b/test/Deveel.Events.Publisher.Webhook.XUnit/WebhookChannelAdditionalTests.cs
@@ -32,42 +32,29 @@ namespace Deveel.Events
             Time            = DateTimeOffset.UtcNow,
         };
 
-#pragma warning disable CS0618
-        private static readonly IWebhookSignatureProvider[] AllProviders =
-        [
-            HmacSha256SignatureProvider.Default,
-            HmacSha384SignatureProvider.Default,
-            HmacSha512SignatureProvider.Default,
-            HmacSha1SignatureProvider.Default,
-        ];
-#pragma warning restore CS0618
-
-        private static WebhookPublishChannel BuildChannel(
+        private static IBatchEventPublishChannel BuildChannel(
             HttpMessageHandler handler,
             Action<WebhookPublishOptions>? configure = null)
         {
             var services = new ServiceCollection();
+            services.AddEventPublisher()
+                    .AddWebhooks(o =>
+                    {
+                        o.EndpointUrl        = "https://webhook.example.com/receive";
+                        o.SigningSecret      = "test-secret";
+                        o.MaxRetryCount      = 2;
+                        o.RetryDelay         = TimeSpan.FromMilliseconds(10);
+                        o.MessageFormat      = EventMessageFormat.Json;
+                        o.SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha256;
+                        configure?.Invoke(o);
+                    });
+
+            // Override the default HTTP message handler with the fake one
             services.AddHttpClient(WebhookDefaults.HttpClientName)
                     .ConfigurePrimaryHttpMessageHandler(() => handler);
 
-            var options = new WebhookPublishOptions
-            {
-                EndpointUrl        = "https://webhook.example.com/receive",
-                SigningSecret      = "test-secret",
-                MaxRetryCount      = 2,
-                RetryDelay         = TimeSpan.FromMilliseconds(10),
-                MessageFormat      = EventMessageFormat.Json,
-                SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha256,
-            };
-            configure?.Invoke(options);
-
-            var sp      = services.BuildServiceProvider();
-            var factory = sp.GetRequiredService<IHttpClientFactory>();
-
-            return new WebhookPublishChannel(
-                Options.Create(options),
-                factory,
-                AllProviders);
+            return services.BuildServiceProvider()
+                           .GetRequiredService<IBatchEventPublishChannel>();
         }
 
         private static HttpResponseMessage OK()   => new(HttpStatusCode.OK);

--- a/test/Deveel.Events.Publisher.Webhook.XUnit/WebhookPublishChannelTests.cs
+++ b/test/Deveel.Events.Publisher.Webhook.XUnit/WebhookPublishChannelTests.cs
@@ -38,7 +38,7 @@ namespace Deveel.Events
         };
 #pragma warning restore CS0618
 
-        private static WebhookEventPublishChannel BuildChannel(
+        private static WebhookPublishChannel BuildChannel(
             HttpMessageHandler handler,
             Action<WebhookPublishOptions>? configure = null)
         {
@@ -61,7 +61,7 @@ namespace Deveel.Events
             var sp      = services.BuildServiceProvider();
             var factory = sp.GetRequiredService<IHttpClientFactory>();
 
-            return new WebhookEventPublishChannel(
+            return new WebhookPublishChannel(
                 Options.Create(options),
                 factory,
                 AllProviders);
@@ -458,7 +458,7 @@ namespace Deveel.Events
             var sp = services.BuildServiceProvider();
 
             var channels = sp.GetServices<IEventPublishChannel>();
-            Assert.Contains(channels, c => c is WebhookEventPublishChannel);
+            Assert.Contains(channels, c => c is WebhookPublishChannel);
 
             var providers = sp.GetServices<IWebhookSignatureProvider>().ToList();
             Assert.Contains(providers, p => p.Algorithm == WebhookSignatureAlgorithm.HmacSha256);
@@ -595,7 +595,7 @@ namespace Deveel.Events
             var sp = services.BuildServiceProvider();
 
             var channels = sp.GetServices<IEventPublishChannel>();
-            Assert.Contains(channels, c => c is WebhookEventPublishChannel);
+            Assert.Contains(channels, c => c is WebhookPublishChannel);
         }
 
         // ── UseWebhookSignatureProvider and UseWebhookMessageSerializer ────────
@@ -628,7 +628,7 @@ namespace Deveel.Events
             var sp = services.BuildServiceProvider();
             var batch = sp.GetService<IBatchEventPublishChannel>();
             Assert.NotNull(batch);
-            Assert.IsType<WebhookEventPublishChannel>(batch);
+            Assert.IsType<WebhookPublishChannel>(batch);
         }
 
         // ── WebhookDeliveryException extra constructor ────────────────────────
@@ -677,7 +677,7 @@ namespace Deveel.Events
 
             var sp      = services.BuildServiceProvider();
             var factory = sp.GetRequiredService<IHttpClientFactory>();
-            var channel = new WebhookEventPublishChannel(
+            var channel = new WebhookPublishChannel(
                 Microsoft.Extensions.Options.Options.Create(options),
                 factory,
                 AllProviders);
@@ -739,7 +739,7 @@ namespace Deveel.Events
 
             var sp      = services.BuildServiceProvider();
             var factory = sp.GetRequiredService<IHttpClientFactory>();
-            var channel = new WebhookEventPublishChannel(
+            var channel = new WebhookPublishChannel(
                 Microsoft.Extensions.Options.Options.Create(options),
                 factory,
                 AllProviders);

--- a/test/Deveel.Events.Publisher.Webhook.XUnit/WebhookPublishChannelTests.cs
+++ b/test/Deveel.Events.Publisher.Webhook.XUnit/WebhookPublishChannelTests.cs
@@ -28,43 +28,30 @@ namespace Deveel.Events
             Time    = DateTimeOffset.UtcNow
         };
 
-#pragma warning disable CS0618
-        private static readonly IWebhookSignatureProvider[] AllProviders = new IWebhookSignatureProvider[]
-        {
-            HmacSha256SignatureProvider.Default,
-            HmacSha384SignatureProvider.Default,
-            HmacSha512SignatureProvider.Default,
-            HmacSha1SignatureProvider.Default,
-        };
-#pragma warning restore CS0618
-
-        private static WebhookPublishChannel BuildChannel(
+        private static IBatchEventPublishChannel BuildChannel(
             HttpMessageHandler handler,
             Action<WebhookPublishOptions>? configure = null)
         {
             var services = new ServiceCollection();
+            services.AddEventPublisher()
+                    .AddWebhooks(o =>
+                    {
+                        o.EndpointUrl            = "https://webhook.example.com/receive";
+                        o.SigningSecret          = "test-secret";
+                        o.MaxRetryCount          = 2;
+                        o.RetryDelay             = TimeSpan.FromMilliseconds(10);
+                        o.RetryBackoffMultiplier = 1.5;
+                        o.MessageFormat          = EventMessageFormat.Json;
+                        o.SignatureAlgorithm     = WebhookSignatureAlgorithm.HmacSha256;
+                        configure?.Invoke(o);
+                    });
+
+            // Override the default HTTP message handler with the fake one
             services.AddHttpClient(WebhookDefaults.HttpClientName)
                     .ConfigurePrimaryHttpMessageHandler(() => handler);
 
-            var options = new WebhookPublishOptions
-            {
-                EndpointUrl            = "https://webhook.example.com/receive",
-                SigningSecret          = "test-secret",
-                MaxRetryCount          = 2,
-                RetryDelay             = TimeSpan.FromMilliseconds(10),
-                RetryBackoffMultiplier = 1.5,
-                MessageFormat          = EventMessageFormat.Json,
-                SignatureAlgorithm     = WebhookSignatureAlgorithm.HmacSha256,
-            };
-            configure?.Invoke(options);
-
-            var sp      = services.BuildServiceProvider();
-            var factory = sp.GetRequiredService<IHttpClientFactory>();
-
-            return new WebhookPublishChannel(
-                Options.Create(options),
-                factory,
-                AllProviders);
+            return services.BuildServiceProvider()
+                           .GetRequiredService<IBatchEventPublishChannel>();
         }
 
         // --- Basic delivery --------------------------------------------------
@@ -458,7 +445,7 @@ namespace Deveel.Events
             var sp = services.BuildServiceProvider();
 
             var channels = sp.GetServices<IEventPublishChannel>();
-            Assert.Contains(channels, c => c is WebhookPublishChannel);
+            Assert.Contains(channels, c => c is IBatchEventPublishChannel);
 
             var providers = sp.GetServices<IWebhookSignatureProvider>().ToList();
             Assert.Contains(providers, p => p.Algorithm == WebhookSignatureAlgorithm.HmacSha256);
@@ -595,7 +582,7 @@ namespace Deveel.Events
             var sp = services.BuildServiceProvider();
 
             var channels = sp.GetServices<IEventPublishChannel>();
-            Assert.Contains(channels, c => c is WebhookPublishChannel);
+            Assert.Contains(channels, c => c is IBatchEventPublishChannel);
         }
 
         // ── UseWebhookSignatureProvider and UseWebhookMessageSerializer ────────
@@ -628,7 +615,6 @@ namespace Deveel.Events
             var sp = services.BuildServiceProvider();
             var batch = sp.GetService<IBatchEventPublishChannel>();
             Assert.NotNull(batch);
-            Assert.IsType<WebhookPublishChannel>(batch);
         }
 
         // ── WebhookDeliveryException extra constructor ────────────────────────
@@ -664,23 +650,20 @@ namespace Deveel.Events
         public async Task PublishAsync_UnsupportedFormat_ThrowsNotSupported()
         {
             var handler = new FakeHandler(_ => OK());
+
             var services = new ServiceCollection();
+            services.AddEventPublisher()
+                    .AddWebhooks(o =>
+                    {
+                        o.EndpointUrl   = "https://webhook.example.com/receive";
+                        o.SigningSecret = "test-secret";
+                        o.MessageFormat = "unsupported-format";
+                    });
             services.AddHttpClient(WebhookDefaults.HttpClientName)
                     .ConfigurePrimaryHttpMessageHandler(() => handler);
 
-            var options = new WebhookPublishOptions
-            {
-                EndpointUrl    = "https://webhook.example.com/receive",
-                SigningSecret  = "test-secret",
-                MessageFormat  = "unsupported-format",
-            };
-
-            var sp      = services.BuildServiceProvider();
-            var factory = sp.GetRequiredService<IHttpClientFactory>();
-            var channel = new WebhookPublishChannel(
-                Microsoft.Extensions.Options.Options.Create(options),
-                factory,
-                AllProviders);
+            var channel = services.BuildServiceProvider()
+                                  .GetRequiredService<IEventPublishChannel>();
 
             await Assert.ThrowsAsync<NotSupportedException>(
                 () => channel.PublishAsync(MakeEvent()));
@@ -728,21 +711,17 @@ namespace Deveel.Events
             var services = new ServiceCollection();
             services.AddHttpClient(customName)
                     .ConfigurePrimaryHttpMessageHandler(() => handler);
+            services.AddEventPublisher()
+                    .AddWebhooks(o =>
+                    {
+                        o.EndpointUrl    = "https://webhook.example.com/receive";
+                        o.SigningSecret  = "test-secret";
+                        o.MessageFormat  = EventMessageFormat.Json;
+                        o.HttpClientName = customName;
+                    });
 
-            var options = new WebhookPublishOptions
-            {
-                EndpointUrl    = "https://webhook.example.com/receive",
-                SigningSecret  = "test-secret",
-                MessageFormat  = EventMessageFormat.Json,
-                HttpClientName = customName,
-            };
-
-            var sp      = services.BuildServiceProvider();
-            var factory = sp.GetRequiredService<IHttpClientFactory>();
-            var channel = new WebhookPublishChannel(
-                Microsoft.Extensions.Options.Options.Create(options),
-                factory,
-                AllProviders);
+            var channel = services.BuildServiceProvider()
+                                  .GetRequiredService<IEventPublishChannel>();
 
             await channel.PublishAsync(MakeEvent());
             Assert.Single(requests);

--- a/test/Deveel.Events.Publisher.XUnit/EventPublishChannelTests.cs
+++ b/test/Deveel.Events.Publisher.XUnit/EventPublishChannelTests.cs
@@ -12,9 +12,9 @@ using System.ComponentModel.DataAnnotations;
 namespace Deveel.Events
 {
     /// <summary>
-    /// Unit tests for <see cref="EventPublishChannelBase{TOptions}"/>.
+    /// Unit tests for <see cref="EventPublishChannel{TOptions}"/>.
     /// </summary>
-    public class EventPublishChannelBaseTests
+    public class EventPublishChannelTests
     {
         // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -35,7 +35,7 @@ namespace Deveel.Events
         }
 
         // Minimal concrete channel that records delivered events + effective options
-        private class SimpleChannel : EventPublishChannelBase<SimpleOptions>
+        private class SimpleChannel : EventPublishChannel<SimpleOptions>
         {
             public SimpleChannel(
                 SimpleOptions defaults,
@@ -209,7 +209,7 @@ namespace Deveel.Events
                 => ValidateOptionsResult.Success;
         }
 
-        private sealed class InspectableChannel : EventPublishChannelBase<SimpleOptions>
+        private sealed class InspectableChannel : EventPublishChannel<SimpleOptions>
         {
             public InspectableChannel(SimpleOptions defaults) : base(defaults) { }
             public SimpleOptions ExposedDefaults => DefaultOptions;
@@ -217,7 +217,7 @@ namespace Deveel.Events
                 => Task.CompletedTask;
         }
 
-        private sealed class SlowChannel : EventPublishChannelBase<SimpleOptions>
+        private sealed class SlowChannel : EventPublishChannel<SimpleOptions>
         {
             public SlowChannel(SimpleOptions defaults) : base(defaults) { }
             protected override async Task PublishCoreAsync(CloudEvent @event, SimpleOptions options, CancellationToken ct)

--- a/test/Deveel.Events.Publisher.XUnit/PublisherOptionsCompatibilityTests.cs
+++ b/test/Deveel.Events.Publisher.XUnit/PublisherOptionsCompatibilityTests.cs
@@ -33,10 +33,10 @@ namespace Deveel.Events
         }
 
         /// <summary>
-        /// A channel built on <see cref="EventPublishChannelBase{TOptions}"/> that records
+        /// A channel built on <see cref="EventPublishChannel{TOptions}"/> that records
         /// the effective options it received for the last publish call.
         /// </summary>
-        private sealed class AlphaChannel : EventPublishChannelBase<AlphaOptions>
+        private sealed class AlphaChannel : EventPublishChannel<AlphaOptions>
         {
             public AlphaChannel(AlphaOptions defaults) : base(defaults) { }
 
@@ -57,7 +57,7 @@ namespace Deveel.Events
         /// A second channel with a different options type. Records the effective options
         /// it received so tests can assert them.
         /// </summary>
-        private sealed class BetaChannel : EventPublishChannelBase<BetaOptions>
+        private sealed class BetaChannel : EventPublishChannel<BetaOptions>
         {
             public BetaChannel(BetaOptions defaults) : base(defaults) { }
 
@@ -75,7 +75,7 @@ namespace Deveel.Events
 
         /// <summary>
         /// A raw <see cref="IEventPublishChannel"/> implementation (no
-        /// <see cref="EventPublishChannelBase{TOptions}"/>) that records what it receives.
+        /// <see cref="EventPublishChannel{TOptions}"/>) that records what it receives.
         /// </summary>
         private sealed class RawChannel : IEventPublishChannel
         {
@@ -194,7 +194,7 @@ namespace Deveel.Events
         [Fact]
         public async Task PublishEvent_RawChannel_IncompatibleOptions_ChannelReceivesNull()
         {
-            // Arrange – a channel that does NOT extend EventPublishChannelBase<TOptions>;
+            // Arrange – a channel that does NOT extend EventPublishChannel<TOptions>;
             // ResolveChannelOptions should return null for it regardless of what options are passed.
             var rawChannel = new RawChannel();
             var publisher  = BuildPublisher(rawChannel);
@@ -272,7 +272,7 @@ namespace Deveel.Events
         /// and is wired to <see cref="AlphaOptions"/>.
         /// </summary>
         private sealed class TypedAlphaChannel<TEvent> :
-            EventPublishChannelBase<AlphaOptions>,
+            EventPublishChannel<AlphaOptions>,
             IEventPublishChannel<TEvent>
             where TEvent : class
         {
@@ -421,7 +421,7 @@ namespace Deveel.Events
         [Fact]
         public async Task PublishEvent_CombinedOptions_RawChannel_ReceivesNull()
         {
-            // Arrange – raw channel not derived from EventPublishChannelBase<TOptions>
+            // Arrange – raw channel not derived from EventPublishChannel<TOptions>
             var rawChannel = new RawChannel();
             var publisher  = BuildPublisher(rawChannel);
 


### PR DESCRIPTION
This pull request introduces a new mechanism for routing events to specific named channels in the event publishing infrastructure. It does so by adding interfaces and options classes that allow both channels and per-call publish options to specify a logical name, enabling selective event delivery. The changes affect all major publisher implementations and the core publishing logic, and provide new extension methods for easier usage.

**Key changes:**

### Named Channel Routing Support

* Introduced the `INamedChannelFilter` interface for `EventPublishOptions` subclasses to support targeting a specific named channel, and the `INamedEventPublishChannel` interface for channels to expose a logical name for routing. Added the `NamedChannelPublishOptions` class as a lightweight way to specify a channel name filter. (`src/Deveel.Events.Publisher/Events/INamedChannelFilter.cs`, `src/Deveel.Events.Publisher/Events/INamedEventPublishChannel.cs`, `src/Deveel.Events.Publisher/Events/NamedChannelPublishOptions.cs`) [[1]](diffhunk://#diff-c229837994c9448f3070dc051a65377d8c7cca9729382d31a82616ac585c0b0cR1-R38) [[2]](diffhunk://#diff-3de64bd73c444b8e58b3df99d89d63d337febe3a53356a3a9ef84f5c9eed46eeR1-R39) [[3]](diffhunk://#diff-e4dfae690b388a97e447aefb35c0ba1b7e3ad6cd39c917d9415e5ba4baa80d19R1-R43)

* Updated all major publisher option classes (`ServiceBusPublishOptions`, `MassTransitPublishOptions`, `RabbitMqPublishOptions`, `WebhookPublishOptions`) to inherit from `NamedChannelPublishOptions` and implement `INamedChannelFilter`, enabling them to carry a channel name. (`src/Deveel.Events.Publisher.AzureServiceBus/Events/ServiceBusPublishOptions.cs`, `src/Deveel.Events.Publisher.MassTransit/Events/MassTransitPublishOptions.cs`, `src/Deveel.Events.Publisher.RabbitMq/Events/RabbitMqPublishOptions.cs`, `src/Deveel.Events.Publisher.Webhook/Events/WebhookPublishOptions.cs`) [[1]](diffhunk://#diff-1a623fddbb827f4a2278d9f30371c0dc1f7cf73dd04dff92dbc0299fd46b0f89L15-R15) [[2]](diffhunk://#diff-aedd9c2de502992ea0a6e28f3e5fe8ea33f6d268a1a6f2fa0ebd8e8576fd34a1L11-R11) [[3]](diffhunk://#diff-610ee77fb79ee225ada75493fb74fa70a7f901c76dae33fc0ab5000989126bd4L15-R15) [[4]](diffhunk://#diff-b1033f4cc1e1ff99f93f25092cdb864cc1d04d7ac31e74ed2c02963ae509a044L24-R24)

* Modified the `Merge` methods of these options classes to include the `ChannelName` property, ensuring correct propagation when merging options. [[1]](diffhunk://#diff-aedd9c2de502992ea0a6e28f3e5fe8ea33f6d268a1a6f2fa0ebd8e8576fd34a1R24) [[2]](diffhunk://#diff-610ee77fb79ee225ada75493fb74fa70a7f901c76dae33fc0ab5000989126bd4R28) [[3]](diffhunk://#diff-b1033f4cc1e1ff99f93f25092cdb864cc1d04d7ac31e74ed2c02963ae509a044R44)

### Channel and Publisher Base Enhancements

* Updated `EventPublishChannelBase<TOptions>` to implement `INamedEventPublishChannel` and expose the channel's name from options if available. (`src/Deveel.Events.Publisher/Events/EventPublishChannelBase.cs`) [[1]](diffhunk://#diff-5bf37d8a9933be33d6d413d0a524346bda484e8bad8755d247779a97c1a22d81L43-R43) [[2]](diffhunk://#diff-5bf37d8a9933be33d6d413d0a524346bda484e8bad8755d247779a97c1a22d81R72-R78)

* Enhanced the core publishing logic in `EventPublisher` to filter channels based on the name specified in publish options, ensuring events are only delivered to matching named channels. Added helper methods for matching/filtering and updated event dispatch logic accordingly. (`src/Deveel.Events.Publisher/Events/EventPublisher.cs`) [[1]](diffhunk://#diff-1b19c1ba1ac1885af0d6984c95dacf845c83ea88d93161966df69de4eab9bb3cR301-R319) [[2]](diffhunk://#diff-1b19c1ba1ac1885af0d6984c95dacf845c83ea88d93161966df69de4eab9bb3cR330-R381) [[3]](diffhunk://#diff-1b19c1ba1ac1885af0d6984c95dacf845c83ea88d93161966df69de4eab9bb3cR440-R445)

### Usability Improvements

* Added new extension methods to `IEventPublisher` to allow publishing events directly to a named channel using a `channelName` string, simplifying the API for users. (`src/Deveel.Events.Publisher/Events/EventPublisherExtensions.cs`)

* Updated the test publisher builder to allow specifying a logical name for test channels, supporting the new routing mechanism in tests. (`src/Deveel.Events.TestPublisher/Events/EventPublisherBuilderExtensions.cs`)

These changes collectively enable fine-grained, name-based routing of events to channels, improving flexibility and control in multi-channel event publishing scenarios.