### PR TITLE
Clarify usage of IEventPublisher in event publishing pipelines

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,6 +15,7 @@
 * [Overview](concepts/README.md)
 * [CloudEvents Standard](concepts/cloudevents.md)
 * [Event Publisher](concepts/event-publisher.md)
+* [Publish Pipeline & Middleware](concepts/publish-pipeline.md)
 * [Publish Channels](concepts/publish-channels.md)
 * [Event Annotations](concepts/event-annotations.md)
 

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -31,16 +31,20 @@ This section explains the fundamental building blocks of the Deveel Events frame
 | Abstraction | Role |
 |-------------|------|
 | `EventPublisher` | The single entry point for publishing events |
+| `IEventMiddleware` | A composable step in the publish pipeline (enrichment, validation, observability, …) |
+| `EventContext` | Carries the current event, scoped services, options, and a data-sharing `Items` bag through the pipeline |
 | `IEventPublishChannel` | One transport target (Azure Service Bus queue, RabbitMQ exchange, …) |
 | `IBatchEventPublishChannel` | A channel that also supports delivering multiple events in a single batched call |
 | `IEventFactory` | Converts an annotated data object into a `CloudEvent` |
 | `IEventIdGenerator` | Generates unique identifiers for events (default: GUID) |
 | `IEventSystemTime` | Supplies the event timestamp (replaceable for testing) |
+| `IEventPublisherFactory` | Resolves a named publisher pipeline by name at runtime |
 
 ## Pages in this section
 
 - [CloudEvents Standard](cloudevents.md)
 - [Event Publisher](event-publisher.md)
+- [Publish Pipeline & Middleware](publish-pipeline.md)
 - [Publish Channels](publish-channels.md)
 - [Event Annotations](event-annotations.md)
 

--- a/docs/concepts/event-publisher.md
+++ b/docs/concepts/event-publisher.md
@@ -2,45 +2,74 @@
 
 ## Design overview
 
-### `EventPublisher` — the injection contract
+### `IEventPublisher` — the contract to depend on
 
-`EventPublisher` is the publishing contract that application code depends on through DI.  
-It exposes overloads that cover pre-built `CloudEvent` instances and annotation-driven publishing from CLR types.
+**`IEventPublisher` is the interface your application code should inject and depend on.**
+It is the stable, minimal contract for publishing events and is the only type you should
+reference in services, controllers, handlers, or any other consumer of the publisher.
 
-`PublishAsync` is the **primary entry point** for most application code. It accepts annotated 
-domain objects, delegates `CloudEvent` construction to 
-`IEventFactory`, and then pushes the result through the same enrich → middleware → validate → dispatch 
-pipeline as `PublishEventAsync`.
+```csharp
+// ✅ Correct — depend on the interface
+public class OrderService(IEventPublisher publisher) { … }
 
-The generic overload `PublishAsync<TEvent>(TEvent @event, ...)` 
-is also available for an even more concise syntax when the event type is known at compile time.
+// ⚠️  Avoid in application code — couples to the implementation
+public class OrderService(EventPublisher publisher) { … }
+```
 
-> **Warning — replacing `EventPublisher` entirely**
->
-> Replacing the publisher implementation means you own the **entire** publish pipeline:  
-> enrichment, validation, channel fan-out, per-call options resolution, typed-channel dispatch,
-> error handling and logging.  Only do this when you need to **completely replace** the pipeline
-> (e.g. a test double that captures events in memory, or an exotic transport that cannot be 
-> modelled as a channel).  For all other customisation needs, **extend `EventPublisher`** instead
-> (see [Extending `EventPublisher`](#extending-eventpublisher) below).
+`IEventPublisher` exposes two method families:
 
-### `EventPublisher` — core capabilities
+| Method | When to use |
+|--------|-------------|
+| `PublishEventAsync(CloudEvent, options?, ct)` | You already have a fully-constructed `CloudEvent`. |
+| `PublishAsync(Type, object?, options?, ct)` | You have an annotated data object and want the framework to build the `CloudEvent` for you. |
 
-`EventPublisher` is the production implementation registered by `AddEventPublisher()`.  
-It provides:
+The generic convenience overload `PublishAsync<TEvent>(TEvent, options?, ct)` (on `EventPublisherExtensions`) 
+wraps the non-generic version for compile-time type safety.
 
-- A structured, overridable **publish pipeline** (enrich → middleware → validate → dispatch).
+### `EventPublisher` — the default implementation
+
+`EventPublisher` is the **production implementation** registered by `AddEventPublisher()`.
+It is an infrastructure type that provides all the boilerplate your event-publishing needs:
+
+- A structured, fully overridable **publish pipeline**: filter → middleware → enrich → validate → dispatch.
 - **Fan-out** delivery to every registered `IEventPublishChannel`.
 - Automatic routing to **typed channels** (`IEventPublishChannel<TEvent>`) when available.
 - **Per-call options** resolution and forwarding per channel.
-- Annotation-driven `CloudEvent` creation via `IEventFactory` / `PublishAsync`.
-- A composable **middleware pipeline** configured at DI-registration time via `EventPublisherBuilder.Use<TMiddleware>()`.
-- Support for **multiple named publisher pipelines**, each with its own channels and middleware.
-- Structured logging and configurable error-propagation policy.
+- Annotation-driven `CloudEvent` creation via `IEventFactory`.
+- A composable **middleware pipeline** via `EventPublisherBuilder.Use<TMiddleware>()` and `UseWhen<TMiddleware>(predicate)`.
+- Support for **multiple named publisher pipelines**, each isolated with its own channels and middleware.
+- Structured logging and configurable error-propagation policy (`ThrowOnErrors`).
 
-Because the publisher-owned stages are exposed as `protected virtual` methods and middleware is
-composed per-builder-registration, you can customise exactly the behaviour you need without
-reimplementing the rest.
+`EventPublisher` is registered as a singleton and is exposed as both the non-keyed `IEventPublisher`
+and as the concrete `EventPublisher` type (the latter only for backward compatibility — prefer `IEventPublisher`).
+
+> **Rule of thumb:** your application code should never import or reference `EventPublisher`
+> directly.  Treat it as a framework-internal implementation detail that happens to be a
+> `public` class for extensibility purposes.
+
+### `EventPublisherPipeline` — the configured middleware chain
+
+`EventPublisherPipeline` holds the **ordered list of middleware registrations** built for a
+publisher during DI setup.  It is passed to the `EventPublisher` constructor by the
+`EventPublisherBuilder` and is compiled into an executable delegate exactly once, the first
+time the publisher is resolved from the container.
+
+You can access the pipeline from the DI container for **diagnostic or testing purposes**:
+
+```csharp
+// E.g. in a health-check, startup self-test, or test fixture:
+var pipeline = serviceProvider.GetRequiredService<EventPublisherPipeline>();
+
+foreach (var reg in pipeline.MiddlewareRegistrations)
+{
+    Console.WriteLine(
+        $"{reg.MiddlewareType.Name}  " +
+        $"(conditional: {reg.IsConditional})");
+}
+```
+
+`EventPublisherPipeline` is **not** part of the publishing API — call it only for inspection.
+To execute the pipeline, use `IEventPublisher.PublishEventAsync` as normal.
 
 ---
 
@@ -84,12 +113,14 @@ builder.Services
 > runtime after resolution.
 
 The default publisher is exposed both as the non-keyed `IEventPublisher` and as the concrete
-`EventPublisher`, so you can inject either:
+`EventPublisher`.  **Always inject `IEventPublisher`** in application code:
 
 ```csharp
-public class OrderService(IEventPublisher publisher) { /* … */ }
-// —or—
-public class OrderService(EventPublisher publisher) { /* … */ }
+// ✅ Preferred — decoupled from the implementation
+public class OrderService(IEventPublisher publisher) { … }
+
+// ⚠️  Only acceptable when a specific EventPublisher subclass API is needed
+public class OrderService(EventPublisher publisher) { … }
 ```
 
 ### Named publishers — separate pipelines
@@ -175,23 +206,30 @@ public class NotificationService(
 
 ## The publish pipeline
 
-Every call to `PublishEventAsync` passes through the following ordered stages:  
-**enrich → middleware → validate → dispatch**.
+Every call to `PublishEventAsync` passes through the following ordered stages:
+**filter → context → middleware → [terminal: enrich → validate → dispatch]**.
 
 The pipeline is composed at DI-registration time from an immutable descriptor and compiled
 exactly once when the publisher singleton is first resolved from the container.
 
 ```
 PublishEventAsync(CloudEvent, options)
-  ├─ 1. Enrich (SetEventId, SetTimeStamp, SetSource, SetAttributes)
-  ├─ 2. Create EventContext
-  ├─ 3. Run middleware chain  (frozen at build time)
-  └─ 4. Terminal validate + dispatch → fan-out to channels
+  ├─ 1. Filter channels by name
+  ├─ 2. Create async scope + EventContext (raw, un-enriched event)
+  ├─ 3. Run middleware chain  (frozen at build time; sees the raw event)
+  └─ 4. Terminal step:
+          a. Enrich  (SetEventId, SetTimeStamp, SetSource, SetAttributes)
+          b. Validate (ValidateCloudEvent)
+          c. Dispatch → fan-out to name-filtered channels
 ```
 
-For the full pipeline reference — including stage descriptions, `IEventMiddleware` implementation
-guide, and `InvalidCloudEventException` handling — see
-**[Publish Pipeline & Middleware](publish-pipeline.md)**.
+> **Key change from v1.0:** middleware now runs **before** enrichment.  This means
+> middleware can freely set or inspect `id`, `time`, `source`, and custom extension
+> attributes before the publisher's own enrichment hooks run.
+
+For the full pipeline reference — including stage descriptions, `IEventMiddleware` and
+`UseWhen` implementation guides, `EventContext.Items`, and `InvalidCloudEventException`
+handling — see **[Publish Pipeline & Middleware](publish-pipeline.md)**.
 
 ---
 
@@ -357,26 +395,37 @@ method on `EventPublisher`.  Subclasses can override it to implement custom matc
 
 ## Extending `EventPublisher`
 
-**Extending `EventPublisher` is the recommended customisation strategy** for the vast majority 
-of scenarios.  The class is designed for inheritance: every step of the publish pipeline is 
-exposed as a `protected virtual` method and the constructor receives its dependencies via 
-standard DI, so subclasses can call `base.XxxAsync(…)` to preserve default behaviour and 
-override only the specific step they need to change.
+> **Extending `EventPublisher` is a rare operation.**
+>
+> The vast majority of cross-cutting scenarios — correlation IDs, tracing, deduplication,
+> observability, conditional routing — are handled most cleanly through the **middleware
+> pipeline** (`Use<TMiddleware>()` / `UseWhen<TMiddleware>(predicate)` on the builder).
+> Middleware is easier to test, easier to reuse, and does not require managing constructor
+> parameters.
+>
+> Only resort to subclassing when you need to change one of the publisher's **built-in
+> decision points** that cannot be reached from middleware.  Even then, the subclass should
+> override only the specific `protected virtual` method it needs and delegate everything
+> else to `base`.
+
+The class is designed for inheritance: every step of the publish pipeline is exposed as a
+`protected virtual` method and the constructor receives its dependencies via standard DI,
+so subclasses can call `base.XxxAsync(…)` to preserve default behaviour.
 
 ### Middleware vs subclassing
 
-Use **middleware** when you want a reusable registration-time step that wraps publish execution without changing the publisher's core protected methods.
-
-Use **subclassing** when you need to change one of the publisher's built-in decision points, such as how events are enriched, validated, filtered, or how per-channel options are resolved.
-
-| Need | Prefer |
-|------|--------|
-| Add cross-cutting logic before/after publish | `Use<TMiddleware>()` on the builder |
-| Short-circuit selected publishes | `Use<TMiddleware>()` on the builder |
-| Resolve scoped services during publish | `Use<TMiddleware>()` on the builder |
-| Change enrichment defaults globally | subclass + override `Set*` methods |
-| Change validation semantics | subclass + override `ValidateCloudEvent` |
-| Change channel selection / options matching | subclass + override dispatch-related protected methods |
+| Need | Correct approach |
+|------|-----------------|
+| Add correlation IDs, tenant IDs, trace attributes | **Middleware** — `Use<TMiddleware>()` |
+| Skip logic based on a runtime condition | **Middleware** — `UseWhen<TMiddleware>(predicate)` |
+| Short-circuit publishing for selected events | **Middleware** — `Use<TMiddleware>()` |
+| Resolve scoped services during publish | **Middleware** — constructor-injected via `EventContext.Services` |
+| Share data between pipeline steps | **Middleware** — `EventContext.Items` |
+| Custom enrichment / context stamping | **Middleware first**; subclass + override `Set*` only if the enrichment must apply even when middleware is absent |
+| Stricter or domain-specific validation | **Subclass** + override `ValidateCloudEvent` |
+| Custom channel selection / name-based routing | **Subclass** + override `FilterChannelsByName` |
+| Custom per-channel options matching | **Subclass** + override `ResolveChannelOptions` |
+| Retry / circuit-breaking around channel calls | **Subclass** + override `PublishEventAsync(channel, …)` |
 
 ### Protected virtual extension points
 
@@ -403,8 +452,8 @@ builder.Services
     .UsePublisher<MyCustomPublisher>();
 ```
 
-This replaces the default `EventPublisher` registration with your type while keeping all other 
-services (channels, ID generator, system time, etc.) intact.
+This replaces the default `EventPublisher` registration with your type while keeping all other
+services (channels, middleware, ID generator, system time, etc.) intact.
 
 ### Example — tightening validation
 
@@ -417,8 +466,9 @@ public class StrictPublisher : EventPublisher
         IOptions<EventPublisherOptions> options,
         IEnumerable<IEventPublishChannel> channels,
         IServiceProvider serviceProvider,
+        EventPublisherPipeline? pipeline = null,
         ILogger<StrictPublisher>? logger = null)
-        : base(options, channels, serviceProvider, logger) { }
+        : base(options, channels, serviceProvider, pipeline, logger) { }
 
     protected override void ValidateCloudEvent(CloudEvent @event)
     {
@@ -434,7 +484,7 @@ public class StrictPublisher : EventPublisher
 
 ### Example — injecting correlation context
 
-Override `SetAttributes` to stamp every event with a trace / correlation identifier sourced 
+Override `SetAttributes` to stamp every event with a trace / correlation identifier sourced
 from the ambient `Activity`:
 
 ```csharp
@@ -460,9 +510,13 @@ public class TracingPublisher : EventPublisher
 }
 ```
 
+> **Prefer middleware for this pattern.** The subclass approach above is shown for completeness.
+> The same result is achieved with less coupling by implementing `IEventMiddleware` and calling
+> `Use<TraceIdMiddleware>()` — see [Publish Pipeline & Middleware](publish-pipeline.md).
+
 ### Example — per-channel retry wrapper
 
-Override `PublishEventAsync(IEventPublishChannel, …)` to add resilience around individual 
+Override `PublishEventAsync(IEventPublishChannel, …)` to add resilience around individual
 channel calls without changing fan-out or validation:
 
 ```csharp
@@ -488,24 +542,33 @@ public class ResilientPublisher : EventPublisher
 
 ---
 
-## When to replace `EventPublisher` entirely
+## Re-implementing `IEventPublisher` — handle with care
 
-Replace the publisher implementation **only** when you need to replace the entire publish 
-pipeline.  Typical cases:
+Implementing `IEventPublisher` from scratch — bypassing `EventPublisher` entirely — means
+you **own the full publishing contract**:
 
-| Scenario | Recommended approach |
-|---|---|
-| In-memory test double (captures events for assertion) | Build a dedicated `EventPublisher` replacement |
-| Null publisher (no-op, e.g. integration-test isolation) | Build a dedicated `EventPublisher` replacement |
-| Completely different fan-out strategy (e.g. priority queues, event sourcing) | Build a dedicated `EventPublisher` replacement |
-| Add custom enrichment / context stamping | **Extend `EventPublisher`**, override `SetAttributes` |
-| Stricter or relaxed validation | **Extend `EventPublisher`**, override `ValidateCloudEvent` |
-| Custom channel selection / name-based routing | **Extend `EventPublisher`**, override `FilterChannelsByName` |
-| Custom options matching per channel | **Extend `EventPublisher`**, override `ResolveChannelOptions` |
-| Retry / circuit-breaking around channel calls | **Extend `EventPublisher`**, override `PublishEventAsync(channel, …)` |
+- Enrichment (id, time, source, extension attributes)
+- Middleware pipeline compilation and execution
+- CloudEvent validation
+- Channel fan-out and per-call options resolution
+- Typed-channel routing
+- Scoped DI scope management
+- Error handling and logging
 
-For tests, you can use the channels in `Deveel.Events.TestPublisher` (for example `AddTestChannel`) 
-to assert what was published without a real transport.
+**This is almost never the right choice for production code.**  The only legitimate scenarios are:
+
+| Scenario | Why it justifies a full re-implementation |
+|----------|-------------------------------------------|
+| In-memory test double | Needs to capture published events for assertion without any real transport. |
+| Null / no-op publisher | Silently discards events during integration-test isolation. |
+| Completely exotic fan-out strategy | Cannot be modelled as one or more `IEventPublishChannel` implementations. |
+
+For tests, the `Deveel.Events.TestPublisher` package provides `AddTestChannel()`, which makes
+an in-memory capture available without re-implementing the publisher at all.
+
+> ⚠️  If you find yourself re-implementing `IEventPublisher` to add a cross-cutting concern
+> (logging, tracing, enrichment, retries), **stop** — use [middleware](publish-pipeline.md#stage-3--middleware)
+> or a [subclass](#extending-eventpublisher) instead.
 
 ---
 

--- a/docs/concepts/publish-pipeline.md
+++ b/docs/concepts/publish-pipeline.md
@@ -11,84 +11,136 @@ descriptor and compiled exactly once when the publisher singleton is first resol
 ```
 PublishEventAsync(CloudEvent, options)
   │
-  ├─ 1. Enrich ──────────────────────────────────────────────────────────────
-  │       SetEventId(event)        → fills id  via IEventIdGenerator
-  │       SetTimeStamp(event)      → fills time via IEventSystemTime
-  │       SetSource(event)         → fills source from EventPublisherOptions
-  │       SetAttributes(event)     → merges EventPublisherOptions.Attributes
+  ├─ 1. Filter channels by name ─────────────────────────────────────────────
+  │       FilterChannelsByName(channels, options)
+  │       → narrow channel list when options.ChannelName is set
   │
-  ├─ 2. Create EventContext ─────────────────────────────────────────────────
-  │       EventContext(event, services, cancellationToken, options)
+  ├─ 2. Create async scope + EventContext ────────────────────────────────────
+  │       await using scope = serviceProvider.CreateAsyncScope()
+  │       EventContext(rawEvent, scope.ServiceProvider, cancellationToken, options)
+  │       ⚠  The event has NOT been enriched yet at this point.
   │
-  ├─ 3. Run middleware chain ────────────────────────────────────────────────
-  │       Use<TMiddleware>() registrations run in order (frozen at build time)
-  │       middleware may mutate context.Event
+  ├─ 3. Run middleware chain ─────────────────────────────────────────────────
+  │       Use<TMiddleware>() / UseWhen<TMiddleware>(predicate) registrations
+  │       run in registration order (frozen at build time)
+  │       middleware may inspect or mutate context.Event (raw, un-enriched)
   │       middleware may short-circuit by not calling next(context)
   │
-  └─ 4. Terminal validate + dispatch ────────────────────────────────────────
-          ValidateCloudEvent(context.Event)
-          FilterChannelsByName(channels, context.Options) → named-channel filter
-          for each IEventPublishChannel:
-            ResolveChannelOptions(channel, context.Options) → per-channel options
-            PublishEventAsync(channel, context.Event, resolvedOptions)
-              → channel.PublishAsync(context.Event, resolvedOptions)
+  └─ 4. Terminal step ────────────────────────────────────────────────────────
+          a. Enrich ────────────────────────────────────────────────────────
+                SetEventId(event)     → fills id  via IEventIdGenerator
+                SetTimeStamp(event)   → fills time via IEventSystemTime
+                SetSource(event)      → fills source from EventPublisherOptions
+                SetAttributes(event)  → merges EventPublisherOptions.Attributes
+          b. Validate ──────────────────────────────────────────────────────
+                ValidateCloudEvent(context.Event)
+                → throws InvalidCloudEventException if required attrs still absent
+          c. Dispatch ──────────────────────────────────────────────────────
+                for each IEventPublishChannel (already name-filtered):
+                  ResolveChannelOptions(channel, context.Options)
+                  PublishEventAsync(channel, context.Event, resolvedOptions)
+                    → channel.PublishAsync(context.Event, resolvedOptions)
 ```
 
-> **Important:** validation happens in the terminal step **after** middleware runs.
-> This means middleware can enrich the event further, replace the event, or update
-> per-call options before the publisher validates the envelope and fans out to channels.
+> **Important — middleware sees the raw event.**  
+> Because enrichment happens in the terminal step, middleware receives the **un-enriched**
+> `CloudEvent`.  This means middleware can freely set `id`, `time`, `source`, or custom
+> extension attributes, and the built-in enrichment hooks will only fill in the values that
+> are still absent once middleware has finished.
 
 ---
 
-## Stage 1 — Enrichment
+## Stage 1 — Channel name filtering
 
-The four enrichment methods run in sequence before any validation occurs, so values they
-fill in satisfy the subsequent validation check automatically.
+Before the `EventContext` is created, `FilterChannelsByName` narrows the set of target
+channels based on `options`:
 
-| Method | What it fills | Condition |
-|--------|---------------|-----------|
-| `SetEventId(CloudEvent)` | `id` attribute | Only when `id` is `null` and an `IEventIdGenerator` is registered |
-| `SetTimeStamp(CloudEvent)` | `time` attribute | Only when `time` is `null` and an `IEventSystemTime` is registered |
-| `SetSource(CloudEvent)` | `source` attribute | Only when `source` is `null` and `EventPublisherOptions.Source` is set |
-| `SetAttributes(CloudEvent)` | Extension attributes from `EventPublisherOptions.Attributes` | Always; existing attributes are overwritten |
+- When `options` implements `INamedChannelFilter` with a non-empty `ChannelName`, only
+  channels whose `INamedEventPublishChannel.Name` matches (case-insensitive) are kept.
+  Anonymous channels (those not implementing `INamedEventPublishChannel`) always pass
+  through.
+- When `options` is `null`, or `ChannelName` is empty/null, **all** channels are included.
 
-All four methods return the (mutated) `CloudEvent` and are `protected virtual` — override any
-of them in a subclass to customise enrichment without touching the rest of the pipeline.  See
-[Extending EventPublisher](event-publisher.md#extending-eventpublisher) for examples.
+`FilterChannelsByName` is `protected virtual` — override it in a subclass to implement
+custom routing logic.
 
 ---
 
 ## Stage 2 — `EventContext` creation
 
-After enrichment, the publisher creates an `EventContext` for the current publish operation.
-This context is passed through the middleware chain and carries:
+An **async DI scope** is created for each publish call via
+`IServiceProvider.CreateAsyncScope()`.  The `EventContext` is then initialised with:
 
 | Property | Description |
 |----------|-------------|
-| `EventContext.Event` | The enriched `CloudEvent` (middleware may mutate or replace it) |
-| `EventContext.Services` | The runtime `IServiceProvider` for the current publish call |
-| `EventContext.CancellationToken` | The cancellation token for the current publish call |
-| `EventContext.Options` | Any per-call `EventPublishOptions` passed by the caller |
+| `EventContext.Event` | The **raw** (not yet enriched) `CloudEvent`. Middleware and the terminal enrichment step may mutate or replace it. |
+| `EventContext.Services` | A **scoped** `IServiceProvider` — a fresh scope per publish call, so scoped services (e.g. `IHttpContextAccessor`, `DbContext`) are resolved correctly. |
+| `EventContext.CancellationToken` | The cancellation token for the current publish call. |
+| `EventContext.Options` | The per-call `EventPublishOptions` passed by the caller (may be `null`). |
+| `EventContext.Items` | A free-form `Dictionary<string, object?>` for passing arbitrary data between middleware steps within the same call. |
+
+### `EventContext.Items` — sharing data between middleware
+
+`Items` is the recommended way to pass intermediate results between middleware without
+coupling the types to each other:
+
+```csharp
+// First middleware: stamp a correlation ID and store it for downstream steps.
+public sealed class CorrelationMiddleware : IEventMiddleware
+{
+    private readonly ICorrelationAccessor _accessor;
+
+    public CorrelationMiddleware(ICorrelationAccessor accessor)
+        => _accessor = accessor;
+
+    public async Task InvokeAsync(EventContext context, EventPublishDelegate next)
+    {
+        var correlationId = _accessor.CorrelationId ?? Guid.NewGuid().ToString();
+        context.Items["correlationId"] = correlationId;
+
+        var attr = CloudEventAttribute.CreateExtension("correlationid", CloudEventAttributeType.String);
+        context.Event[attr] = correlationId;
+
+        await next(context);
+    }
+}
+
+// Second middleware: use the correlation ID set by the first one.
+public sealed class AuditMiddleware : IEventMiddleware
+{
+    private readonly IAuditLog _audit;
+
+    public AuditMiddleware(IAuditLog audit) => _audit = audit;
+
+    public async Task InvokeAsync(EventContext context, EventPublishDelegate next)
+    {
+        var correlationId = context.Items.TryGetValue("correlationId", out var v) ? v as string : null;
+        await next(context);
+        await _audit.RecordAsync(context.Event.Type!, correlationId, context.CancellationToken);
+    }
+}
+```
 
 ---
 
 ## Stage 3 — Middleware
 
 Middleware is a **registration-time** concept: steps are added to the pipeline when the
-publisher is configured via `EventPublisherBuilder.Use<TMiddleware>()`.  The pipeline
-descriptor is **frozen** (compiled into an immutable `EventPublisherPipelineDescriptor`)
-the first time the publisher singleton is resolved from the container.  You cannot add or
-remove middleware after that point.
+publisher is configured via `EventPublisherBuilder.Use<TMiddleware>()` or
+`EventPublisherBuilder.UseWhen<TMiddleware>(predicate)`.  The pipeline descriptor is
+**frozen** the first time the publisher singleton is resolved from the container.  You
+cannot add or remove middleware after that point.
 
 ### Core types
 
 | Type | Role |
 |------|------|
 | `IEventMiddleware` | A composable step in the publish pipeline |
-| `EventContext` | Carries the current `CloudEvent`, `IServiceProvider`, cancellation token, and per-call options |
+| `EventContext` | Carries the current `CloudEvent`, scoped `IServiceProvider`, cancellation token, per-call options, and an `Items` bag |
 | `EventPublishDelegate` | `Task InvokeAsync(EventContext)` — represents the remainder of the pipeline (`next`) |
+| `MiddlewareRegistration` | Describes a registered middleware step (type, activation arguments, optional predicate) |
 
-### Registering middleware at build time
+### Registering middleware — `Use<TMiddleware>()`
 
 Add middleware on the `EventPublisherBuilder` during DI registration:
 
@@ -99,7 +151,7 @@ builder.Services
     .Use<MetricsMiddleware>();
 ```
 
-You can also pass explicit extra constructor arguments (activated via `ActivatorUtilities`):
+You can pass explicit extra constructor arguments (forwarded to `ActivatorUtilities`):
 
 ```csharp
 builder.Services
@@ -107,13 +159,35 @@ builder.Services
     .Use<AuditMiddleware>("orders");  // "orders" forwarded as an extra ctor arg
 ```
 
+### Registering conditional middleware — `UseWhen<TMiddleware>(predicate)`
+
+`UseWhen` registers a middleware that is **skipped** when the predicate returns `false`.
+When skipped, the pipeline proceeds directly to the next registered step.
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    // Only stamp a trace ID when tracing is active for this request
+    .UseWhen<TraceMiddleware>(ctx =>
+        System.Diagnostics.Activity.Current is not null)
+    // Only throttle events whose type starts with "com.example.bulk"
+    .UseWhen<ThrottleMiddleware>(ctx =>
+        ctx.Event.Type?.StartsWith("com.example.bulk") == true)
+    .AddChannel<RabbitMqPublishChannel>();
+```
+
+> **Tip:** prefer `UseWhen` over an `if` block inside the middleware body when the
+> predicate is a pure, allocation-free expression (e.g. checking a flag or an event-type
+> prefix).  This avoids instantiating the middleware object when it would immediately
+> short-circuit anyway.
+
 ### Ordering and activation rules
 
 - Middleware runs in **registration order** — the first `Use<T>()` call becomes the
   **outermost** wrapper (closest to the caller).
 - A **fresh middleware instance** is created for every publish call via `ActivatorUtilities`.
 - Constructor dependencies are resolved from `EventContext.Services` at invocation time,
-  which means **scoped services are supported**.
+  which means **scoped services are fully supported**.
 - The pipeline is compiled **once** when the publisher is first resolved; it cannot be
   changed after that point.
 
@@ -124,14 +198,18 @@ A middleware class implements `IEventMiddleware.InvokeAsync(EventContext, EventP
 ```csharp
 public sealed class CorrelationIdMiddleware : IEventMiddleware
 {
+    // Dependencies injected by ActivatorUtilities from the scoped EventContext.Services
+    private readonly ICorrelationAccessor _accessor;
+
+    public CorrelationIdMiddleware(ICorrelationAccessor accessor)
+        => _accessor = accessor;
+
     public async Task InvokeAsync(EventContext context, EventPublishDelegate next)
     {
-        var accessor = context.Services.GetRequiredService<ICorrelationAccessor>();
-
-        if (!string.IsNullOrEmpty(accessor.CorrelationId))
+        if (!string.IsNullOrEmpty(_accessor.CorrelationId))
         {
             var attr = CloudEventAttribute.CreateExtension("correlationid", CloudEventAttributeType.String);
-            context.Event[attr] = accessor.CorrelationId;
+            context.Event[attr] = _accessor.CorrelationId;
         }
 
         await next(context);
@@ -156,11 +234,67 @@ receive the event if short-circuited:
 ```csharp
 public sealed class DeduplicationMiddleware : IEventMiddleware
 {
+    private readonly IEventDeduplicationStore _store;
+
+    public DeduplicationMiddleware(IEventDeduplicationStore store)
+        => _store = store;
+
     public async Task InvokeAsync(EventContext context, EventPublishDelegate next)
     {
-        var store = context.Services.GetRequiredService<IEventDeduplicationStore>();
-        if (await store.HasSeenAsync(context.Event.Id!, context.CancellationToken))
+        if (await _store.HasSeenAsync(context.Event.Id!, context.CancellationToken))
             return;   // stop here — do not forward to channels
+
+        await next(context);
+
+        // Mark as seen after successful delivery
+        await _store.MarkAsync(context.Event.Id!, context.CancellationToken);
+    }
+}
+```
+
+### Observability middleware pattern
+
+```csharp
+public sealed class MetricsMiddleware : IEventMiddleware
+{
+    private readonly IMetricsCollector _metrics;
+
+    public MetricsMiddleware(IMetricsCollector metrics) => _metrics = metrics;
+
+    public async Task InvokeAsync(EventContext context, EventPublishDelegate next)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        try
+        {
+            await next(context);
+            _metrics.RecordPublish(context.Event.Type!, sw.Elapsed, success: true);
+        }
+        catch
+        {
+            _metrics.RecordPublish(context.Event.Type!, sw.Elapsed, success: false);
+            throw;
+        }
+    }
+}
+```
+
+### Modifying `context.Options` in middleware
+
+Middleware can replace or wrap the per-call options before the terminal dispatch step reads
+them.  This is useful for injecting per-call routing decisions that depend on runtime state:
+
+```csharp
+public sealed class TenantRoutingMiddleware : IEventMiddleware
+{
+    private readonly ITenantContext _tenant;
+
+    public TenantRoutingMiddleware(ITenantContext tenant) => _tenant = tenant;
+
+    public async Task InvokeAsync(EventContext context, EventPublishDelegate next)
+    {
+        // Route to a tenant-specific named channel
+        if (context.Options == null)
+            context.Options = new NamedChannelPublishOptions(_tenant.ChannelName);
 
         await next(context);
     }
@@ -171,9 +305,13 @@ public sealed class DeduplicationMiddleware : IEventMiddleware
 
 | Pattern | Description |
 |---------|-------------|
-| Enrichment | Add correlation IDs, tenant IDs, trace attributes |
+| Enrichment | Add correlation IDs, tenant IDs, trace attributes to every event |
+| Conditional enrichment | Use `UseWhen` to add attributes only when a condition is met |
 | Validation / policy | Inspect `context.Event` and block selected publishes |
+| Deduplication | Short-circuit when the same event ID has already been seen |
 | Observability | Log, trace, and measure latency before/after `next(context)` |
+| Options injection | Set or wrap `context.Options` to change channel routing at runtime |
+| Data sharing | Use `context.Items` to pass intermediate results between steps |
 | Subscription dispatching | Wired automatically by `AddSubscriptions()` — see below |
 
 ### Dispatcher middleware (subscriptions)
@@ -199,10 +337,35 @@ See [Subscriptions Dispatcher](../subscriptions/dispatcher.md) for full details.
 
 ---
 
-## Stage 4 — Validation
+## Stage 4 (terminal) — Enrichment
 
-`ValidateCloudEvent` checks the four mandatory CloudEvents 1.0 attributes **after** all
-middleware has run, in the terminal step.
+Once all middleware has run, the terminal step **enriches** the event by calling the four
+`Set*` methods in sequence.
+
+| Method | What it fills | Condition |
+|--------|---------------|-----------|
+| `SetEventId(CloudEvent)` | `id` attribute | Only when `id` is `null` and an `IEventIdGenerator` is registered |
+| `SetTimeStamp(CloudEvent)` | `time` attribute | Only when `time` is `null` and an `IEventSystemTime` is registered |
+| `SetSource(CloudEvent)` | `source` attribute | Only when `source` is `null` and `EventPublisherOptions.Source` is set |
+| `SetAttributes(CloudEvent)` | Extension attributes from `EventPublisherOptions.Attributes` | Always; existing attributes are **overwritten** |
+
+> **Middleware-set attributes vs. `EventPublisherOptions.Attributes`:**  
+> Because `SetAttributes` runs after middleware and always overwrites existing values,
+> any attribute key listed in `EventPublisherOptions.Attributes` will **overwrite** a value
+> set by middleware.  If you need middleware to have the final say, do not list that
+> attribute key in `EventPublisherOptions.Attributes`, or override `SetAttributes` in a
+> subclass to change the merge strategy.
+
+All four methods are `protected virtual` — override any of them in a subclass to customise
+enrichment without touching the rest of the pipeline.  See
+[Extending EventPublisher](event-publisher.md#extending-eventpublisher) for examples.
+
+---
+
+## Stage 4 (terminal) — Validation
+
+`ValidateCloudEvent` checks the four mandatory CloudEvents 1.0 attributes **after**
+middleware and enrichment have both run.
 
 | Attribute | Auto-filled? | Must be caller-supplied when… |
 |-----------|-------------|-------------------------------|
@@ -211,11 +374,10 @@ middleware has run, in the terminal step.
 | `type` | ❌ | Always — no default exists |
 | `specversion` | ✅ by the CloudNative SDK (always `"1.0"`) | Never in practice |
 
-If any required attribute is still absent after middleware completes,
-`ValidateCloudEvent` throws `InvalidCloudEventException` **before** dispatching to any
-channel.  This exception is always propagated regardless of the `ThrowOnErrors` option,
-because a structurally invalid envelope is a programming error, not a transient delivery
-failure.
+If any required attribute is still absent, `ValidateCloudEvent` throws
+`InvalidCloudEventException` **before** dispatching to any channel.  This exception is
+always propagated regardless of the `ThrowOnErrors` option, because a structurally invalid
+envelope is a programming error, not a transient delivery failure.
 
 ### `InvalidCloudEventException`
 
@@ -237,25 +399,45 @@ catch (InvalidCloudEventException ex)
 
 ---
 
-## Stage 5 — Dispatch
+## Stage 4 (terminal) — Dispatch
 
 The publisher's dispatch stage:
 
-1. **Name filtering** — `FilterChannelsByName` narrows the channel list when the
-   caller-supplied `options` implement `INamedChannelFilter` with a non-empty `ChannelName`.
-   Only channels that implement `INamedEventPublishChannel` with a matching `Name` are kept;
-   anonymous channels always pass through.  `CombinedPublishOptions` does not implement
-   `INamedChannelFilter`; for combined options, name matching is done per bundled entry inside
-   `ResolveChannelOptions`.
+1. **Fan-out** over the already name-filtered channels (filtering was done in Stage 1).
 2. **Per-channel options resolution** — `ResolveChannelOptions` extracts the compatible
    `EventPublishOptions` entry for the current channel (see
    [Per-call publish options](event-publisher.md#per-call-publish-options)).
-3. **Fan-out** — `PublishEventAsync(IEventPublishChannel, CloudEvent, EventPublishOptions?)`
+3. **Delivery** — `PublishEventAsync(IEventPublishChannel, CloudEvent, EventPublishOptions?)`
    forwards the call to `channel.PublishAsync`.
 
 If a channel throws and `ThrowOnErrors` is `false` (the default), the error is logged and
 delivery continues to the remaining channels.  When `ThrowOnErrors` is `true` the exception
 is wrapped in `EventPublishException` and re-thrown, stopping fan-out immediately.
+
+---
+
+## `MiddlewareRegistration`
+
+`EventPublisherPipeline.MiddlewareRegistrations` exposes the ordered list of
+`MiddlewareRegistration` entries that make up the pipeline.  Each entry carries:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `MiddlewareType` | `Type` | The concrete `IEventMiddleware` implementation type. |
+| `ActivationArguments` | `object[]` | Extra constructor arguments forwarded to `ActivatorUtilities`. |
+| `Predicate` | `Func<EventContext, bool>?` | The condition predicate registered via `UseWhen`, or `null` when the middleware is unconditional. |
+| `IsConditional` | `bool` | `true` when a predicate is attached (i.e. registered via `UseWhen`). |
+
+This API is read-only and primarily useful for diagnostics and testing:
+
+```csharp
+// Resolving the pipeline (e.g. in a health-check or startup validation):
+var pipeline = serviceProvider.GetRequiredService<EventPublisherPipeline>();
+foreach (var reg in pipeline.MiddlewareRegistrations)
+{
+    Console.WriteLine($"{reg.MiddlewareType.Name} (conditional: {reg.IsConditional})");
+}
+```
 
 ---
 
@@ -266,8 +448,10 @@ Middleware and subclassing are complementary extensibility mechanisms:
 | Need | Prefer |
 |------|--------|
 | Add cross-cutting logic before/after publish | `Use<TMiddleware>()` on the builder |
+| Skip middleware based on a runtime condition | `UseWhen<TMiddleware>(predicate)` on the builder |
 | Short-circuit selected publishes | `Use<TMiddleware>()` on the builder |
 | Resolve scoped services during publish | `Use<TMiddleware>()` on the builder |
+| Share data between middleware steps | `EventContext.Items` |
 | Change enrichment defaults globally | Subclass + override `Set*` methods |
 | Change validation semantics | Subclass + override `ValidateCloudEvent` |
 | Change channel selection / options matching | Subclass + override dispatch-related protected methods |
@@ -277,11 +461,35 @@ subclassing examples.
 
 ---
 
-## Related pages
+## End-to-end example
 
-- [Event Publisher](event-publisher.md)
-- [Event Creation](event-creation.md)
-- [Publish Channels](publish-channels.md)
-- [Named Channels](../publishers/named-channels.md)
-- [Subscriptions Dispatcher](../subscriptions/dispatcher.md)
+The following example wires a correlation middleware, a conditional trace middleware, and
+a metrics middleware into the default publisher pipeline:
 
+```csharp
+// Program.cs / Startup.cs
+builder.Services
+    .AddEventPublisher(opts =>
+    {
+        opts.Source = new Uri("https://myapp.example.com");
+        opts.ThrowOnErrors = true;
+    })
+    // Unconditional — stamps a correlation ID on every event
+    .Use<CorrelationIdMiddleware>()
+    // Conditional — only stamps a W3C trace ID when a trace is active
+    .UseWhen<TraceIdMiddleware>(ctx => System.Diagnostics.Activity.Current is not null)
+    // Unconditional — measures latency for every publish call
+    .Use<MetricsMiddleware>()
+    .AddChannel<RabbitMqPublishChannel>();
+```
+
+Pipeline execution for a single `PublishEventAsync` call:
+
+```
+caller → CorrelationIdMiddleware.InvokeAsync
+          → TraceIdMiddleware.InvokeAsync  (only if Activity.Current != null)
+            → MetricsMiddleware.InvokeAsync
+              → [terminal] SetEventId / SetTimeStamp / SetSource / SetAttributes
+                         → ValidateCloudEvent
+                         → RabbitMqPublishChannel.PublishAsync
+```


### PR DESCRIPTION
This pull request significantly improves and clarifies the documentation for the event publishing pipeline, middleware, and extension points. It introduces a new conceptual page, updates the core documentation to emphasize best practices (such as always depending on `IEventPublisher`), and provides more detailed guidance on when to use middleware versus subclassing or full re-implementation. The changes aim to make the documentation more approachable for new users and to steer advanced users toward the most maintainable customization patterns.

**Documentation structure and conceptual updates:**

* Added a new documentation page, `publish-pipeline.md`, and linked it throughout the docs to provide a dedicated reference for the publish pipeline and middleware concepts. [[1]](diffhunk://#diff-492f4fe6d732168c58e78f2a627614dc59f1e41a5d12da3d8347d3957e9673f6R18) [[2]](diffhunk://#diff-8d8974e92bca9c21dd053e84c4c3950254b408a1732e28e98944c1313009af58R34-R47)

**Clarification and guidance on publisher usage:**

* Updated all guidance to recommend depending on the `IEventPublisher` interface in application code rather than the concrete `EventPublisher` class, with clear code examples and rationale. [[1]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bL5-R72) [[2]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bL87-R123)
* Clarified the roles of `EventPublisher`, `EventPublisherPipeline`, and related abstractions, including how and when to access or extend them. [[1]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bL5-R72) [[2]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bL87-R123)

**Pipeline and middleware documentation improvements:**

* Rewrote the pipeline section to detail the new stage order (filter → context → middleware → enrich → validate → dispatch), and emphasized that middleware now runs before enrichment, allowing more flexible customization.
* Expanded the explanation of `EventPublisherPipeline` and its diagnostic uses, distinguishing it from the publishing API.

**Extension and customization guidance:**

* Provided clearer, more prescriptive guidance on when to use middleware, subclassing, or full re-implementation, including a detailed comparison table and best-practice recommendations. [[1]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bL360-R428) [[2]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bL407-R456) [[3]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bR513-R516)
* Updated example code for subclassing to reflect the new pipeline signature and to encourage middleware for most cross-cutting concerns. [[1]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bR469-R471) [[2]](diffhunk://#diff-f0291435b1714b05cfc60e910b649129e2268c4e60251274bc23b35b594b2b3bR513-R516)

**Guidance on advanced scenarios:**

* Replaced the "When to replace `EventPublisher` entirely" section with a more cautious, detailed explanation of re-implementing `IEventPublisher`, listing legitimate scenarios and steering users toward test utilities or middleware when possible.

These changes together make the documentation more consistent, actionable, and easier to navigate for both new and advanced users.… of IEventPublisher