### PR TITLE
Add schema validation middleware and refactor AuditTrailPublishChannel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+### 🚀 Features
+
+- **Schema Validation at Publish Time**: New `Hermodr.Publisher.EventSchema` package adds automatic schema validation middleware to the publish pipeline (#90)
+  - `SchemaValidationMiddleware` — validates event payloads against registered schemas before channel dispatch
+  - `SchemaValidationOptions` — configurable `MissingSchemaBehavior` (Allow/Block/Fallback) and `ValidationFailureBehavior` (Throw/Log)
+  - `SchemaRegistrationsApplier` — registers built-in deserializers (JSON, XML) into the deserializer registry at startup
+  - `UseSchemaValidation()` — fluent extension on `EventPublisherBuilder` with auto-registration of schema services
+  - Version-aware validation via `dataversion` CloudEvent extension attribute
+  - Format-agnostic deserialization enables validation for JSON, XML, and future formats
+
+### 🧪 Tests
+
+- 212 new tests across `Hermodr.Schema.XUnit` (200) and `Hermodr.Publisher.EventSchema.XUnit` (12) covering all middleware behaviors, version-aware lookup, and error handling
+
 ## v1.2.6 - OpenTelemetry Enhancements
 
 ### 🚀 Features

--- a/Hermodr.sln
+++ b/Hermodr.sln
@@ -129,6 +129,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hermodr.Publisher.DeliveryL
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hermodr.Publisher.DeliveryLog.InMemory.XUnit", "test\Hermodr.Publisher.DeliveryLog.InMemory.XUnit\Hermodr.Publisher.DeliveryLog.InMemory.XUnit.csproj", "{5DB649B6-E550-472D-8BC4-8ACC9C8B3543}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hermodr.Publisher.EventSchema", "src\Hermodr.Publisher.EventSchema\Hermodr.Publisher.EventSchema.csproj", "{70BC28B4-7A46-40E7-AF46-E583397EBE18}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hermodr.Publisher.EventSchema.XUnit", "test\Hermodr.Publisher.EventSchema.XUnit\Hermodr.Publisher.EventSchema.XUnit.csproj", "{C83AD316-BE6F-4C0D-BBA3-B394765A548C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -763,6 +767,30 @@ Global
 		{5DB649B6-E550-472D-8BC4-8ACC9C8B3543}.Release|x64.Build.0 = Release|Any CPU
 		{5DB649B6-E550-472D-8BC4-8ACC9C8B3543}.Release|x86.ActiveCfg = Release|Any CPU
 		{5DB649B6-E550-472D-8BC4-8ACC9C8B3543}.Release|x86.Build.0 = Release|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Debug|x64.Build.0 = Debug|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Debug|x86.Build.0 = Debug|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Release|x64.ActiveCfg = Release|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Release|x64.Build.0 = Release|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Release|x86.ActiveCfg = Release|Any CPU
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18}.Release|x86.Build.0 = Release|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Debug|x64.Build.0 = Debug|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Debug|x86.Build.0 = Debug|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Release|x64.ActiveCfg = Release|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Release|x64.Build.0 = Release|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Release|x86.ActiveCfg = Release|Any CPU
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -824,6 +852,8 @@ Global
 		{E7C213C9-9442-4100-B85A-628C80CB6C0D} = {B34ECEB3-D2F9-459B-A3DE-99E04123E593}
 		{258F13B2-F9E4-4783-9E37-68E72808D106} = {EDED427E-1408-4971-9FA9-EBFCACCEAC22}
 		{5DB649B6-E550-472D-8BC4-8ACC9C8B3543} = {EDED427E-1408-4971-9FA9-EBFCACCEAC22}
+		{70BC28B4-7A46-40E7-AF46-E583397EBE18} = {B34ECEB3-D2F9-459B-A3DE-99E04123E593}
+		{C83AD316-BE6F-4C0D-BBA3-B394765A548C} = {EDED427E-1408-4971-9FA9-EBFCACCEAC22}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2F6B1794-D5DB-4788-A4E3-2786DA1F4359}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -46,6 +46,7 @@
 * [Export as YAML](schema/export-yaml.md)
 * [Export as AsyncAPI](schema/export-asyncapi.md)
 * [Validation](schema/validation.md)
+* [Validation at Publish Time](schema/validation-at-publish.md)
 
 ## Event Subscriptions
 

--- a/docs/concepts/publish-pipeline.md
+++ b/docs/concepts/publish-pipeline.md
@@ -308,6 +308,7 @@ public sealed class TenantRoutingMiddleware : IEventMiddleware
 | Enrichment | Add correlation IDs, tenant IDs, trace attributes to every event |
 | Conditional enrichment | Use `UseWhen` to add attributes only when a condition is met |
 | Validation / policy | Inspect `context.Event` and block selected publishes |
+| Schema validation | Validate payload against registered schemas — see [Schema Validation at Publish Time](../schema/validation-at-publish.md) |
 | Deduplication | Short-circuit when the same event ID has already been seen |
 | Observability | Log, trace, and measure latency before/after `next(context)` |
 | Distributed tracing | Built-in via `AddOpenTelemetry()` — see [OpenTelemetry Instrumentation](../publishers/opentelemetry.md) |

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -56,6 +56,7 @@ The framework is split into focused NuGet packages so you only take what you nee
 | [`Hermodr.Schema`](#hermodr-schema) | Core schema model, fluent builder, JSON writer, and schema validation |
 | [`Hermodr.Schema.Yaml`](#hermodr-schema-yaml) | Export an event schema as a YAML document |
 | [`Hermodr.Schema.AsyncApi`](#hermodr-schema-asyncapi) | Export schemas as an AsyncAPI 2.x document (JSON or YAML) |
+| [`Hermodr.Publisher.EventSchema`](#hermodr-publisher-eventschema) | Automatic schema validation middleware for the publish pipeline |
 
 ## Test package
 
@@ -403,4 +404,18 @@ dotnet add package Hermodr.AuditTrail.NDJson
 ```
 
 See the [Audit Trail with NDJson Files](samples/audit-trail-ndjson.md) sample for a full walkthrough.
+
+---
+
+### `Hermodr.Publisher.EventSchema`
+
+[![NuGet](https://img.shields.io/nuget/v/Hermodr.Publisher.EventSchema.svg)](https://www.nuget.org/packages/Hermodr.Publisher.EventSchema)
+
+Adds a middleware component that automatically validates every event's payload against its registered schema before dispatch. Supports format-agnostic validation (JSON, XML), version-aware schema lookup, and configurable behaviors for missing schemas and validation failures.
+
+```bash
+dotnet add package Hermodr.Publisher.EventSchema
+```
+
+See [Schema Validation at Publish Time](schema/validation-at-publish.md) for the full guide.
 

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -30,6 +30,7 @@ dotnet add package Hermodr.Schema
 | [Export as YAML](export-yaml.md) | Serialise a schema to a YAML document |
 | [Export as AsyncAPI](export-asyncapi.md) | Generate complete AsyncAPI 2.x documents |
 | [Validation](validation.md) | Validate `CloudEvent` instances against a schema |
+| [Validation at Publish Time](validation-at-publish.md) | Automatic schema validation via middleware |
 
 ## Schema model at a glance
 

--- a/docs/schema/validation-at-publish.md
+++ b/docs/schema/validation-at-publish.md
@@ -1,0 +1,122 @@
+# Schema Validation at Publish Time
+
+The `Hermodr.Publisher.EventSchema` package adds a middleware component that automatically validates every event's payload against its registered schema before the event reaches any publish channel.
+
+## Prerequisites
+
+```bash
+dotnet add package Hermodr.Publisher.EventSchema
+```
+
+## Quick start
+
+Register the schema validation middleware on the publisher builder:
+
+```csharp
+using Hermodr;
+
+builder.Services
+    .AddEventPublisher(opts => opts.Source = new Uri("https://example.com"))
+    .UseSchemaValidation()
+    .AddChannel<RabbitMqPublishChannel>();
+```
+
+`UseSchemaValidation()` auto-registers all schema services (`IEventSchemaRegistry`, `IEventSchemaValidator`, deserializers) if they are not already registered.
+
+## Registering schemas
+
+Schemas must be registered before validation can run. Pass them via the `configureSchemaServices` callback:
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .UseSchemaValidation(
+        configureOptions: null,
+        configureSchemaServices: schema =>
+        {
+            schema.SchemaRegistrations.Add(registry =>
+            {
+                var schema = new EventSchema("order.placed", "1.0", "application/json");
+                schema.Properties.Add(new EventProperty("orderId", "string", "1.0"));
+                schema.Properties[0]!.Constraints.Add(new PropertyRequiredConstraint());
+                schema.Properties.Add(new EventProperty("amount", "decimal", "1.0"));
+                schema.Properties[1]!.Constraints.Add(new PropertyRequiredConstraint());
+                registry.Register(schema);
+            });
+        });
+```
+
+You can also register schemas from CLR types using assembly scanning:
+
+```csharp
+schema.AssembliesToScan.Add(typeof(OrderPlacedData).Assembly);
+```
+
+## Configuration
+
+### Missing schema behavior
+
+Controls what happens when no schema is registered for an event type:
+
+| Behavior | Description |
+|----------|-------------|
+| `Allow` (default) | The event is published without validation |
+| `Block` | A `SchemaValidationException` is thrown |
+| `Fallback` | A schema with no constraints is used (all properties pass) |
+
+```csharp
+.UseSchemaValidation(opts =>
+{
+    opts.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+})
+```
+
+### Validation failure behavior
+
+Controls what happens when the payload does not match the schema:
+
+| Behavior | Description |
+|----------|-------------|
+| `Throw` (default) | A `SchemaValidationException` is thrown with all validation errors |
+| `Log` | Errors are logged but the event is still published |
+
+```csharp
+.UseSchemaValidation(opts =>
+{
+    opts.ValidationFailureBehavior = ValidationFailureBehavior.Log;
+})
+```
+
+## Version-aware validation
+
+The middleware supports schema versioning through the `dataversion` CloudEvent extension attribute. When present, the exact version is looked up; when absent, the latest registered version is used.
+
+```csharp
+var @event = new CloudEvent
+{
+    Type = "order.placed",
+    Source = new Uri("https://example.com"),
+    Data = data
+};
+
+// Set the version extension attribute
+var attr = CloudEventAttribute.CreateExtension("dataversion", CloudEventAttributeType.String);
+@event[attr] = "2.0";
+```
+
+## How it works
+
+The middleware runs after enrichment and before channel dispatch:
+
+1. Looks up the schema by `CloudEvent.Type` (and optional `dataversion` extension)
+2. Deserializes the event payload using a format-agnostic deserializer (JSON, XML, etc.)
+3. Validates every property against the schema's constraints (required, range, enum)
+4. On failure: throws or logs according to `ValidationFailureBehavior`
+5. On success: calls `next(context)` to continue the pipeline
+
+## Related pages
+
+- [Schema Validation](validation.md) — manual validation with `IEventSchemaValidator`
+- [Fluent Builder](fluent-builder.md) — building schemas programmatically
+- [From Annotations](from-annotations.md) — deriving schemas from annotated classes
+- [Publish Pipeline](../concepts/publish-pipeline.md) — middleware pipeline overview

--- a/docs/schema/validation.md
+++ b/docs/schema/validation.md
@@ -105,8 +105,13 @@ await foreach (var result in _validator.ValidateEventAsync(schema, @event))
 }
 ```
 
+## Publish-time validation
+
+The `Hermodr.Publisher.EventSchema` package provides a middleware that automatically validates every event against its registered schema before dispatch. See [Schema Validation at Publish Time](validation-at-publish.md) for setup and configuration.
+
 ## Related pages
 
+- [Schema Validation at Publish Time](validation-at-publish.md)
 - [Fluent Builder](fluent-builder.md)
 - [From Annotations](from-annotations.md)
 - [Event Publisher](../concepts/event-publisher.md)

--- a/src/Hermodr.AuditTrail.EntityFramework/Hermodr.AuditTrail.EntityFramework.csproj
+++ b/src/Hermodr.AuditTrail.EntityFramework/Hermodr.AuditTrail.EntityFramework.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.EntityFramework" Version="1.6.4" />
+    <PackageReference Include="Kista.EntityFramework" Version="1.6.7" />
   </ItemGroup>
 </Project>

--- a/src/Hermodr.AuditTrail.InMemory/Hermodr.AuditTrail.InMemory.csproj
+++ b/src/Hermodr.AuditTrail.InMemory/Hermodr.AuditTrail.InMemory.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.InMemory" Version="1.6.4" />
+    <PackageReference Include="Kista.InMemory" Version="1.6.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Hermodr.AuditTrail/Hermodr.AuditTrail.csproj
+++ b/src/Hermodr.AuditTrail/Hermodr.AuditTrail.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
-    <PackageReference Include="Kista" Version="1.6.4" />
+    <PackageReference Include="Kista" Version="1.6.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Hermodr.Publisher.AuditTrail/AuditTrailPublishChannel.cs
+++ b/src/Hermodr.Publisher.AuditTrail/AuditTrailPublishChannel.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 
 using CloudNative.CloudEvents;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -37,18 +38,15 @@ public class AuditTrailPublishChannel : EventPublishChannel<AuditTrailPublishOpt
     /// <param name="options">
     /// The channel-level default options resolved from the DI container.
     /// </param>
-    /// <param name="validators">
-    /// An optional collection of <see cref="IValidateOptions{AuditTrailPublishOptions}"/> services.
-    /// </param>
     /// <param name="logger">
     /// An optional logger.
     /// </param>
     public AuditTrailPublishChannel(
         IAuditTrailWriter writer,
         IOptions<AuditTrailPublishOptions> options,
-        IEnumerable<IValidateOptions<AuditTrailPublishOptions>>? validators = null,
+        IServiceProvider serviceProvider,
         ILogger<AuditTrailPublishChannel>? logger = null)
-        : base(options.Value, validators)
+        : base(options.Value, serviceProvider)
     {
         Writer = writer ?? throw new ArgumentNullException(nameof(writer));
         _logger = logger ?? NullLogger<AuditTrailPublishChannel>.Instance;

--- a/src/Hermodr.Publisher.AuditTrail/AuditTrailPublishChannel{TEvent}.cs
+++ b/src/Hermodr.Publisher.AuditTrail/AuditTrailPublishChannel{TEvent}.cs
@@ -1,5 +1,6 @@
 using CloudNative.CloudEvents;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -27,18 +28,15 @@ public class AuditTrailPublishChannel<TEvent> : AuditTrailPublishChannel, IEvent
     /// <param name="options">
     /// The channel-level default options resolved from the DI container.
     /// </param>
-    /// <param name="validators">
-    /// An optional collection of <see cref="IValidateOptions{AuditTrailPublishOptions}"/> services.
-    /// </param>
     /// <param name="logger">
     /// An optional logger.
     /// </param>
     public AuditTrailPublishChannel(
         IAuditTrailWriter writer,
         IOptions<AuditTrailPublishOptions> options,
-        IEnumerable<IValidateOptions<AuditTrailPublishOptions>>? validators = null,
+        IServiceProvider serviceProvider,
         ILogger<AuditTrailPublishChannel>? logger = null)
-        : base(writer, options, validators, logger)
+        : base(writer, options, serviceProvider, logger)
     {
     }
 }

--- a/src/Hermodr.Publisher.AzureServiceBus/ServiceBusPublishChannel.cs
+++ b/src/Hermodr.Publisher.AzureServiceBus/ServiceBusPublishChannel.cs
@@ -10,6 +10,7 @@ using Azure.Messaging.ServiceBus;
 
 using CloudNative.CloudEvents;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -43,11 +44,6 @@ namespace Hermodr {
         /// <param name="messageCreator">
         /// The factory to create the message to send to the queue.
         /// </param>
-        /// <param name="validators">
-        /// Optional collection of <see cref="IValidateOptions{ServiceBusPublishOptions}"/>
-        /// services registered in the DI container. When the collection is empty or <c>null</c>
-        /// validation falls back to DataAnnotations.
-        /// </param>
         /// <param name="logger">
         /// A logger to record the operations of the channel.
         /// </param>
@@ -55,9 +51,9 @@ namespace Hermodr {
 			IOptions<ServiceBusPublishOptions> options,
 			IServiceBusClientFactory clientFactory,
 			ServiceBusMessageFactory messageCreator,
-			IEnumerable<IValidateOptions<ServiceBusPublishOptions>>? validators = null,
+			IServiceProvider serviceProvider,
 			ILogger<ServiceBusPublishChannel>? logger = null)
-			: base(options.Value, validators) {
+			: base(options.Value, serviceProvider) {
 
 			var clientOptions = options.Value.ClientOptions ?? new ServiceBusClientOptions();
 

--- a/src/Hermodr.Publisher.AzureServiceBus/ServiceBusPublishChannel`1.cs
+++ b/src/Hermodr.Publisher.AzureServiceBus/ServiceBusPublishChannel`1.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 //
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -45,20 +46,19 @@ namespace Hermodr
         /// </param>
         /// <param name="clientFactory">Factory that creates the <see cref="ServiceBusClient"/>.</param>
         /// <param name="messageCreator">Factory that converts a CloudEvent into a Service Bus message.</param>
-        /// <param name="validators">Optional DI-registered options validators.</param>
         /// <param name="logger">Optional logger; falls back to NullLogger when <c>null</c>.</param>
         public ServiceBusPublishChannel(
             IOptions<ServiceBusPublishOptions<TEvent>> typedOptions,
             IOptions<ServiceBusPublishOptions> baseOptions,
             IServiceBusClientFactory clientFactory,
             ServiceBusMessageFactory messageCreator,
-            IEnumerable<IValidateOptions<ServiceBusPublishOptions>>? validators = null,
+            IServiceProvider serviceProvider,
             ILogger<ServiceBusPublishChannel>? logger = null)
             : base(
                 Options.Create(ServiceBusPublishOptions<TEvent>.Merge(baseOptions.Value, typedOptions.Value)),
                 clientFactory,
                 messageCreator,
-                validators,
+                serviceProvider,
                 logger)
         {
         }

--- a/src/Hermodr.Publisher.DeadLetter.EntityFramework/Hermodr.Publisher.DeadLetter.EntityFramework.csproj
+++ b/src/Hermodr.Publisher.DeadLetter.EntityFramework/Hermodr.Publisher.DeadLetter.EntityFramework.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.EntityFramework" Version="1.6.6" />
+    <PackageReference Include="Kista.EntityFramework" Version="1.6.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">

--- a/src/Hermodr.Publisher.DeadLetter/DeadLetterMessageReplayer.cs
+++ b/src/Hermodr.Publisher.DeadLetter/DeadLetterMessageReplayer.cs
@@ -20,8 +20,8 @@ public class DeadLetterMessageReplayer : IDeadLetterMessageReplayer
     private readonly DeadLetterTelemetry _telemetry = new();
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly DeadLetterReplayOptions _options;
-    private readonly IEventSystemTime _systemTime;
     private readonly ILogger _logger;
+    private readonly IServiceProvider _serviceProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DeadLetterMessageReplayer"/> class.
@@ -29,14 +29,16 @@ public class DeadLetterMessageReplayer : IDeadLetterMessageReplayer
     public DeadLetterMessageReplayer(
         IServiceScopeFactory scopeFactory,
         IOptions<DeadLetterReplayOptions> options,
-        IEventSystemTime? systemTime = null,
+        IServiceProvider serviceProvider,
         ILogger<DeadLetterMessageReplayer>? logger = null)
     {
         _scopeFactory = scopeFactory;
         _options = options.Value;
-        _systemTime = systemTime ?? EventSystemTime.Instance;
+        _serviceProvider = serviceProvider;
         _logger = logger ?? NullLogger<DeadLetterMessageReplayer>.Instance;
     }
+
+    private IEventSystemTime SystemTime => _serviceProvider.GetRequiredService<IEventSystemTime>();
 
     /// <inheritdoc />
     public async Task ReplayAsync(IDeadLetterMessage message, CancellationToken cancellationToken = default)
@@ -81,7 +83,7 @@ public class DeadLetterMessageReplayer : IDeadLetterMessageReplayer
                 await store.SetRetryAsync(
                     message,
                     ex.Message,
-                    _systemTime.UtcNow.Add(_options.RetryInterval),
+                    SystemTime.UtcNow.Add(_options.RetryInterval),
                     cancellationToken);
             }
             else

--- a/src/Hermodr.Publisher.DeliveryLog.EntityFramework/EntityEventDeliveryLogRepository.cs
+++ b/src/Hermodr.Publisher.DeliveryLog.EntityFramework/EntityEventDeliveryLogRepository.cs
@@ -1,6 +1,7 @@
 using Kista;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Hermodr;
@@ -10,28 +11,28 @@ namespace Hermodr;
 /// </summary>
 public class EntityEventDeliveryLogRepository : EntityRepository<DbEventDeliveryRecord, string>, IEventPublishDeliveryLog
 {
-    private readonly IEventSystemTime _systemTime;
     private readonly IEventDeliveryRecordFactory<DbEventDeliveryRecord> _recordFactory;
+    private readonly IServiceProvider _serviceProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EntityEventDeliveryLogRepository"/> class.
     /// </summary>
     /// <param name="context">The <see cref="DeliveryLogDbContext"/> to use for data access.</param>
     /// <param name="recordFactory">The factory used to create <see cref="DbEventDeliveryRecord"/> instances.</param>
-    /// <param name="systemTime">An optional clock abstraction for timestamping.</param>
-    /// <param name="services">An optional <see cref="IServiceProvider"/> for dependency resolution.</param>
+    /// <param name="serviceProvider">The service provider for lazy resolution of dependencies.</param>
     /// <param name="logger">An optional logger for diagnostic output.</param>
     public EntityEventDeliveryLogRepository(
         DeliveryLogDbContext context,
         IEventDeliveryRecordFactory<DbEventDeliveryRecord> recordFactory,
-        IEventSystemTime? systemTime = null,
-        IServiceProvider? services = null,
+        IServiceProvider serviceProvider,
         ILogger<EntityRepository<DbEventDeliveryRecord, string>>? logger = null)
-        : base(context, services!, logger!)
+        : base(context, serviceProvider, logger!)
     {
         _recordFactory = recordFactory;
-        _systemTime = systemTime ?? EventSystemTime.Instance;
+        _serviceProvider = serviceProvider;
     }
+
+    private IEventSystemTime SystemTime => _serviceProvider.GetRequiredService<IEventSystemTime>();
 
     /// <inheritdoc />
     public string ProviderName => "EntityFrameworkCore";

--- a/src/Hermodr.Publisher.DeliveryLog.EntityFramework/Hermodr.Publisher.DeliveryLog.EntityFramework.csproj
+++ b/src/Hermodr.Publisher.DeliveryLog.EntityFramework/Hermodr.Publisher.DeliveryLog.EntityFramework.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.EntityFramework" Version="1.6.6" />
+    <PackageReference Include="Kista.EntityFramework" Version="1.6.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">

--- a/src/Hermodr.Publisher.DeliveryLog.InMemory/Hermodr.Publisher.DeliveryLog.InMemory.csproj
+++ b/src/Hermodr.Publisher.DeliveryLog.InMemory/Hermodr.Publisher.DeliveryLog.InMemory.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.InMemory" Version="1.6.6" />
+    <PackageReference Include="Kista.InMemory" Version="1.6.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Hermodr.Publisher.DeliveryLog/DeliveryLogMiddleware.cs
+++ b/src/Hermodr.Publisher.DeliveryLog/DeliveryLogMiddleware.cs
@@ -1,4 +1,5 @@
 using CloudNative.CloudEvents;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -11,8 +12,8 @@ namespace Hermodr;
 public class DeliveryLogMiddleware : IEventMiddleware
 {
     private readonly IEventPublishDeliveryLog _deliveryLog;
-    private readonly IEventSystemTime _systemTime;
     private readonly ILogger _logger;
+    private readonly IServiceProvider _serviceProvider;
 
     /// <summary>
     /// Creates a new instance of the <see cref="DeliveryLogMiddleware"/>.
@@ -20,21 +21,23 @@ public class DeliveryLogMiddleware : IEventMiddleware
     /// <param name="deliveryLog">
     /// The service used to record delivery attempts.
     /// </param>
-    /// <param name="systemTime">
-    /// An optional service for obtaining the current UTC time; defaults to <see cref="EventSystemTime.Instance"/>.
-    /// </param>
     /// <param name="logger">
     /// An optional logger for diagnostic output.
     /// </param>
+    /// <param name="serviceProvider">
+    /// The service provider for lazy resolution of dependencies.
+    /// </param>
     public DeliveryLogMiddleware(
         IEventPublishDeliveryLog deliveryLog,
-        IEventSystemTime? systemTime = null,
-        ILogger<DeliveryLogMiddleware>? logger = null)
+        ILogger<DeliveryLogMiddleware>? logger = null,
+        IServiceProvider? serviceProvider = null)
     {
         _deliveryLog = deliveryLog ?? throw new ArgumentNullException(nameof(deliveryLog));
-        _systemTime = systemTime ?? EventSystemTime.Instance;
         _logger = logger ?? NullLogger<DeliveryLogMiddleware>.Instance;
+        _serviceProvider = serviceProvider!;
     }
+
+    private IEventSystemTime SystemTime => _serviceProvider.GetRequiredService<IEventSystemTime>();
 
     /// <summary>
     /// Invokes the middleware, recording the delivery outcome after the next delegate completes.
@@ -50,7 +53,7 @@ public class DeliveryLogMiddleware : IEventMiddleware
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(next);
 
-        var startTime = _systemTime.UtcNow;
+        var startTime = SystemTime.UtcNow;
         var channelName = (context.Options as INamedChannelFilter)?.ChannelName;
         var attempt = GetAttemptNumber(context);
         var outcome = EventDeliveryOutcome.Succeeded;
@@ -71,7 +74,7 @@ public class DeliveryLogMiddleware : IEventMiddleware
         }
         finally
         {
-            var elapsed = _systemTime.UtcNow - startTime;
+            var elapsed = SystemTime.UtcNow - startTime;
 
             var record = new EventDeliveryRecord
             {

--- a/src/Hermodr.Publisher.EventSchema/EventPublisherBuilderExtensions.cs
+++ b/src/Hermodr.Publisher.EventSchema/EventPublisherBuilderExtensions.cs
@@ -1,0 +1,90 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Extension methods for <see cref="EventPublisherBuilder"/> that add schema validation
+    /// to the event publishing pipeline.
+    /// </summary>
+    public static class EventPublisherBuilderExtensions
+    {
+        /// <summary>
+        /// Adds schema validation middleware to the publisher pipeline.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This middleware validates every event's payload against its registered schema
+        /// before the event reaches any publish channel. Validation is performed using
+        /// format-agnostic deserialization (JSON, XML, etc.) and checks constraints such
+        /// as required fields, range limits, and enum values.
+        /// </para>
+        /// <para>
+        /// If schema services (<see cref="IEventSchemaRegistry"/>, <see cref="IEventSchemaValidator"/>,
+        /// etc.) have not been registered yet, they are automatically registered by this method.
+        /// </para>
+        /// </remarks>
+        /// <param name="builder">The publisher builder to configure.</param>
+        /// <param name="configureOptions">
+        /// An optional action to customize <see cref="SchemaValidationOptions"/>.
+        /// </param>
+        /// <param name="configureSchemaServices">
+        /// An optional action to configure schema service options (assembly scanning, explicit registrations).
+        /// Only used when schema services are not already registered.
+        /// </param>
+        /// <returns>The same <paramref name="builder"/> for chaining.</returns>
+        /// <example>
+        /// <code language="csharp">
+        /// services.AddEventPublisher()
+        ///     .UseSchemaValidation(options =>
+        ///     {
+        ///         options.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+        ///         options.ValidationFailureBehavior = ValidationFailureBehavior.Throw;
+        ///     }, schemaOptions =>
+        ///     {
+        ///         schemaOptions.AssembliesToScan.Add(typeof(Program).Assembly);
+        ///     })
+        ///     .AddChannel&lt;RabbitMqPublishChannel&gt;();
+        /// </code>
+        /// </example>
+        public static EventPublisherBuilder UseSchemaValidation(
+            this EventPublisherBuilder builder,
+            Action<SchemaValidationOptions>? configureOptions = null,
+            Action<EventSchemaServicesOptions>? configureSchemaServices = null)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            // Auto-register schema services if not already registered
+            var schemaRegistryRegistered = builder.Services.Any(
+                d => d.ServiceType == typeof(IEventSchemaRegistry));
+
+            if (!schemaRegistryRegistered)
+            {
+                builder.Services.AddEventSchemaServices(configureSchemaServices);
+            }
+            else if (configureSchemaServices != null)
+            {
+                builder.Services.Configure(configureSchemaServices);
+            }
+
+            // Configure validation options
+            if (configureOptions != null)
+            {
+                builder.Services.Configure(configureOptions);
+            }
+
+            // Pre-register middleware in DI so all constructor dependencies are resolved
+            builder.Services.TryAddSingleton<SchemaValidationMiddleware>();
+
+            // Add middleware to pipeline
+            builder.Use<SchemaValidationMiddleware>();
+
+            return builder;
+        }
+    }
+}

--- a/src/Hermodr.Publisher.EventSchema/Hermodr.Publisher.EventSchema.csproj
+++ b/src/Hermodr.Publisher.EventSchema/Hermodr.Publisher.EventSchema.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Hermodr Publisher Event Schema Validation</Title>
+    <Description>Schema validation middleware for the Hermodr event publisher, validating event payloads against registered schemas before channel dispatch.</Description>
+    <PackageTags>event;events;schema;validation;publisher;middleware</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Hermodr.Publisher\Hermodr.Publisher.csproj" />
+    <ProjectReference Include="..\Hermodr.Schema\Hermodr.Schema.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Hermodr.Publisher.EventSchema/MissingSchemaBehavior.cs
+++ b/src/Hermodr.Publisher.EventSchema/MissingSchemaBehavior.cs
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Defines the behavior when no schema is registered for an event type.
+    /// </summary>
+    public enum MissingSchemaBehavior
+    {
+        /// <summary>
+        /// Skip validation when no schema is found for the event type.
+        /// The event is published without schema validation.
+        /// </summary>
+        Allow = 0,
+
+        /// <summary>
+        /// Throw a <see cref="SchemaValidationException"/> when no schema is found
+        /// for the event type.
+        /// </summary>
+        Block = 1,
+
+        /// <summary>
+        /// Use a default "object" schema (no constraints) when no schema is found.
+        /// The event is published without constraint validation.
+        /// </summary>
+        Fallback = 2
+    }
+}

--- a/src/Hermodr.Publisher.EventSchema/SchemaValidationException.cs
+++ b/src/Hermodr.Publisher.EventSchema/SchemaValidationException.cs
@@ -1,0 +1,60 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Exception thrown when schema validation fails during event publishing.
+    /// </summary>
+    public class SchemaValidationException : Exception
+    {
+        /// <summary>
+        /// Gets the list of validation errors that caused the exception.
+        /// </summary>
+        public IReadOnlyList<ValidationResult> Errors { get; }
+
+        /// <summary>
+        /// Gets the event type that was being validated, if known.
+        /// </summary>
+        public string? EventType { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchemaValidationException"/> class.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="errors">The validation errors.</param>
+        /// <param name="eventType">The event type being validated.</param>
+        public SchemaValidationException(
+            string message,
+            IReadOnlyList<ValidationResult>? errors = null,
+            string? eventType = null)
+            : base(message)
+        {
+            Errors = errors ?? Array.Empty<ValidationResult>();
+            EventType = eventType;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchemaValidationException"/> class
+        /// with a single validation error.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="error">The single validation error.</param>
+        /// <param name="eventType">The event type being validated.</param>
+        public SchemaValidationException(
+            string message,
+            ValidationResult error,
+            string? eventType = null)
+            : base(message)
+        {
+            Errors = error != null
+                ? new[] { error }
+                : Array.Empty<ValidationResult>();
+            EventType = eventType;
+        }
+    }
+}

--- a/src/Hermodr.Publisher.EventSchema/SchemaValidationMiddleware.cs
+++ b/src/Hermodr.Publisher.EventSchema/SchemaValidationMiddleware.cs
@@ -1,0 +1,124 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Middleware that validates event payloads against their registered schemas
+    /// before the event reaches any publish channel.
+    /// </summary>
+    public sealed class SchemaValidationMiddleware : IEventMiddleware
+    {
+        private readonly IEventSchemaRegistry _schemaRegistry;
+        private readonly IEventSchemaValidator _validator;
+        private readonly SchemaValidationOptions _options;
+        private readonly ILogger<SchemaValidationMiddleware> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchemaValidationMiddleware"/> class.
+        /// </summary>
+        /// <param name="schemaRegistry">The schema registry for schema lookup.</param>
+        /// <param name="validator">The schema validator.</param>
+        /// <param name="options">The validation options.</param>
+        /// <param name="logger">A logger instance.</param>
+        /// <param name="initializer">Ensures schema registrations are applied before first validation.</param>
+        public SchemaValidationMiddleware(
+            IEventSchemaRegistry schemaRegistry,
+            IEventSchemaValidator validator,
+            IOptions<SchemaValidationOptions> options,
+            ILogger<SchemaValidationMiddleware> logger,
+            SchemaRegistrationsApplier registrations)
+        {
+            _schemaRegistry = schemaRegistry;
+            _validator = validator;
+            _options = options?.Value ?? new SchemaValidationOptions();
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public async Task InvokeAsync(EventContext context, EventPublishDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(next);
+
+            var eventType = context.Event.Type;
+            var version = context.Event["dataversion"] as string;
+
+            // Lookup schema by event type + version
+            var schema = string.IsNullOrEmpty(eventType) ? null : _schemaRegistry.GetSchema(eventType, version);
+
+            if (schema == null)
+            {
+                switch (_options.MissingSchemaBehavior)
+                {
+                    case MissingSchemaBehavior.Block:
+                        throw new SchemaValidationException(
+                            $"No schema registered for event type '{eventType}'" +
+                            (version != null ? $" version '{version}'" : ""),
+                            eventType: eventType);
+
+                    case MissingSchemaBehavior.Fallback:
+                        // Use a default empty schema (no constraints)
+                        schema = CreateFallbackSchema(eventType, version);
+                        break;
+
+                    case MissingSchemaBehavior.Allow:
+                    default:
+                        _logger.LogDebug(
+                            "No schema found for event type {EventType}{Version}, skipping validation",
+                            eventType,
+                            version != null ? $" (version {version})" : "");
+                        await next(context);
+                        return;
+                }
+            }
+
+            // Validate event payload against schema
+            var errors = new List<ValidationResult>();
+            await foreach (var error in _validator.ValidateEventAsync(schema, context.Event, context.CancellationToken))
+            {
+                errors.Add(error);
+            }
+
+            if (errors.Count > 0)
+            {
+                var exception = new SchemaValidationException(
+                    $"Schema validation failed for event type '{eventType}'" +
+                    (version != null ? $" version '{version}'" : "") +
+                    $" with {errors.Count} error(s): {string.Join("; ", errors.Select(e => e.ErrorMessage))}",
+                    errors,
+                    eventType);
+
+                if (_options.LogValidationErrors)
+                {
+                    _logger.LogError(exception,
+                        "Schema validation failed for event type {EventType}{Version} with {ErrorCount} error(s)",
+                        eventType,
+                        version != null ? $" (version {version})" : "",
+                        errors.Count);
+                }
+
+                if (_options.ValidationFailureBehavior == ValidationFailureBehavior.Throw)
+                {
+                    throw exception;
+                }
+            }
+
+            await next(context);
+        }
+
+        private static IEventSchema CreateFallbackSchema(string eventType, string? version)
+        {
+            return new EventSchema(
+                eventType,
+                version ?? "1.0",
+                "object");
+        }
+    }
+}

--- a/src/Hermodr.Publisher.EventSchema/SchemaValidationMiddleware.cs
+++ b/src/Hermodr.Publisher.EventSchema/SchemaValidationMiddleware.cs
@@ -4,7 +4,9 @@
 //
 
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Hermodr
@@ -15,30 +17,52 @@ namespace Hermodr
     /// </summary>
     public sealed class SchemaValidationMiddleware : IEventMiddleware
     {
-        private readonly IEventSchemaRegistry _schemaRegistry;
-        private readonly IEventSchemaValidator _validator;
         private readonly SchemaValidationOptions _options;
         private readonly ILogger<SchemaValidationMiddleware> _logger;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly Lazy<Task> _initializationTask;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SchemaValidationMiddleware"/> class.
         /// </summary>
-        /// <param name="schemaRegistry">The schema registry for schema lookup.</param>
-        /// <param name="validator">The schema validator.</param>
         /// <param name="options">The validation options.</param>
         /// <param name="logger">A logger instance.</param>
-        /// <param name="initializer">Ensures schema registrations are applied before first validation.</param>
+        /// <param name="serviceProvider">The service provider for lazy resolution of dependencies.</param>
         public SchemaValidationMiddleware(
-            IEventSchemaRegistry schemaRegistry,
-            IEventSchemaValidator validator,
             IOptions<SchemaValidationOptions> options,
             ILogger<SchemaValidationMiddleware> logger,
-            SchemaRegistrationsApplier registrations)
+            IServiceProvider serviceProvider)
         {
-            _schemaRegistry = schemaRegistry;
-            _validator = validator;
             _options = options?.Value ?? new SchemaValidationOptions();
-            _logger = logger;
+            _logger = logger ?? NullLogger<SchemaValidationMiddleware>.Instance;
+            _serviceProvider = serviceProvider;
+            _initializationTask = new Lazy<Task>(InitializeAsync, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        private IEventSchemaRegistry SchemaRegistry =>
+            _serviceProvider.GetRequiredService<IEventSchemaRegistry>();
+
+        private IEventSchemaValidator Validator =>
+            _serviceProvider.GetRequiredService<IEventSchemaValidator>();
+
+        private async Task InitializeAsync()
+        {
+            var options = _serviceProvider.GetRequiredService<IOptions<EventSchemaServicesOptions>>();
+            var registry = _serviceProvider.GetRequiredService<IEventSchemaRegistry>();
+            var deserializerRegistry = _serviceProvider.GetRequiredService<IEventDataDeserializerRegistry>();
+            var deserializers = _serviceProvider.GetServices<IEventDataDeserializer>();
+
+            foreach (var deserializer in deserializers)
+                deserializerRegistry.Register(deserializer);
+
+            foreach (var deserializer in options.Value.AdditionalDeserializers)
+                deserializerRegistry.Register(deserializer);
+
+            foreach (var assembly in options.Value.AssembliesToScan)
+                registry.ScanAssembly(assembly);
+
+            foreach (var registration in options.Value.SchemaRegistrations)
+                registration(registry);
         }
 
         /// <inheritdoc/>
@@ -47,11 +71,13 @@ namespace Hermodr
             ArgumentNullException.ThrowIfNull(context);
             ArgumentNullException.ThrowIfNull(next);
 
+            await _initializationTask.Value;
+
             var eventType = context.Event.Type;
             var version = context.Event["dataversion"] as string;
 
             // Lookup schema by event type + version
-            var schema = string.IsNullOrEmpty(eventType) ? null : _schemaRegistry.GetSchema(eventType, version);
+            var schema = string.IsNullOrEmpty(eventType) ? null : SchemaRegistry.GetSchema(eventType, version);
 
             if (schema == null)
             {
@@ -81,7 +107,7 @@ namespace Hermodr
 
             // Validate event payload against schema
             var errors = new List<ValidationResult>();
-            await foreach (var error in _validator.ValidateEventAsync(schema, context.Event, context.CancellationToken))
+            await foreach (var error in Validator.ValidateEventAsync(schema, context.Event, context.CancellationToken))
             {
                 errors.Add(error);
             }

--- a/src/Hermodr.Publisher.EventSchema/SchemaValidationOptions.cs
+++ b/src/Hermodr.Publisher.EventSchema/SchemaValidationOptions.cs
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Configuration options for schema validation middleware.
+    /// </summary>
+    public class SchemaValidationOptions
+    {
+        /// <summary>
+        /// Gets or sets the behavior when no schema is registered for an event type.
+        /// Defaults to <see cref="MissingSchemaBehavior.Allow"/> for backward compatibility.
+        /// </summary>
+        public MissingSchemaBehavior MissingSchemaBehavior { get; set; } = MissingSchemaBehavior.Allow;
+
+        /// <summary>
+        /// Gets or sets the behavior when schema validation fails.
+        /// Defaults to <see cref="ValidationFailureBehavior.Throw"/> for fail-fast validation.
+        /// </summary>
+        public ValidationFailureBehavior ValidationFailureBehavior { get; set; } = ValidationFailureBehavior.Throw;
+
+        /// <summary>
+        /// Gets or sets whether validation errors are logged even when not thrown.
+        /// Defaults to <c>true</c>.
+        /// </summary>
+        public bool LogValidationErrors { get; set; } = true;
+
+        /// <summary>
+        /// Gets the list of content types that should be validated.
+        /// When empty, all content types with a registered deserializer are validated.
+        /// </summary>
+        public IList<string> SupportedContentTypes { get; } = new List<string>();
+    }
+}

--- a/src/Hermodr.Publisher.EventSchema/ValidationFailureBehavior.cs
+++ b/src/Hermodr.Publisher.EventSchema/ValidationFailureBehavior.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Defines the behavior when schema validation fails.
+    /// </summary>
+    public enum ValidationFailureBehavior
+    {
+        /// <summary>
+        /// Throw a <see cref="SchemaValidationException"/> when validation fails.
+        /// This is the default and recommended behavior for fail-fast validation.
+        /// </summary>
+        Throw = 0,
+
+        /// <summary>
+        /// Log the validation error but continue with publishing.
+        /// NOT RECOMMENDED for production use, as it defeats the purpose of validation.
+        /// </summary>
+        Log = 1
+    }
+}

--- a/src/Hermodr.Publisher.MassTransit/MassTransitPublishChannel.cs
+++ b/src/Hermodr.Publisher.MassTransit/MassTransitPublishChannel.cs
@@ -12,6 +12,7 @@ using CloudNative.CloudEvents.SystemTextJson;
 
 using MassTransit;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -45,11 +46,6 @@ namespace Hermodr
         /// <param name="sendEndpointProvider">
         /// The MassTransit send-endpoint provider used when a destination address is configured.
         /// </param>
-        /// <param name="validators">
-        /// Optional collection of <see cref="IValidateOptions{MassTransitPublishOptions}"/>
-        /// services registered in the DI container. When the collection is empty or <c>null</c>
-        /// validation falls back to DataAnnotations.
-        /// </param>
         /// <param name="logger">
         /// An optional logger; when <c>null</c> a <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger{T}"/> is used.
         /// </param>
@@ -57,9 +53,9 @@ namespace Hermodr
             IOptions<MassTransitPublishOptions> options,
             IPublishEndpoint publishEndpoint,
             ISendEndpointProvider sendEndpointProvider,
-            IEnumerable<IValidateOptions<MassTransitPublishOptions>>? validators = null,
+            IServiceProvider serviceProvider,
             ILogger<MassTransitPublishChannel>? logger = null)
-            : base(options.Value, validators)
+            : base(options.Value, serviceProvider)
         {
             _publishEndpoint = publishEndpoint;
             _sendEndpointProvider = sendEndpointProvider;

--- a/src/Hermodr.Publisher.MassTransit/MassTransitPublishChannel`1.cs
+++ b/src/Hermodr.Publisher.MassTransit/MassTransitPublishChannel`1.cs
@@ -5,6 +5,7 @@
 
 using MassTransit;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -42,20 +43,19 @@ namespace Hermodr
         /// </param>
         /// <param name="publishEndpoint">MassTransit publish endpoint.</param>
         /// <param name="sendEndpointProvider">MassTransit send-endpoint provider.</param>
-        /// <param name="validators">Optional DI-registered options validators.</param>
         /// <param name="logger">Optional logger; falls back to NullLogger when <c>null</c>.</param>
         public MassTransitPublishChannel(
             IOptions<MassTransitPublishOptions<TEvent>> typedOptions,
             IOptions<MassTransitPublishOptions> baseOptions,
             IPublishEndpoint publishEndpoint,
             ISendEndpointProvider sendEndpointProvider,
-            IEnumerable<IValidateOptions<MassTransitPublishOptions>>? validators = null,
+            IServiceProvider serviceProvider,
             ILogger<MassTransitPublishChannel>? logger = null)
             : base(
                 Options.Create(MassTransitPublishOptions.Merge(baseOptions.Value, typedOptions.Value)),
                 publishEndpoint,
                 sendEndpointProvider,
-                validators,
+                serviceProvider,
                 logger)
         {
         }

--- a/src/Hermodr.Publisher.Outbox.EntityFramework/Hermodr.Publisher.Outbox.EntityFramework.csproj
+++ b/src/Hermodr.Publisher.Outbox.EntityFramework/Hermodr.Publisher.Outbox.EntityFramework.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Kista.EntityFramework" Version="1.6.6" />
+        <PackageReference Include="Kista.EntityFramework" Version="1.6.7" />
     </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">

--- a/src/Hermodr.Publisher.Outbox/OutboxPublishChannel.cs
+++ b/src/Hermodr.Publisher.Outbox/OutboxPublishChannel.cs
@@ -20,7 +20,6 @@ internal sealed class OutboxPublishChannel<TMessage> : EventPublishChannel<Outbo
     private readonly OutboxTelemetry _telemetry = new();
     private readonly IOutboxMessageFactory<TMessage> _messageFactory;
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IEventSystemTime _systemTime;
     private readonly ILogger _logger;
 
     /// <summary>
@@ -39,14 +38,6 @@ internal sealed class OutboxPublishChannel<TMessage> : EventPublishChannel<Outbo
     /// <see cref="IOutboxMessageStore{TMessage}"/> can be resolved without causing
     /// a scoped-in-singleton lifetime violation.
     /// </param>
-    /// <param name="systemTime">
-    /// The clock abstraction used to evaluate whether a scheduled publish time is
-    /// in the future and should be deferred in the outbox.
-    /// </param>
-    /// <param name="validators">
-    /// An optional collection of <see cref="IValidateOptions{TOptions}"/> services.
-    /// When empty or <c>null</c> validation falls back to DataAnnotations.
-    /// </param>
     /// <param name="logger">
     /// An optional logger; when <c>null</c> a <see cref="NullLogger{T}"/> is used.
     /// </param>
@@ -54,18 +45,15 @@ internal sealed class OutboxPublishChannel<TMessage> : EventPublishChannel<Outbo
         IOptions<OutboxPublishOptions> options,
         IOutboxMessageFactory<TMessage> messageFactory,
         IServiceScopeFactory scopeFactory,
-        IEventSystemTime systemTime,
-        IEnumerable<IValidateOptions<OutboxPublishOptions>>? validators = null,
+        IServiceProvider serviceProvider,
         ILogger<OutboxPublishChannel<TMessage>>? logger = null)
-        : base(options.Value, validators)
+        : base(options.Value, serviceProvider)
     {
         ArgumentNullException.ThrowIfNull(messageFactory);
         ArgumentNullException.ThrowIfNull(scopeFactory);
-        ArgumentNullException.ThrowIfNull(systemTime);
 
         _messageFactory = messageFactory;
         _scopeFactory   = scopeFactory;
-        _systemTime     = systemTime;
         _logger = logger ?? NullLogger<OutboxPublishChannel<TMessage>>.Instance;
     }
 
@@ -97,7 +85,7 @@ internal sealed class OutboxPublishChannel<TMessage> : EventPublishChannel<Outbo
             var message = _messageFactory.Create(@event, options);
             await store.AddAsync(message, cancellationToken);
 
-            if (options.ScheduleDeliveryAt is { } scheduleDeliveryAt && scheduleDeliveryAt > _systemTime.UtcNow)
+            if (options.ScheduleDeliveryAt is { } scheduleDeliveryAt && scheduleDeliveryAt > ServiceProvider.GetRequiredService<IEventSystemTime>().UtcNow)
             {
                 await store.SetDeferredAsync(message, scheduleDeliveryAt, cancellationToken);
             }

--- a/src/Hermodr.Publisher.RabbitMq/RabbitMqPublishChannel.cs
+++ b/src/Hermodr.Publisher.RabbitMq/RabbitMqPublishChannel.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 
 using CloudNative.CloudEvents;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -46,10 +47,9 @@ namespace Hermodr
         IAsyncDisposable, IDisposable
     {
         private readonly RabbitMqTransportTelemetry _telemetry = new();
-        private readonly IRabbitMqMessageFactory _messageFactory;
-        private readonly IEventSystemTime _systemTime;
         private readonly ILogger _logger;
         private readonly IConnection _connection;
+        private IRabbitMqMessageFactory? _messageFactory;
 
         // Semaphore used to serialize channel creation and publishing so that
         // a channel is not shared across concurrent callers during recovery.
@@ -68,38 +68,22 @@ namespace Hermodr
         /// An active <see cref="RabbitMQ.Client.IConnection"/> to the RabbitMQ broker.
         /// The channel borrows this connection and does not dispose it.
         /// </param>
-        /// <param name="messageFactory">
-        /// The factory used to convert a <see cref="CloudNative.CloudEvents.CloudEvent"/>
-        /// into a <see cref="RabbitMqMessage"/> ready for publishing.
-        /// </param>
-        /// <param name="systemTime">
-        /// Optional provider of the current UTC time; used to stamp
-        /// <see cref="RabbitMQ.Client.AmqpTimestamp"/> on messages whose
-        /// <see cref="CloudNative.CloudEvents.CloudEvent.Time"/> is <c>null</c>.
-        /// Defaults to <see cref="EventSystemTime.Instance"/> when <c>null</c>.
-        /// </param>
-        /// <param name="validators">
-        /// Optional collection of <see cref="IValidateOptions{RabbitMqPublishOptions}"/>
-        /// services registered in the DI container. When the collection is empty or <c>null</c>
-        /// validation falls back to DataAnnotations.
-        /// </param>
         /// <param name="logger">
         /// An optional logger; when <c>null</c> a <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger{T}"/> is used.
         /// </param>
         public RabbitMqPublishChannel(
             IOptions<RabbitMqPublishOptions> options,
             IConnection connection,
-            IRabbitMqMessageFactory messageFactory,
-            IEventSystemTime? systemTime = null,
-            IEnumerable<IValidateOptions<RabbitMqPublishOptions>>? validators = null,
+            IServiceProvider serviceProvider,
             ILogger<RabbitMqPublishChannel>? logger = null)
-            : base(options.Value, validators)
+            : base(options.Value, serviceProvider)
         {
             _connection = connection;
-            _messageFactory = messageFactory;
-            _systemTime = systemTime ?? EventSystemTime.Instance;
             _logger = logger ?? new NullLogger<RabbitMqPublishChannel>();
         }
+
+        private IRabbitMqMessageFactory MessageFactory =>
+            _messageFactory ??= ServiceProvider.GetRequiredService<IRabbitMqMessageFactory>();
 
         // ── Effective defaults for nullable value-type properties ──────────────────
         private const bool DefaultPersistentMessages = true;
@@ -193,7 +177,7 @@ namespace Hermodr
             if (string.IsNullOrWhiteSpace(routingKey))
                 throw new InvalidOperationException("The routing key is not defined");
 
-            var message = _messageFactory.CreateMessage(@event);
+            var message = MessageFactory.CreateMessage(@event);
 
             var props = new BasicProperties
             {
@@ -202,7 +186,7 @@ namespace Hermodr
                 Type = @event.Type,
                 MessageId = @event.Id,
                 Timestamp = new AmqpTimestamp(
-                    (@event.Time ?? _systemTime.UtcNow).ToUnixTimeSeconds()),
+                    (@event.Time ?? ServiceProvider.GetRequiredService<IEventSystemTime>().UtcNow).ToUnixTimeSeconds()),
                 DeliveryMode = (options.PersistentMessages ?? DefaultPersistentMessages)
                     ? DeliveryModes.Persistent
                     : DeliveryModes.Transient,

--- a/src/Hermodr.Publisher.RabbitMq/RabbitMqPublishChannel`1.cs
+++ b/src/Hermodr.Publisher.RabbitMq/RabbitMqPublishChannel`1.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 //
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -44,23 +45,17 @@ namespace Hermodr
         /// will contain default values that are overridden by <paramref name="typedOptions"/>.
         /// </param>
         /// <param name="connection">The AMQ connection shared with other channels.</param>
-        /// <param name="messageFactory">Factory that converts a CloudEvent into a RabbitMQ message.</param>
-        /// <param name="validators">Optional DI-registered options validators.</param>
         /// <param name="logger">Optional logger; falls back to NullLogger when <c>null</c>.</param>
         public RabbitMqPublishChannel(
             IOptions<RabbitMqPublishOptions<TEvent>> typedOptions,
             IOptions<RabbitMqPublishOptions> baseOptions,
             IConnection connection,
-            IRabbitMqMessageFactory messageFactory,
-            IEventSystemTime? systemTime = null,
-            IEnumerable<IValidateOptions<RabbitMqPublishOptions>>? validators = null,
+            IServiceProvider serviceProvider,
             ILogger<RabbitMqPublishChannel>? logger = null)
             : base(
                 Options.Create(RabbitMqPublishOptions.Merge(baseOptions.Value, typedOptions.Value)),
                 connection,
-                messageFactory,
-                systemTime,
-                validators,
+                serviceProvider,
                 logger)
         {
         }

--- a/src/Hermodr.Publisher.Webhook/WebhookPublishChannel.cs
+++ b/src/Hermodr.Publisher.Webhook/WebhookPublishChannel.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 
 using CloudNative.CloudEvents;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -52,8 +53,8 @@ namespace Hermodr
         private readonly IEventSystemTime _systemTime;
         private readonly ILogger _logger;
 
-        private readonly IDictionary<WebhookSignatureAlgorithm, IWebhookSignatureProvider> _signatureProviders;
-        private readonly IDictionary<string, IEventSerializer> _serializers;
+        private IDictionary<WebhookSignatureAlgorithm, IWebhookSignatureProvider>? _signatureProviders;
+        private IDictionary<string, IEventSerializer>? _serializers;
 
         // Cached pipeline built from the channel-level default retry options.
         // Avoids rebuilding the Polly pipeline on every delivery when per-call
@@ -68,23 +69,6 @@ namespace Hermodr
         /// The <see cref="IHttpClientFactory"/> used to create named HTTP clients for
         /// each delivery attempt.
         /// </param>
-        /// <param name="signatureProviders">
-        /// Optional set of <see cref="IWebhookSignatureProvider"/> implementations.
-        /// When non-<c>null</c>, any provider whose
-        /// <see cref="IWebhookSignatureProvider.Algorithm"/> matches an entry already
-        /// registered replaces the built-in default for that algorithm.
-        /// </param>
-        /// <param name="serializers">
-        /// Optional set of <see cref="IEventSerializer"/> implementations.
-        /// When non-<c>null</c>, any serializer whose
-        /// <see cref="IEventSerializer.Format"/> matches a built-in key replaces the default.
-        /// </param>
-        /// <param name="validators">
-        /// Optional collection of <see cref="IValidateOptions{WebhookPublishOptions}"/>
-        /// services registered in the DI container. When the collection is empty or <c>null</c>
-        /// validation falls back to DataAnnotations applied to the effective
-        /// (merged) <see cref="WebhookPublishOptions"/>.
-        /// </param>
         /// <param name="logger">
         /// An optional logger; when <c>null</c> a
         /// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger{T}"/> is used.
@@ -92,15 +76,12 @@ namespace Hermodr
         public WebhookPublishChannel(
             IOptions<WebhookPublishOptions> options,
             IHttpClientFactory httpClientFactory,
-            IEventSystemTime? systemTime = null,
-            IEnumerable<IWebhookSignatureProvider>? signatureProviders = null,
-            IEnumerable<IEventSerializer>? serializers = null,
-            IEnumerable<IValidateOptions<WebhookPublishOptions>>? validators = null,
+            IServiceProvider serviceProvider,
             ILogger<WebhookPublishChannel>? logger = null)
-            : base(options.Value, validators)
+            : base(options.Value, serviceProvider)
         {
             _httpClientFactory = httpClientFactory;
-            _systemTime        = systemTime ?? EventSystemTime.Instance;
+            _systemTime        = EventSystemTime.Instance;
             _logger            = logger ?? NullLogger<WebhookPublishChannel>.Instance;
 
             // Build the default pipeline lazily from the channel-level options.
@@ -113,35 +94,55 @@ namespace Hermodr
                     options.Value.RetryBackoffMultiplier ?? 2.0,
                     options.Value.RetryableStatusCodes),
                 LazyThreadSafetyMode.ExecutionAndPublication);
-
-            // Signature providers
-            _signatureProviders = new Dictionary<WebhookSignatureAlgorithm, IWebhookSignatureProvider>
-            {
-                [WebhookSignatureAlgorithm.HmacSha256] = HmacSha256SignatureProvider.Default,
-                [WebhookSignatureAlgorithm.HmacSha384] = HmacSha384SignatureProvider.Default,
-                [WebhookSignatureAlgorithm.HmacSha512] = HmacSha512SignatureProvider.Default,
-#pragma warning disable CS0618
-                [WebhookSignatureAlgorithm.HmacSha1]   = HmacSha1SignatureProvider.Default,
-#pragma warning restore CS0618
-            };
-            if (signatureProviders != null)
-                foreach (var p in signatureProviders)
-                    _signatureProviders[p.Algorithm] = p;
-
-            // Message serializers — keyed by format string
-            _serializers = new Dictionary<string, IEventSerializer>(StringComparer.OrdinalIgnoreCase)
-            {
-                [EventMessageFormat.Json]            = JsonEventSerializer.Default,
-                [EventMessageFormat.Xml]             = XmlEventSerializer.Default,
-                [EventMessageFormat.CloudEventsJson] = CloudEventsJsonSerializer.Default,
-                [EventMessageFormat.CloudEventsXml]  = CloudEventsXmlSerializer.Default,
-            };
-            if (serializers != null)
-                foreach (var s in serializers)
-                    _serializers[s.Format] = s;
         }
 
         // ── EventPublishChannel<WebhookPublishOptions> ──────────────────
+
+        private IEventSystemTime SystemTime => ServiceProvider.GetRequiredService<IEventSystemTime>();
+
+        private IDictionary<WebhookSignatureAlgorithm, IWebhookSignatureProvider> SignatureProviders
+        {
+            get
+            {
+                if (_signatureProviders == null)
+                {
+                    var providers = new Dictionary<WebhookSignatureAlgorithm, IWebhookSignatureProvider>
+                    {
+                        [WebhookSignatureAlgorithm.HmacSha256] = HmacSha256SignatureProvider.Default,
+                        [WebhookSignatureAlgorithm.HmacSha384] = HmacSha384SignatureProvider.Default,
+                        [WebhookSignatureAlgorithm.HmacSha512] = HmacSha512SignatureProvider.Default,
+#pragma warning disable CS0618
+                        [WebhookSignatureAlgorithm.HmacSha1]   = HmacSha1SignatureProvider.Default,
+#pragma warning restore CS0618
+                    };
+                    foreach (var p in ServiceProvider.GetServices<IWebhookSignatureProvider>())
+                        providers[p.Algorithm] = p;
+                    _signatureProviders = providers;
+                }
+                return _signatureProviders;
+            }
+        }
+
+        private IDictionary<string, IEventSerializer> Serializers
+        {
+            get
+            {
+                if (_serializers == null)
+                {
+                    var serializers = new Dictionary<string, IEventSerializer>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [EventMessageFormat.Json]            = JsonEventSerializer.Default,
+                        [EventMessageFormat.Xml]             = XmlEventSerializer.Default,
+                        [EventMessageFormat.CloudEventsJson] = CloudEventsJsonSerializer.Default,
+                        [EventMessageFormat.CloudEventsXml]  = CloudEventsXmlSerializer.Default,
+                    };
+                    foreach (var s in ServiceProvider.GetServices<IEventSerializer>())
+                        serializers[s.Format] = s;
+                    _serializers = serializers;
+                }
+                return _serializers;
+            }
+        }
 
         /// <summary>
         /// Performs a property-level merge: each nullable delivery field in
@@ -257,7 +258,7 @@ namespace Hermodr
 
             var deliveryId = Guid.NewGuid().ToString("N");
             var provider   = GetSignatureProvider(signatureAlgorithm);
-            var timestamp  = (eventTime ?? _systemTime.UtcNow).ToUnixTimeSeconds();
+            var timestamp  = (eventTime ?? SystemTime.UtcNow).ToUnixTimeSeconds();
             var algorithm  = signatureAlgorithm.ToString();
 
             if (eventType != null)
@@ -396,14 +397,14 @@ namespace Hermodr
 
         private IEventSerializer GetSerializer(string format)
         {
-            if (_serializers.TryGetValue(format, out var s)) return s;
+            if (Serializers.TryGetValue(format, out var s)) return s;
             throw new NotSupportedException(
                 $"No serializer registered for webhook message format '{format}'.");
         }
 
         private IWebhookSignatureProvider GetSignatureProvider(WebhookSignatureAlgorithm alg)
         {
-            if (_signatureProviders.TryGetValue(alg, out var p)) return p;
+            if (SignatureProviders.TryGetValue(alg, out var p)) return p;
             throw new NotSupportedException($"No signature provider registered for algorithm '{alg}'.");
         }
 

--- a/src/Hermodr.Publisher.Webhook/WebhookPublishChannel`1.cs
+++ b/src/Hermodr.Publisher.Webhook/WebhookPublishChannel`1.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 //
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -40,26 +41,17 @@ namespace Hermodr
         /// <c>AddWebhooks(configure)</c>.  Unset typed values fall back to these defaults.
         /// </param>
         /// <param name="httpClientFactory">HTTP client factory for webhook delivery.</param>
-        /// <param name="signatureProviders">Optional signature providers.</param>
-        /// <param name="serializers">Optional event serializers.</param>
-        /// <param name="validators">Optional DI-registered options validators.</param>
         /// <param name="logger">Optional logger; falls back to NullLogger when <c>null</c>.</param>
         public WebhookPublishChannel(
             IOptions<WebhookPublishOptions<TEvent>> typedOptions,
             IOptions<WebhookPublishOptions> baseOptions,
             IHttpClientFactory httpClientFactory,
-            IEventSystemTime? systemTime = null,
-            IEnumerable<IWebhookSignatureProvider>? signatureProviders = null,
-            IEnumerable<IEventSerializer>? serializers = null,
-            IEnumerable<IValidateOptions<WebhookPublishOptions>>? validators = null,
+            IServiceProvider serviceProvider,
             ILogger<WebhookPublishChannel>? logger = null)
             : base(
                 Options.Create(WebhookPublishOptions.Merge(baseOptions.Value, typedOptions.Value)),
                 httpClientFactory,
-                systemTime,
-                signatureProviders,
-                serializers,
-                validators,
+                serviceProvider,
                 logger)
         {
         }

--- a/src/Hermodr.Publisher/EventPublishChannel.cs
+++ b/src/Hermodr.Publisher/EventPublishChannel.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 
 using CloudNative.CloudEvents;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Hermodr
@@ -23,7 +24,12 @@ namespace Hermodr
     {
         private readonly ChannelTelemetry _telemetry = new();
         private readonly TOptions _defaultOptions;
-        private readonly IEnumerable<IValidateOptions<TOptions>> _validators;
+        private IEnumerable<IValidateOptions<TOptions>>? _validators;
+
+        /// <summary>
+        /// Gets the service provider for lazy resolution of dependencies.
+        /// </summary>
+        protected IServiceProvider ServiceProvider { get; }
 
         /// <summary>
         /// Initialises the channel with its channel-level defaults and optional extra
@@ -33,20 +39,21 @@ namespace Hermodr
         /// The channel-level default options used when no per-call overrides are supplied.
         /// Must not be <c>null</c>.
         /// </param>
-        /// <param name="validators">
-        /// An optional collection of <see cref="IValidateOptions{TOptions}"/> services
-        /// registered in the DI container.  When the collection is empty or <c>null</c>
-        /// validation falls back to
-        /// <see cref="Validator.ValidateObject(object, ValidationContext)"/> (DataAnnotations).
+        /// <param name="serviceProvider">
+        /// The service provider used to resolve <see cref="IValidateOptions{TOptions}"/>
+        /// services lazily.
         /// </param>
         protected EventPublishChannel(
             TOptions defaultOptions,
-            IEnumerable<IValidateOptions<TOptions>>? validators = null)
+            IServiceProvider serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(defaultOptions);
             _defaultOptions = defaultOptions;
-            _validators = validators ?? [];
+            ServiceProvider = serviceProvider;
         }
+
+        private IEnumerable<IValidateOptions<TOptions>> Validators =>
+            _validators ??= ServiceProvider.GetServices<IValidateOptions<TOptions>>();
 
         /// <inheritdoc cref="INamedEventPublishChannel.Name"/>
         /// <remarks>
@@ -87,7 +94,7 @@ namespace Hermodr
         /// </exception>
         protected virtual void ValidateOptions(TOptions options)
         {
-            if (!_validators.Any())
+            if (!Validators.Any())
             {
                 // No IValidateOptions<T> registered – fall back to DataAnnotations.
                 var ctx = new ValidationContext(options);
@@ -96,7 +103,7 @@ namespace Hermodr
             }
 
             var failures = new List<string>();
-            foreach (var validator in _validators)
+            foreach (var validator in Validators)
             {
                 var result = validator.Validate(null, options);
                 if (result.Failed)

--- a/src/Hermodr.Publisher/EventPublishChannel.cs
+++ b/src/Hermodr.Publisher/EventPublishChannel.cs
@@ -24,7 +24,6 @@ namespace Hermodr
     {
         private readonly ChannelTelemetry _telemetry = new();
         private readonly TOptions _defaultOptions;
-        private IEnumerable<IValidateOptions<TOptions>>? _validators;
 
         /// <summary>
         /// Gets the service provider for lazy resolution of dependencies.
@@ -53,7 +52,7 @@ namespace Hermodr
         }
 
         private IEnumerable<IValidateOptions<TOptions>> Validators =>
-            _validators ??= ServiceProvider.GetServices<IValidateOptions<TOptions>>();
+            ServiceProvider.GetServices<IValidateOptions<TOptions>>();
 
         /// <inheritdoc cref="INamedEventPublishChannel.Name"/>
         /// <remarks>

--- a/src/Hermodr.Schema/EventDataDeserializerRegistry.cs
+++ b/src/Hermodr.Schema/EventDataDeserializerRegistry.cs
@@ -1,0 +1,46 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Collections.Concurrent;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Thread-safe registry for event data deserializers with content-type matching.
+    /// </summary>
+    public sealed class EventDataDeserializerRegistry : IEventDataDeserializerRegistry
+    {
+        private readonly ConcurrentDictionary<string, IEventDataDeserializer> _deserializers = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <inheritdoc/>
+        public void Register(IEventDataDeserializer deserializer)
+        {
+            ArgumentNullException.ThrowIfNull(deserializer);
+            _deserializers[deserializer.ContentType.ToLowerInvariant()] = deserializer;
+        }
+
+        /// <inheritdoc/>
+        public IEventDataDeserializer? GetDeserializer(string contentType)
+        {
+            if (string.IsNullOrEmpty(contentType))
+                return null;
+
+            // Try exact match first (case-insensitive)
+            var normalizedContentType = contentType.ToLowerInvariant();
+            if (_deserializers.TryGetValue(normalizedContentType, out var deserializer))
+                return deserializer;
+
+            // Try wildcard prefix match (e.g., "application/*" → "application/json")
+            var prefix = contentType.Split('/')[0].ToLowerInvariant();
+            foreach (var kvp in _deserializers)
+            {
+                if (kvp.Key.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase))
+                    return kvp.Value;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Hermodr.Schema/EventSchemaRegistry.cs
+++ b/src/Hermodr.Schema/EventSchemaRegistry.cs
@@ -1,0 +1,111 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Thread-safe registry for event schemas with version-aware lookup.
+    /// </summary>
+    public sealed class EventSchemaRegistry : IEventSchemaRegistry
+    {
+        private readonly ConcurrentDictionary<string, IEventSchema> _schemas = new(StringComparer.Ordinal);
+        private readonly IEventSchemaFactory _factory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventSchemaRegistry"/> class.
+        /// </summary>
+        /// <param name="factory">The schema factory used to construct schemas from CLR types.</param>
+        public EventSchemaRegistry(IEventSchemaFactory factory)
+        {
+            _factory = factory;
+        }
+
+        /// <inheritdoc/>
+        public void Register(IEventSchema schema)
+        {
+            ArgumentNullException.ThrowIfNull(schema);
+            var key = BuildSchemaKey(schema.EventType, schema.Version.ToString());
+            _schemas[key] = schema;
+        }
+
+        /// <inheritdoc/>
+        public void Register<TData>() where TData : class
+            => Register(_factory.CreateFromType<TData>());
+
+        /// <inheritdoc/>
+        public void Register(Type dataType)
+        {
+            ArgumentNullException.ThrowIfNull(dataType);
+            var schema = _factory.CreateFromType(dataType);
+            Register(schema);
+        }
+
+        /// <inheritdoc/>
+        public void ScanAssembly(Assembly assembly)
+        {
+            ArgumentNullException.ThrowIfNull(assembly);
+
+            var eventTypes = assembly.GetTypes()
+                .Where(t => t.GetCustomAttribute<EventAttribute>() != null);
+
+            foreach (var type in eventTypes)
+            {
+                var attr = type.GetCustomAttribute<EventAttribute>();
+                // Skip types that use DataSchema URI instead of DataVersion
+                if (attr != null && attr.DataVersion == null)
+                    continue;
+
+                try
+                {
+                    Register(type);
+                }
+                catch (Exception)
+                {
+                    // Skip types that cannot be registered (e.g., missing version)
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public IEventSchema? GetSchema(string eventType, string? version = null)
+        {
+            if (string.IsNullOrEmpty(eventType))
+                return null;
+
+            if (version != null)
+            {
+                // Exact version match
+                var key = BuildSchemaKey(eventType, version);
+                return _schemas.TryGetValue(key, out var schema) ? schema : null;
+            }
+
+            // No version specified - return latest version
+            return _schemas
+                .Where(kvp => kvp.Key.StartsWith(eventType + ":", StringComparison.Ordinal))
+                .OrderByDescending(kvp => kvp.Value.Version)
+                .Select(kvp => kvp.Value)
+                .FirstOrDefault();
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<IEventSchema> GetAllVersions(string eventType)
+        {
+            if (string.IsNullOrEmpty(eventType))
+                return Array.Empty<IEventSchema>();
+
+            return _schemas
+                .Where(kvp => kvp.Key.StartsWith(eventType + ":", StringComparison.Ordinal))
+                .OrderByDescending(kvp => kvp.Value.Version)
+                .Select(kvp => kvp.Value)
+                .ToList();
+        }
+
+        private static string BuildSchemaKey(string eventType, string version)
+            => $"{eventType}:{version}";
+    }
+}

--- a/src/Hermodr.Schema/EventSchemaServicesOptions.cs
+++ b/src/Hermodr.Schema/EventSchemaServicesOptions.cs
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Reflection;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Configuration options for event schema services.
+    /// </summary>
+    public class EventSchemaServicesOptions
+    {
+        /// <summary>
+        /// Gets the list of assemblies to scan for types annotated with <see cref="EventAttribute"/>.
+        /// Scanning occurs at application startup after all services are registered.
+        /// </summary>
+        public IList<Assembly> AssembliesToScan { get; } = new List<Assembly>();
+
+        /// <summary>
+        /// Gets the list of explicit schema registration actions to execute at startup.
+        /// </summary>
+        public IList<Action<IEventSchemaRegistry>> SchemaRegistrations { get; } = new List<Action<IEventSchemaRegistry>>();
+
+        /// <summary>
+        /// Gets the list of additional deserializers to register beyond the built-in JSON and XML deserializers.
+        /// </summary>
+        public IList<IEventDataDeserializer> AdditionalDeserializers { get; } = new List<IEventDataDeserializer>();
+    }
+}

--- a/src/Hermodr.Schema/EventSchemaValidator.cs
+++ b/src/Hermodr.Schema/EventSchemaValidator.cs
@@ -143,7 +143,7 @@ namespace Hermodr
                         yield return error;
                 }
 
-                if (property.Properties.Count > 0 && value != null)
+                if (property.Properties.Count > 0)
                 {
                     var nestedSchema = CreateNestedSchema(property);
                     foreach (var nestedError in ValidateObjectTree(value, nestedSchema, propertyPath))

--- a/src/Hermodr.Schema/EventSchemaValidator.cs
+++ b/src/Hermodr.Schema/EventSchemaValidator.cs
@@ -1,0 +1,339 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using CloudNative.CloudEvents;
+using System.Collections;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Validates CloudEvent payloads against their registered schemas using format-agnostic deserialization.
+    /// </summary>
+    public sealed class EventSchemaValidator : IEventSchemaValidator
+    {
+        private readonly IEventDataDeserializerRegistry _deserializerRegistry;
+        private readonly ILogger<EventSchemaValidator> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventSchemaValidator"/> class.
+        /// </summary>
+        /// <param name="deserializerRegistry">The deserializer registry for content-type-based deserialization.</param>
+        /// <param name="logger">A logger instance for diagnostic output.</param>
+        public EventSchemaValidator(
+            IEventDataDeserializerRegistry deserializerRegistry,
+            ILogger<EventSchemaValidator> logger)
+        {
+            _deserializerRegistry = deserializerRegistry;
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public async IAsyncEnumerable<ValidationResult> ValidateEventAsync(
+            IEventSchema schema,
+            CloudEvent @event,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(schema);
+            ArgumentNullException.ThrowIfNull(@event);
+
+            var contentType = @event.DataContentType ?? "application/json";
+            var deserializer = _deserializerRegistry.GetDeserializer(contentType);
+
+            if (deserializer == null)
+            {
+                _logger.LogWarning(
+                    "No deserializer found for content type {ContentType}, skipping validation for event type {EventType}",
+                    contentType,
+                    @event.Type);
+                yield break;
+            }
+
+            var dataStream = GetDataStream(@event);
+            if (dataStream == null || dataStream.Length == 0)
+            {
+                yield break;
+            }
+
+            object? data;
+            try
+            {
+                data = await deserializer.DeserializeAsync(dataStream, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to deserialize event data for event type {EventType}", @event.Type);
+                yield break;
+            }
+
+            foreach (var error in ValidateObjectTree(data, schema, pathPrefix: ""))
+            {
+                yield return error;
+            }
+        }
+
+        private static Stream? GetDataStream(CloudEvent @event)
+        {
+            if (@event.Data == null)
+                return null;
+
+            if (@event.Data is Stream stream)
+                return stream;
+
+            if (@event.Data is byte[] bytes)
+                return new MemoryStream(bytes);
+
+            if (@event.Data is string str)
+                return new MemoryStream(System.Text.Encoding.UTF8.GetBytes(str));
+
+            return null;
+        }
+
+        private IEnumerable<ValidationResult> ValidateObjectTree(
+            object? data,
+            IEventSchema schema,
+            string pathPrefix)
+        {
+            if (data == null)
+            {
+                yield return new ValidationResult(
+                    "Event data is null",
+                    memberNames: Array.Empty<string>());
+                yield break;
+            }
+
+            var dataDict = ConvertToDictionary(data);
+
+            foreach (var property in schema.Properties)
+            {
+                var propertyPath = string.IsNullOrEmpty(pathPrefix)
+                    ? property.Name
+                    : $"{pathPrefix}.{property.Name}";
+
+                if (!dataDict.TryGetValue(property.Name, out var value))
+                {
+                    if (property.IsRequired)
+                    {
+                        yield return new ValidationResult(
+                            $"Required property '{property.Name}' is missing",
+                            memberNames: new[] { propertyPath });
+                    }
+                    continue;
+                }
+
+                if (value == null && !property.IsNullable)
+                {
+                    yield return new ValidationResult(
+                        $"Property '{property.Name}' cannot be null",
+                        memberNames: new[] { propertyPath });
+                    continue;
+                }
+
+                if (value == null)
+                    continue;
+
+                foreach (var constraint in property.Constraints)
+                {
+                    var error = ValidateConstraint(value, constraint, propertyPath);
+                    if (error != null)
+                        yield return error;
+                }
+
+                if (property.Properties.Count > 0 && value != null)
+                {
+                    var nestedSchema = CreateNestedSchema(property);
+                    foreach (var nestedError in ValidateObjectTree(value, nestedSchema, propertyPath))
+                    {
+                        yield return nestedError;
+                    }
+                }
+            }
+        }
+
+        private static Dictionary<string, object?> ConvertToDictionary(object? data)
+        {
+            if (data == null)
+                return new Dictionary<string, object?>();
+
+            if (data is Dictionary<string, object?> dict)
+                return dict;
+
+            if (data is IDictionary<string, object?> genericDict)
+                return new Dictionary<string, object?>(genericDict);
+
+            if (data is IDictionary nonGenericDict)
+            {
+                var result = new Dictionary<string, object?>();
+                foreach (DictionaryEntry entry in nonGenericDict)
+                {
+                    result[entry.Key.ToString() ?? string.Empty] = entry.Value;
+                }
+                return result;
+            }
+
+            return new Dictionary<string, object?>();
+        }
+
+        private static ValidationResult? ValidateConstraint(
+            object value,
+            IEventPropertyConstraint constraint,
+            string propertyPath)
+        {
+            return constraint switch
+            {
+                PropertyRequiredConstraint => ValidateRequired(value, propertyPath),
+                IRangeConstraint range => ValidateRange(value, range, propertyPath),
+                IEnumMemberConstraint enumConstraint => ValidateEnum(value, enumConstraint, propertyPath),
+                _ => null
+            };
+        }
+
+        private static ValidationResult? ValidateRequired(object value, string propertyPath)
+        {
+            if (value == null)
+            {
+                return new ValidationResult(
+                    $"Required property '{GetPropertyName(propertyPath)}' is missing",
+                    memberNames: new[] { propertyPath });
+            }
+            return null;
+        }
+
+        private static ValidationResult? ValidateRange(object value, IRangeConstraint constraint, string propertyPath)
+        {
+            if (value == null)
+                return null;
+
+            if (constraint.Min == null && constraint.Max == null)
+                return null;
+
+            // Convert numeric values to a common type for comparison
+            // JSON deserialization produces double, but constraints may use int/long/decimal
+            if (constraint.Min != null)
+            {
+                var normalizedValue = ConvertNumericValue(value, constraint.Min.GetType());
+                if (normalizedValue != null && Comparer<object>.Default.Compare(normalizedValue, constraint.Min) < 0)
+                {
+                    return new ValidationResult(
+                        $"Value '{value}' is below minimum {constraint.Min}",
+                        memberNames: new[] { propertyPath });
+                }
+            }
+
+            if (constraint.Max != null)
+            {
+                var normalizedValue = ConvertNumericValue(value, constraint.Max.GetType());
+                if (normalizedValue != null && Comparer<object>.Default.Compare(normalizedValue, constraint.Max) > 0)
+                {
+                    return new ValidationResult(
+                        $"Value '{value}' is above maximum {constraint.Max}",
+                        memberNames: new[] { propertyPath });
+                }
+            }
+
+            return null;
+        }
+
+        private static object? ConvertNumericValue(object value, Type targetType)
+        {
+            try
+            {
+                // If the types match, return as-is
+                if (value.GetType() == targetType)
+                    return value;
+
+                // If both are numeric, try to convert
+                if (value is double d)
+                {
+                    if (targetType == typeof(int)) return (int)d;
+                    if (targetType == typeof(long)) return (long)d;
+                    if (targetType == typeof(float)) return (float)d;
+                    if (targetType == typeof(decimal)) return (decimal)d;
+                    if (targetType == typeof(double)) return d;
+                }
+                if (value is int i)
+                {
+                    if (targetType == typeof(double)) return (double)i;
+                    if (targetType == typeof(long)) return (long)i;
+                    if (targetType == typeof(decimal)) return (decimal)i;
+                }
+                if (value is long l)
+                {
+                    if (targetType == typeof(double)) return (double)l;
+                    if (targetType == typeof(int)) return (int)l;
+                }
+
+                return Convert.ChangeType(value, targetType);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static ValidationResult? ValidateEnum(object value, IEnumMemberConstraint constraint, string propertyPath)
+        {
+            // Try direct match first
+            if (constraint.AllowedValueObjects.Any(v => Equals(v, value)))
+                return null;
+
+            // Try numeric conversion for JSON number mismatches (double vs int)
+            foreach (var allowed in constraint.AllowedValueObjects)
+            {
+                if (allowed == null) continue;
+
+                // If both are numeric types, try converting
+                if (IsNumericType(value.GetType()) && IsNumericType(allowed.GetType()))
+                {
+                    var converted = ConvertNumericValue(value, allowed.GetType());
+                    if (converted != null && Equals(converted, allowed))
+                        return null;
+                }
+            }
+
+            var allowedValues = string.Join(", ", constraint.AllowedValueObjects.Select(v => v?.ToString() ?? "null"));
+            return new ValidationResult(
+                $"Value '{value}' is not in allowed set [{allowedValues}]",
+                memberNames: new[] { propertyPath });
+        }
+
+        private static bool IsNumericType(Type type)
+        {
+            return type == typeof(int)
+                || type == typeof(long)
+                || type == typeof(float)
+                || type == typeof(double)
+                || type == typeof(decimal)
+                || type == typeof(short)
+                || type == typeof(byte);
+        }
+
+        private static string GetPropertyName(string propertyPath)
+        {
+            var parts = propertyPath.Split('.');
+            return parts.Length > 0 ? parts[parts.Length - 1] : propertyPath;
+        }
+
+        private static IEventSchema CreateNestedSchema(IEventProperty property)
+        {
+            var nestedSchema = new EventSchema(
+                $"nested.{property.Name}",
+                property.Version?.ToString() ?? "1.0",
+                "object")
+            {
+                Description = property.Description
+            };
+
+            foreach (var subProperty in property.Properties)
+            {
+                nestedSchema.Properties.Add((EventProperty)subProperty);
+            }
+
+            return nestedSchema;
+        }
+    }
+}

--- a/src/Hermodr.Schema/Hermodr.Schema.csproj
+++ b/src/Hermodr.Schema/Hermodr.Schema.csproj
@@ -6,6 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hermodr.Annotations\Hermodr.Annotations.csproj" />

--- a/src/Hermodr.Schema/IEventDataDeserializer.cs
+++ b/src/Hermodr.Schema/IEventDataDeserializer.cs
@@ -1,0 +1,33 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Deserializes event data from a specific content type into a format-agnostic object tree.
+    /// </summary>
+    public interface IEventDataDeserializer
+    {
+        /// <summary>
+        /// Gets the content type this deserializer handles.
+        /// </summary>
+        string ContentType { get; }
+
+        /// <summary>
+        /// Determines if this deserializer can handle the specified content type.
+        /// </summary>
+        /// <param name="contentType">The content type to check.</param>
+        /// <returns>True if this deserializer can handle the content type; otherwise, false.</returns>
+        bool CanDeserialize(string contentType);
+
+        /// <summary>
+        /// Deserializes the event data stream into a format-agnostic object tree.
+        /// </summary>
+        /// <param name="data">The data stream to deserialize.</param>
+        /// <param name="cancellationToken">A token to cancel the deserialization operation.</param>
+        /// <returns>A deserialized object tree (typically Dictionary&lt;string, object?&gt;), or null if the data is empty.</returns>
+        Task<object?> DeserializeAsync(Stream data, CancellationToken cancellationToken);
+    }
+}

--- a/src/Hermodr.Schema/IEventDataDeserializerRegistry.cs
+++ b/src/Hermodr.Schema/IEventDataDeserializerRegistry.cs
@@ -1,0 +1,26 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Registry for event data deserializers, enabling content-type-based deserializer resolution.
+    /// </summary>
+    public interface IEventDataDeserializerRegistry
+    {
+        /// <summary>
+        /// Registers a deserializer for a specific content type.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to register.</param>
+        void Register(IEventDataDeserializer deserializer);
+
+        /// <summary>
+        /// Gets the deserializer that can handle the specified content type.
+        /// </summary>
+        /// <param name="contentType">The content type to find a deserializer for.</param>
+        /// <returns>The deserializer if found; otherwise, null.</returns>
+        IEventDataDeserializer? GetDeserializer(string contentType);
+    }
+}

--- a/src/Hermodr.Schema/IEventSchemaRegistry.cs
+++ b/src/Hermodr.Schema/IEventSchemaRegistry.cs
@@ -1,0 +1,54 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Reflection;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Registry for event schemas with version-aware lookup capabilities.
+    /// </summary>
+    public interface IEventSchemaRegistry
+    {
+        /// <summary>
+        /// Registers an event schema instance.
+        /// </summary>
+        /// <param name="schema">The schema to register.</param>
+        void Register(IEventSchema schema);
+
+        /// <summary>
+        /// Registers an event schema by constructing it from a CLR type annotated with <see cref="EventAttribute"/>.
+        /// </summary>
+        /// <typeparam name="TData">The event data type.</typeparam>
+        void Register<TData>() where TData : class;
+
+        /// <summary>
+        /// Registers an event schema by constructing it from a CLR type annotated with <see cref="EventAttribute"/>.
+        /// </summary>
+        /// <param name="dataType">The event data type.</param>
+        void Register(Type dataType);
+
+        /// <summary>
+        /// Scans an assembly for types annotated with <see cref="EventAttribute"/> and registers their schemas.
+        /// </summary>
+        /// <param name="assembly">The assembly to scan.</param>
+        void ScanAssembly(Assembly assembly);
+
+        /// <summary>
+        /// Gets the schema for the specified event type and version.
+        /// </summary>
+        /// <param name="eventType">The event type to look up.</param>
+        /// <param name="version">The specific version to retrieve, or null to get the latest version.</param>
+        /// <returns>The schema if found; otherwise, null.</returns>
+        IEventSchema? GetSchema(string eventType, string? version = null);
+
+        /// <summary>
+        /// Gets all registered versions of the specified event type.
+        /// </summary>
+        /// <param name="eventType">The event type to retrieve versions for.</param>
+        /// <returns>A list of all registered schemas for the event type, ordered by version.</returns>
+        IReadOnlyList<IEventSchema> GetAllVersions(string eventType);
+    }
+}

--- a/src/Hermodr.Schema/JsonEventDataDeserializer.cs
+++ b/src/Hermodr.Schema/JsonEventDataDeserializer.cs
@@ -1,0 +1,72 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Text.Json;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Deserializes JSON event data into a format-agnostic object tree.
+    /// </summary>
+    public sealed class JsonEventDataDeserializer : IEventDataDeserializer
+    {
+        /// <inheritdoc/>
+        public string ContentType => "application/json";
+
+        /// <inheritdoc/>
+        public bool CanDeserialize(string contentType)
+        {
+            if (string.IsNullOrEmpty(contentType))
+                return false;
+
+            return contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase)
+                || contentType.StartsWith("application/cloudevents+json", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <inheritdoc/>
+        public async Task<object?> DeserializeAsync(Stream data, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+
+            var jsonDoc = await JsonDocument.ParseAsync(data, cancellationToken: cancellationToken);
+            return ConvertJsonElementToObject(jsonDoc.RootElement);
+        }
+
+        private static object? ConvertJsonElementToObject(JsonElement element)
+        {
+            return element.ValueKind switch
+            {
+                JsonValueKind.Null => null,
+                JsonValueKind.String => element.GetString(),
+                JsonValueKind.Number => element.GetDouble(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Array => ConvertJsonArrayToList(element),
+                JsonValueKind.Object => ConvertJsonObjectToDictionary(element),
+                _ => null
+            };
+        }
+
+        private static List<object?> ConvertJsonArrayToList(JsonElement arrayElement)
+        {
+            var list = new List<object?>();
+            foreach (var item in arrayElement.EnumerateArray())
+            {
+                list.Add(ConvertJsonElementToObject(item));
+            }
+            return list;
+        }
+
+        private static Dictionary<string, object?> ConvertJsonObjectToDictionary(JsonElement objElement)
+        {
+            var dict = new Dictionary<string, object?>();
+            foreach (var property in objElement.EnumerateObject())
+            {
+                dict[property.Name] = ConvertJsonElementToObject(property.Value);
+            }
+            return dict;
+        }
+    }
+}

--- a/src/Hermodr.Schema/ServiceCollectionExtensions.cs
+++ b/src/Hermodr.Schema/ServiceCollectionExtensions.cs
@@ -1,0 +1,90 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Extension methods for registering event schema services with dependency injection.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds event schema services including the schema factory, validator, registry, and deserializers.
+        /// </summary>
+        /// <param name="services">The service collection to add services to.</param>
+        /// <param name="configureOptions">An optional action to configure schema service options.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddEventSchemaServices(
+            this IServiceCollection services,
+            Action<EventSchemaServicesOptions>? configureOptions = null)
+        {
+            bool initializerRegistered = services.Any(d => d.ServiceType == typeof(SchemaRegistrationsApplier));
+
+            if (!initializerRegistered)
+            {
+                // Configure options (always do this, even if already registered)
+                if (configureOptions != null)
+                {
+                    services.Configure(configureOptions);
+                }
+
+                // Core services
+                services.TryAddSingleton<IEventSchemaFactory, EventSchemaFactory>();
+                services.TryAddSingleton<IEventSchemaValidator, EventSchemaValidator>();
+                services.TryAddSingleton<IEventSchemaRegistry, EventSchemaRegistry>();
+                services.TryAddSingleton<IEventDataDeserializerRegistry, EventDataDeserializerRegistry>();
+
+                // Built-in deserializers
+                services.TryAddSingleton<IEventDataDeserializer, JsonEventDataDeserializer>();
+                services.TryAddSingleton<IEventDataDeserializer, XmlEventDataDeserializer>();
+
+                // Register the applier as a singleton - its constructor runs once at resolution
+                services.TryAddSingleton<SchemaRegistrationsApplier>();
+            }
+            else if (configureOptions != null)
+            {
+                services.Configure(configureOptions);
+            }
+
+            return services;
+        }
+    }
+
+    /// <summary>
+    /// Applies schema registrations (assembly scanning and explicit registrations)
+    /// when first resolved from the DI container.
+    /// </summary>
+    public sealed class SchemaRegistrationsApplier
+    {
+        /// <summary>
+        /// Initializes the schema registrations applier and applies all pending registrations.
+        /// </summary>
+        public SchemaRegistrationsApplier(
+            Microsoft.Extensions.Options.IOptions<EventSchemaServicesOptions> options,
+            IEventSchemaRegistry registry,
+            IEventDataDeserializerRegistry deserializerRegistry,
+            IEnumerable<IEventDataDeserializer> deserializers)
+        {
+            var opts = options.Value;
+
+            // Register built-in deserializers (JSON, XML, etc.) first
+            foreach (var deserializer in deserializers)
+                deserializerRegistry.Register(deserializer);
+
+            // Then additional deserializers from options
+            foreach (var deserializer in opts.AdditionalDeserializers)
+                deserializerRegistry.Register(deserializer);
+
+            foreach (var assembly in opts.AssembliesToScan)
+                registry.ScanAssembly(assembly);
+
+            foreach (var registration in opts.SchemaRegistrations)
+                registration(registry);
+        }
+    }
+}

--- a/src/Hermodr.Schema/ServiceCollectionExtensions.cs
+++ b/src/Hermodr.Schema/ServiceCollectionExtensions.cs
@@ -23,68 +23,22 @@ namespace Hermodr
             this IServiceCollection services,
             Action<EventSchemaServicesOptions>? configureOptions = null)
         {
-            bool initializerRegistered = services.Any(d => d.ServiceType == typeof(SchemaRegistrationsApplier));
-
-            if (!initializerRegistered)
-            {
-                // Configure options (always do this, even if already registered)
-                if (configureOptions != null)
-                {
-                    services.Configure(configureOptions);
-                }
-
-                // Core services
-                services.TryAddSingleton<IEventSchemaFactory, EventSchemaFactory>();
-                services.TryAddSingleton<IEventSchemaValidator, EventSchemaValidator>();
-                services.TryAddSingleton<IEventSchemaRegistry, EventSchemaRegistry>();
-                services.TryAddSingleton<IEventDataDeserializerRegistry, EventDataDeserializerRegistry>();
-
-                // Built-in deserializers
-                services.TryAddSingleton<IEventDataDeserializer, JsonEventDataDeserializer>();
-                services.TryAddSingleton<IEventDataDeserializer, XmlEventDataDeserializer>();
-
-                // Register the applier as a singleton - its constructor runs once at resolution
-                services.TryAddSingleton<SchemaRegistrationsApplier>();
-            }
-            else if (configureOptions != null)
+            if (configureOptions != null)
             {
                 services.Configure(configureOptions);
             }
 
+            // Core services
+            services.TryAddSingleton<IEventSchemaFactory, EventSchemaFactory>();
+            services.TryAddSingleton<IEventSchemaValidator, EventSchemaValidator>();
+            services.TryAddSingleton<IEventSchemaRegistry, EventSchemaRegistry>();
+            services.TryAddSingleton<IEventDataDeserializerRegistry, EventDataDeserializerRegistry>();
+
+            // Built-in deserializers
+            services.TryAddSingleton<IEventDataDeserializer, JsonEventDataDeserializer>();
+            services.TryAddSingleton<IEventDataDeserializer, XmlEventDataDeserializer>();
+
             return services;
-        }
-    }
-
-    /// <summary>
-    /// Applies schema registrations (assembly scanning and explicit registrations)
-    /// when first resolved from the DI container.
-    /// </summary>
-    public sealed class SchemaRegistrationsApplier
-    {
-        /// <summary>
-        /// Initializes the schema registrations applier and applies all pending registrations.
-        /// </summary>
-        public SchemaRegistrationsApplier(
-            Microsoft.Extensions.Options.IOptions<EventSchemaServicesOptions> options,
-            IEventSchemaRegistry registry,
-            IEventDataDeserializerRegistry deserializerRegistry,
-            IEnumerable<IEventDataDeserializer> deserializers)
-        {
-            var opts = options.Value;
-
-            // Register built-in deserializers (JSON, XML, etc.) first
-            foreach (var deserializer in deserializers)
-                deserializerRegistry.Register(deserializer);
-
-            // Then additional deserializers from options
-            foreach (var deserializer in opts.AdditionalDeserializers)
-                deserializerRegistry.Register(deserializer);
-
-            foreach (var assembly in opts.AssembliesToScan)
-                registry.ScanAssembly(assembly);
-
-            foreach (var registration in opts.SchemaRegistrations)
-                registration(registry);
         }
     }
 }

--- a/src/Hermodr.Schema/XmlEventDataDeserializer.cs
+++ b/src/Hermodr.Schema/XmlEventDataDeserializer.cs
@@ -1,0 +1,78 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Xml.Linq;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Deserializes XML event data into a format-agnostic object tree.
+    /// </summary>
+    public sealed class XmlEventDataDeserializer : IEventDataDeserializer
+    {
+        /// <inheritdoc/>
+        public string ContentType => "application/xml";
+
+        /// <inheritdoc/>
+        public bool CanDeserialize(string contentType)
+        {
+            if (string.IsNullOrEmpty(contentType))
+                return false;
+
+            return contentType.StartsWith("application/xml", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <inheritdoc/>
+        public Task<object?> DeserializeAsync(Stream data, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var doc = XDocument.Load(data);
+            var result = ConvertXElementToDictionary(doc.Root);
+            return Task.FromResult<object?>(result);
+        }
+
+        private static Dictionary<string, object?> ConvertXElementToDictionary(XElement element)
+        {
+            var dict = new Dictionary<string, object?>();
+
+            // Add attributes as properties (attributes take precedence)
+            foreach (var attr in element.Attributes())
+            {
+                // Ignore namespaces, use local name only
+                dict[attr.Name.LocalName] = attr.Value;
+            }
+
+            // Add child elements as properties
+            foreach (var child in element.Elements())
+            {
+                // Ignore namespaces, use local name only
+                var key = child.Name.LocalName;
+
+                // If attribute already exists with same name, element doesn't override
+                if (!dict.ContainsKey(key))
+                {
+                    dict[key] = ConvertXElementToObject(child);
+                }
+            }
+
+            return dict;
+        }
+
+        private static object? ConvertXElementToObject(XElement element)
+        {
+            // If element has child elements, convert to dictionary
+            if (element.HasElements)
+            {
+                return ConvertXElementToDictionary(element);
+            }
+
+            // Otherwise, return the text value
+            return element.Value;
+        }
+    }
+}

--- a/test/Hermodr.Publisher.AuditTrail.XUnit/Unit/AuditTrailPublishChannelEdgeCaseTests.cs
+++ b/test/Hermodr.Publisher.AuditTrail.XUnit/Unit/AuditTrailPublishChannelEdgeCaseTests.cs
@@ -1,4 +1,5 @@
 using CloudNative.CloudEvents;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -18,7 +19,7 @@ public class AuditTrailPublishChannelEdgeCaseTests
     public void Constructor_NullWriter_ShouldThrowArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new AuditTrailPublishChannel(null!, Options.Create(new AuditTrailPublishOptions())));
+            new AuditTrailPublishChannel(null!, Options.Create(new AuditTrailPublishOptions()), new ServiceCollection().BuildServiceProvider()));
     }
 
     [Fact]
@@ -28,7 +29,8 @@ public class AuditTrailPublishChannelEdgeCaseTests
         var failingWriter = new FailingAuditTrailWriter();
         var channel = new AuditTrailPublishChannel(
             failingWriter,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         var cloudEvent = new CloudEvent
         {
@@ -47,7 +49,8 @@ public class AuditTrailPublishChannelEdgeCaseTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var channel = new AuditTrailPublishChannel(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         var cloudEvent = new CloudEvent
         {
@@ -69,7 +72,8 @@ public class AuditTrailPublishChannelEdgeCaseTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var channel = new AuditTrailPublishChannel(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         var cloudEvent = new CloudEvent
         {
@@ -90,7 +94,8 @@ public class AuditTrailPublishChannelEdgeCaseTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var channel = new AuditTrailPublishChannel(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         var cloudEvent = new CloudEvent
         {
@@ -111,7 +116,8 @@ public class AuditTrailPublishChannelEdgeCaseTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var channel = new AuditTrailPublishChannel(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         for (int i = 0; i < 5; i++)
         {

--- a/test/Hermodr.Publisher.AuditTrail.XUnit/Unit/AuditTrailPublishChannelGenericTests.cs
+++ b/test/Hermodr.Publisher.AuditTrail.XUnit/Unit/AuditTrailPublishChannelGenericTests.cs
@@ -1,4 +1,5 @@
 using CloudNative.CloudEvents;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Hermodr.Publisher.AuditTrail.XUnit.Unit;
@@ -18,7 +19,8 @@ public class AuditTrailPublishChannelGenericTests
     {
         var channel = new AuditTrailPublishChannel<TestEvent>(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         Assert.IsAssignableFrom<IEventPublishChannel<TestEvent>>(channel);
         Assert.IsAssignableFrom<IEventPublishChannel>(channel);
@@ -30,7 +32,8 @@ public class AuditTrailPublishChannelGenericTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var channel = new AuditTrailPublishChannel<TestEvent>(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         var cloudEvent = new CloudEvent
         {
@@ -52,7 +55,8 @@ public class AuditTrailPublishChannelGenericTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var channel = new AuditTrailPublishChannel<TestEvent>(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         var cloudEvent = new CloudEvent
         {
@@ -73,7 +77,8 @@ public class AuditTrailPublishChannelGenericTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var channel = new AuditTrailPublishChannel<TestEvent>(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         for (int i = 0; i < 5; i++)
         {
@@ -93,7 +98,7 @@ public class AuditTrailPublishChannelGenericTests
     public void Constructor_NullWriter_ShouldThrowArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new AuditTrailPublishChannel<TestEvent>(null!, Options.Create(new AuditTrailPublishOptions())));
+            new AuditTrailPublishChannel<TestEvent>(null!, Options.Create(new AuditTrailPublishOptions()), new ServiceCollection().BuildServiceProvider()));
     }
 
     [Fact]
@@ -101,7 +106,8 @@ public class AuditTrailPublishChannelGenericTests
     {
         var channel = new AuditTrailPublishChannel<TestEvent>(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
 
         // Should be assignable to base type
         Assert.IsAssignableFrom<AuditTrailPublishChannel>(channel);

--- a/test/Hermodr.Publisher.AuditTrail.XUnit/Unit/AuditTrailPublishChannelTests.cs
+++ b/test/Hermodr.Publisher.AuditTrail.XUnit/Unit/AuditTrailPublishChannelTests.cs
@@ -1,4 +1,5 @@
 using CloudNative.CloudEvents;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -15,7 +16,8 @@ public class AuditTrailPublishChannelTests
         _auditTrail = new InMemoryAuditTrail(_bag);
         _channel = new AuditTrailPublishChannel(
             _auditTrail,
-            Options.Create(new AuditTrailPublishOptions()));
+            Options.Create(new AuditTrailPublishOptions()),
+            new ServiceCollection().BuildServiceProvider());
     }
 
     [Fact]

--- a/test/Hermodr.Publisher.DeliveryLog.EntityFramework.XUnit/Unit/EntityEventDeliveryLogRepositoryTests.cs
+++ b/test/Hermodr.Publisher.DeliveryLog.EntityFramework.XUnit/Unit/EntityEventDeliveryLogRepositoryTests.cs
@@ -3,6 +3,7 @@ using CloudNative.CloudEvents;
 using Kista;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Hermodr;
@@ -31,7 +32,7 @@ public class EntityEventDeliveryLogRepositoryTests : IAsyncDisposable
 
         _repository = new EntityEventDeliveryLogRepository(_context,
             new EventDeliveryRecordFactory(),
-            services: null,
+            new ServiceCollection().BuildServiceProvider(),
             logger: NullLogger<EntityRepository<DbEventDeliveryRecord, string>>.Instance);
     }
 

--- a/test/Hermodr.Publisher.EventSchema.XUnit/Hermodr.Publisher.EventSchema.XUnit.csproj
+++ b/test/Hermodr.Publisher.EventSchema.XUnit/Hermodr.Publisher.EventSchema.XUnit.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hermodr.Publisher.EventSchema\Hermodr.Publisher.EventSchema.csproj" />
+    <ProjectReference Include="..\..\src\Hermodr.TestPublisher\Hermodr.TestPublisher.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Hermodr.Publisher.EventSchema.XUnit/Unit/SchemaValidationMiddlewareTests.cs
+++ b/test/Hermodr.Publisher.EventSchema.XUnit/Unit/SchemaValidationMiddlewareTests.cs
@@ -1,0 +1,340 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using CloudNative.CloudEvents;
+using Microsoft.Extensions.DependencyInjection;
+using System.ComponentModel.DataAnnotations;
+
+namespace Hermodr
+{
+    [Trait("Function", "SchemaValidation")]
+    public class SchemaValidationMiddlewareTests
+    {
+        private static CloudEvent MakeEvent(string type = "test.event", string? version = null, string? jsonData = null)
+        {
+            var cloudEvent = new CloudEvent
+            {
+                Type = type,
+                Source = new Uri("https://test.example.com/source"),
+                Id = Guid.NewGuid().ToString("N"),
+                Time = DateTimeOffset.UtcNow,
+                DataContentType = "application/json",
+                Data = jsonData ?? """{"name": "John", "email": "john@test.com"}"""
+            };
+
+            if (version != null)
+            {
+                var attr = CloudEventAttribute.CreateExtension("dataversion", CloudEventAttributeType.String);
+                cloudEvent[attr] = version;
+            }
+
+            return cloudEvent;
+        }
+
+        private static (IServiceProvider Provider, List<CloudEvent> Received) BuildProvider(
+            Action<EventPublisherBuilder>? configure = null,
+            Action<EventSchemaServicesOptions>? configureSchema = null)
+        {
+            var received = new List<CloudEvent>();
+            var services = new ServiceCollection().AddLogging();
+            var builder = services.AddEventPublisher(opts =>
+                opts.Source = new Uri("https://test.example.com/source"));
+
+            // Register schema services with test schemas
+            services.AddEventSchemaServices(schemaOptions =>
+            {
+                schemaOptions.SchemaRegistrations.Add(registry =>
+                {
+                    var schemaV1 = new EventSchema("test.event", "1.0", "application/json");
+                    schemaV1.Properties.Add(new EventProperty("name", "string", "1.0") { IsNullable = false });
+                    schemaV1.Properties[0]!.Constraints.Add(new PropertyRequiredConstraint());
+                    schemaV1.Properties.Add(new EventProperty("email", "string", "1.0") { IsNullable = false });
+                    schemaV1.Properties[1]!.Constraints.Add(new PropertyRequiredConstraint());
+                    registry.Register(schemaV1);
+
+                    var schemaV2 = new EventSchema("test.event", "2.0", "application/json");
+                    schemaV2.Properties.Add(new EventProperty("name", "string", "2.0") { IsNullable = false });
+                    schemaV2.Properties[0]!.Constraints.Add(new PropertyRequiredConstraint());
+                    schemaV2.Properties.Add(new EventProperty("email", "string", "2.0") { IsNullable = false });
+                    schemaV2.Properties[1]!.Constraints.Add(new PropertyRequiredConstraint());
+                    schemaV2.Properties.Add(new EventProperty("age", "int", "2.0") { IsNullable = true });
+                    registry.Register(schemaV2);
+
+                    var strictSchema = new EventSchema("strict.event", "1.0", "application/json");
+                    strictSchema.Properties.Add(new EventProperty("name", "string", "1.0") { IsNullable = false });
+                    strictSchema.Properties[0]!.Constraints.Add(new PropertyRequiredConstraint());
+                    strictSchema.Properties.Add(new EventProperty("age", "int", "1.0") { IsNullable = false });
+                    strictSchema.Properties[1]!.Constraints.Add(new PropertyRequiredConstraint());
+                    registry.Register(strictSchema);
+                });
+            });
+
+            configure?.Invoke(builder);
+            builder.AddTestChannel(e => received.Add(e));
+            return (services.BuildServiceProvider(), received);
+        }
+
+        // ─── Missing schema behavior ─────────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_MissingSchemaAllow_Publishes()
+        {
+            var (provider, received) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Allow));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var cloudEvent = MakeEvent("unknown.event");
+
+            await publisher.PublishEventAsync(cloudEvent);
+
+            Assert.Single(received);
+        }
+
+        [Fact]
+        public async Task Middleware_MissingSchemaBlock_Throws()
+        {
+            var (provider, _) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Block));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var cloudEvent = MakeEvent("unknown.event");
+
+            var ex = await Assert.ThrowsAsync<SchemaValidationException>(() =>
+                publisher.PublishEventAsync(cloudEvent));
+
+            Assert.Contains("unknown.event", ex.Message);
+            Assert.Equal("unknown.event", ex.EventType);
+        }
+
+        [Fact]
+        public async Task Middleware_MissingSchemaFallback_Publishes()
+        {
+            var (provider, received) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Fallback));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var cloudEvent = MakeEvent("unknown.event");
+
+            await publisher.PublishEventAsync(cloudEvent);
+
+            Assert.Single(received);
+        }
+
+        // ─── Validation failure behavior ───────────────────────────────
+
+        [Fact]
+        public async Task Middleware_ValidationFailureThrow_Throws()
+        {
+            var (provider, _) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                {
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+                    opts.ValidationFailureBehavior = ValidationFailureBehavior.Throw;
+                }));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var cloudEvent = MakeEvent("test.event", "1.0", """{"name": "John"}"""); // Missing email
+
+            var ex = await Assert.ThrowsAsync<SchemaValidationException>(() =>
+                publisher.PublishEventAsync(cloudEvent));
+
+            Assert.Contains("email", ex.Message);
+            Assert.NotEmpty(ex.Errors);
+        }
+
+        // ─── Valid event passes ─────────────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_ValidEvent_Publishes()
+        {
+            var (provider, received) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                {
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+                    opts.ValidationFailureBehavior = ValidationFailureBehavior.Throw;
+                }));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var cloudEvent = MakeEvent("test.event", "1.0", """{"name": "John", "email": "john@test.com"}""");
+
+            await publisher.PublishEventAsync(cloudEvent);
+
+            Assert.Single(received);
+        }
+
+        // ─── Version-aware validation ───────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_VersionedEvent_ValidatesAgainstCorrectVersion()
+        {
+            var (provider, received) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                {
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+                    opts.ValidationFailureBehavior = ValidationFailureBehavior.Throw;
+                }));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+
+            // v1.0 requires name + email, v2.0 adds optional age
+            var cloudEvent = MakeEvent("test.event", "1.0", """{"name": "John", "email": "john@test.com", "age": 30}""");
+
+            await publisher.PublishEventAsync(cloudEvent);
+
+            Assert.Single(received);
+        }
+
+        [Fact]
+        public async Task Middleware_VersionedEvent_UnknownVersion_Blocks()
+        {
+            var (provider, _) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                {
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+                    opts.ValidationFailureBehavior = ValidationFailureBehavior.Throw;
+                }));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var cloudEvent = MakeEvent("test.event", "99.0", """{"name": "John"}""");
+
+            var ex = await Assert.ThrowsAsync<SchemaValidationException>(() =>
+                publisher.PublishEventAsync(cloudEvent));
+
+            Assert.Contains("99.0", ex.Message);
+        }
+
+        // ─── Null event type ───────────────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_EmptyEventType_Blocks()
+        {
+            var (provider, _) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                {
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+                    opts.ValidationFailureBehavior = ValidationFailureBehavior.Throw;
+                }));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var cloudEvent = new CloudEvent
+            {
+                Source = new Uri("https://test.example.com/source"),
+                Id = Guid.NewGuid().ToString("N"),
+                Time = DateTimeOffset.UtcNow,
+                DataContentType = "application/json",
+                Data = """{"name": "John"}"""
+            };
+
+            var ex = await Assert.ThrowsAsync<SchemaValidationException>(() =>
+                publisher.PublishEventAsync(cloudEvent));
+
+            Assert.Contains("event type", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // ─── Multiple validation errors ──────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_MultipleValidationErrors_AllReported()
+        {
+            var (provider, _) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                {
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+                    opts.ValidationFailureBehavior = ValidationFailureBehavior.Throw;
+                }));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var cloudEvent = MakeEvent("strict.event", "1.0", """{}"""); // Missing name + age
+
+            var ex = await Assert.ThrowsAsync<SchemaValidationException>(() =>
+                publisher.PublishEventAsync(cloudEvent));
+
+            Assert.Equal(2, ex.Errors.Count);
+            Assert.Contains(ex.Errors, e => e.MemberNames.First() == "name");
+            Assert.Contains(ex.Errors, e => e.MemberNames.First() == "age");
+        }
+
+        // ─── Schema validation disabled (no UseSchemaValidation) ────────
+
+        [Fact]
+        public async Task Middleware_NotRegistered_NoValidation()
+        {
+            var (provider, received) = BuildProvider(); // No UseSchemaValidation
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var cloudEvent = MakeEvent("test.event", "1.0", """{"name": "John"}"""); // Missing email
+
+            await publisher.PublishEventAsync(cloudEvent);
+
+            Assert.Single(received); // Published without validation
+        }
+
+        // ─── Schema services auto-registration ─────────────────────────
+
+        [Fact]
+        public async Task Middleware_AutoRegistersSchemaServices()
+        {
+            var received = new List<CloudEvent>();
+            var services = new ServiceCollection().AddLogging();
+            var builder = services.AddEventPublisher(opts =>
+                opts.Source = new Uri("https://test.example.com/source"));
+
+            // No explicit AddEventSchemaServices - should be auto-registered
+            builder.UseSchemaValidation(opts =>
+            {
+                opts.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+                opts.ValidationFailureBehavior = ValidationFailureBehavior.Throw;
+            }, schemaOptions =>
+            {
+                schemaOptions.SchemaRegistrations.Add(registry =>
+                {
+                    var schema = new EventSchema("auto.event", "1.0", "application/json");
+                    schema.Properties.Add(new EventProperty("name", "string", "1.0"));
+                    schema.Properties[0]!.Constraints.Add(new PropertyRequiredConstraint());
+                    registry.Register(schema);
+                });
+            });
+
+            builder.AddTestChannel(e => received.Add(e));
+            var provider = services.BuildServiceProvider();
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+
+            // Valid event should pass
+            var validEvent = MakeEvent("auto.event", "1.0", """{"name": "AutoTest"}""");
+            await publisher.PublishEventAsync(validEvent);
+            Assert.Single(received);
+
+            // Invalid event should throw
+            var invalidEvent = MakeEvent("auto.event", "1.0", """{}""");
+            await Assert.ThrowsAsync<SchemaValidationException>(() =>
+                publisher.PublishEventAsync(invalidEvent));
+        }
+
+        // ─── Event with no version uses latest ─────────────────────────
+
+        [Fact]
+        public async Task Middleware_NoVersion_UsesLatest()
+        {
+            var (provider, received) = BuildProvider(builder =>
+                builder.UseSchemaValidation(opts =>
+                {
+                    opts.MissingSchemaBehavior = MissingSchemaBehavior.Block;
+                    opts.ValidationFailureBehavior = ValidationFailureBehavior.Throw;
+                }));
+
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+
+            // No version specified - should use latest (2.0) which allows optional age
+            var cloudEvent = MakeEvent("test.event", version: null, jsonData: """{"name": "John", "email": "john@test.com", "age": 30}""");
+
+            await publisher.PublishEventAsync(cloudEvent);
+
+            Assert.Single(received);
+        }
+    }
+}

--- a/test/Hermodr.Publisher.OpenTelemetry.XUnit/Unit/TelemetryEdgeCasesTests.cs
+++ b/test/Hermodr.Publisher.OpenTelemetry.XUnit/Unit/TelemetryEdgeCasesTests.cs
@@ -246,7 +246,7 @@ public class TelemetryEdgeCasesTests
 
     private sealed class SimpleTestChannel : EventPublishChannel<SimpleTestOptions>
     {
-        public SimpleTestChannel() : base(new SimpleTestOptions()) { }
+        public SimpleTestChannel(IServiceProvider? serviceProvider = null) : base(new SimpleTestOptions(), serviceProvider ?? new ServiceCollection().BuildServiceProvider()) { }
 
         protected override Task PublishCoreAsync(CloudEvent @event, SimpleTestOptions options, CancellationToken cancellationToken)
         {

--- a/test/Hermodr.Publisher.XUnit/Unit/EventPublishChannelTests.cs
+++ b/test/Hermodr.Publisher.XUnit/Unit/EventPublishChannelTests.cs
@@ -5,6 +5,7 @@
 
 using CloudNative.CloudEvents;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using System.ComponentModel.DataAnnotations;
@@ -39,8 +40,8 @@ namespace Hermodr
         {
             public SimpleChannel(
                 SimpleOptions defaults,
-                IEnumerable<IValidateOptions<SimpleOptions>>? validators = null)
-                : base(defaults, validators) { }
+                IServiceProvider? serviceProvider = null)
+                : base(defaults, serviceProvider ?? new ServiceCollection().BuildServiceProvider()) { }
 
             public List<(CloudEvent Event, SimpleOptions Options)> Published { get; } = new();
 
@@ -122,10 +123,13 @@ namespace Hermodr
         [Fact]
         public async Task PublishAsync_WithIValidateOptionsFailure_ThrowsOptionsValidationException()
         {
-            var validator = new AlwaysFailValidator();
+            var services = new ServiceCollection();
+            services.AddSingleton<IValidateOptions<SimpleOptions>>(new AlwaysFailValidator());
+            var serviceProvider = services.BuildServiceProvider();
+
             var channel   = new SimpleChannel(
                 new SimpleOptions { Endpoint = "https://example.com" },
-                new[] { validator });
+                serviceProvider);
 
             await Assert.ThrowsAsync<OptionsValidationException>(
                 () => channel.PublishAsync(ValidEvent(), null, CancellationToken.None));
@@ -134,10 +138,14 @@ namespace Hermodr
         [Fact]
         public async Task PublishAsync_WithIValidateOptionsSuccess_DeliversEvent()
         {
+            var services = new ServiceCollection();
+            services.AddSingleton<IValidateOptions<SimpleOptions>>(new AlwaysPassValidator());
+            var serviceProvider = services.BuildServiceProvider();
+
             var validator = new AlwaysPassValidator();
             var channel   = new SimpleChannel(
                 new SimpleOptions { Endpoint = "https://example.com" },
-                new[] { validator });
+                serviceProvider);
 
             await channel.PublishAsync(ValidEvent(), null, CancellationToken.None);
 
@@ -147,15 +155,15 @@ namespace Hermodr
         [Fact]
         public async Task PublishAsync_MultipleValidators_OneFailure_ThrowsAndAccumulatesMessages()
         {
-            var validators = new IValidateOptions<SimpleOptions>[]
-            {
-                new AlwaysPassValidator(),
-                new AlwaysFailValidator("validation-error-1"),
-                new AlwaysFailValidator("validation-error-2"),
-            };
+            var services = new ServiceCollection();
+            services.AddSingleton<IValidateOptions<SimpleOptions>>(new AlwaysPassValidator());
+            services.AddSingleton<IValidateOptions<SimpleOptions>>(new AlwaysFailValidator("validation-error-1"));
+            services.AddSingleton<IValidateOptions<SimpleOptions>>(new AlwaysFailValidator("validation-error-2"));
+            var serviceProvider = services.BuildServiceProvider();
+
             var channel = new SimpleChannel(
                 new SimpleOptions { Endpoint = "https://example.com" },
-                validators);
+                serviceProvider);
 
             var ex = await Assert.ThrowsAsync<OptionsValidationException>(
                 () => channel.PublishAsync(ValidEvent(), null, CancellationToken.None));
@@ -211,7 +219,7 @@ namespace Hermodr
 
         private sealed class InspectableChannel : EventPublishChannel<SimpleOptions>
         {
-            public InspectableChannel(SimpleOptions defaults) : base(defaults) { }
+            public InspectableChannel(SimpleOptions defaults, IServiceProvider? serviceProvider = null) : base(defaults, serviceProvider ?? new ServiceCollection().BuildServiceProvider()) { }
             public SimpleOptions ExposedDefaults => DefaultOptions;
             protected override Task PublishCoreAsync(CloudEvent @event, SimpleOptions options, CancellationToken ct)
                 => Task.CompletedTask;
@@ -219,7 +227,7 @@ namespace Hermodr
 
         private sealed class SlowChannel : EventPublishChannel<SimpleOptions>
         {
-            public SlowChannel(SimpleOptions defaults) : base(defaults) { }
+            public SlowChannel(SimpleOptions defaults, IServiceProvider? serviceProvider = null) : base(defaults, serviceProvider ?? new ServiceCollection().BuildServiceProvider()) { }
             protected override async Task PublishCoreAsync(CloudEvent @event, SimpleOptions options, CancellationToken ct)
                 => await Task.Delay(TimeSpan.FromSeconds(10), ct);
         }

--- a/test/Hermodr.Publisher.XUnit/Unit/PublisherOptionsCompatibilityTests.cs
+++ b/test/Hermodr.Publisher.XUnit/Unit/PublisherOptionsCompatibilityTests.cs
@@ -38,7 +38,7 @@ namespace Hermodr
         /// </summary>
         private sealed class AlphaChannel : EventPublishChannel<AlphaOptions>
         {
-            public AlphaChannel(AlphaOptions defaults) : base(defaults) { }
+            public AlphaChannel(AlphaOptions defaults, IServiceProvider? serviceProvider = null) : base(defaults, serviceProvider ?? new ServiceCollection().BuildServiceProvider()) { }
 
             /// <summary>Options received by the last <see cref="PublishCoreAsync"/> invocation.</summary>
             public AlphaOptions? LastEffectiveOptions { get; private set; }
@@ -59,7 +59,7 @@ namespace Hermodr
         /// </summary>
         private sealed class BetaChannel : EventPublishChannel<BetaOptions>
         {
-            public BetaChannel(BetaOptions defaults) : base(defaults) { }
+            public BetaChannel(BetaOptions defaults, IServiceProvider? serviceProvider = null) : base(defaults, serviceProvider ?? new ServiceCollection().BuildServiceProvider()) { }
 
             public BetaOptions? LastEffectiveOptions { get; private set; }
 
@@ -276,7 +276,7 @@ namespace Hermodr
             IEventPublishChannel<TEvent>
             where TEvent : class
         {
-            public TypedAlphaChannel(AlphaOptions defaults) : base(defaults) { }
+            public TypedAlphaChannel(AlphaOptions defaults, IServiceProvider? serviceProvider = null) : base(defaults, serviceProvider ?? new ServiceCollection().BuildServiceProvider()) { }
 
             public AlphaOptions? LastEffectiveOptions { get; private set; }
 

--- a/test/Hermodr.Publisher.XUnit/Unit/ScheduledPublishingTests.cs
+++ b/test/Hermodr.Publisher.XUnit/Unit/ScheduledPublishingTests.cs
@@ -91,8 +91,8 @@ public static class ScheduledPublishingTests
 
     private sealed class NonSchedulingTestChannel : EventPublishChannel<TestPublishOptions>
     {
-        public NonSchedulingTestChannel()
-            : base(new TestPublishOptions())
+        public NonSchedulingTestChannel(IServiceProvider? serviceProvider = null)
+            : base(new TestPublishOptions(), serviceProvider ?? new ServiceCollection().BuildServiceProvider())
         {
         }
 
@@ -107,8 +107,8 @@ public static class ScheduledPublishingTests
 
     private sealed class NativeSchedulingTestChannel : EventPublishChannel<TestPublishOptions>, IScheduledEventPublishChannel
     {
-        public NativeSchedulingTestChannel()
-            : base(new TestPublishOptions())
+        public NativeSchedulingTestChannel(IServiceProvider? serviceProvider = null)
+            : base(new TestPublishOptions(), serviceProvider ?? new ServiceCollection().BuildServiceProvider())
         {
         }
 

--- a/test/Hermodr.Schema.XUnit/Unit/EventDataDeserializerRegistryTests.cs
+++ b/test/Hermodr.Schema.XUnit/Unit/EventDataDeserializerRegistryTests.cs
@@ -1,0 +1,102 @@
+namespace Hermodr
+{
+    public static class EventDataDeserializerRegistryTests
+    {
+        private static EventDataDeserializerRegistry CreateRegistry()
+        {
+            var registry = new EventDataDeserializerRegistry();
+            registry.Register(new JsonEventDataDeserializer());
+            registry.Register(new XmlEventDataDeserializer());
+            return registry;
+        }
+
+        [Fact]
+        public static void Register_And_Retrieve_ExactMatch()
+        {
+            var registry = CreateRegistry();
+
+            var deserializer = registry.GetDeserializer("application/json");
+
+            Assert.NotNull(deserializer);
+            Assert.IsType<JsonEventDataDeserializer>(deserializer);
+        }
+
+        [Fact]
+        public static void Register_And_Retrieve_CaseInsensitive()
+        {
+            var registry = CreateRegistry();
+
+            var deserializer = registry.GetDeserializer("APPLICATION/JSON");
+
+            Assert.NotNull(deserializer);
+            Assert.IsType<JsonEventDataDeserializer>(deserializer);
+        }
+
+        [Fact]
+        public static void GetDeserializer_WildcardPrefixMatch()
+        {
+            var registry = CreateRegistry();
+
+            var deserializer = registry.GetDeserializer("application/vnd.custom+json");
+
+            Assert.NotNull(deserializer);
+            Assert.IsType<JsonEventDataDeserializer>(deserializer);
+        }
+
+        [Fact]
+        public static void GetDeserializer_UnknownContentType_ReturnsNull()
+        {
+            var registry = CreateRegistry();
+
+            var deserializer = registry.GetDeserializer("text/plain");
+
+            Assert.Null(deserializer);
+        }
+
+        [Fact]
+        public static void GetDeserializer_NullOrEmpty_ReturnsNull()
+        {
+            var registry = CreateRegistry();
+
+            Assert.Null(registry.GetDeserializer(null!));
+            Assert.Null(registry.GetDeserializer(""));
+        }
+
+        [Fact]
+        public static void Register_CustomDeserializer_CanBeRetrieved()
+        {
+            var registry = CreateRegistry();
+            var custom = new CustomTestDeserializer();
+            registry.Register(custom);
+
+            var deserializer = registry.GetDeserializer("application/x-protobuf");
+
+            Assert.NotNull(deserializer);
+            Assert.IsType<CustomTestDeserializer>(deserializer);
+        }
+
+        [Fact]
+        public static void Register_OverwritesExisting()
+        {
+            var registry = CreateRegistry();
+            var custom = new CustomTestDeserializer();
+            registry.Register(custom);
+
+            var deserializer = registry.GetDeserializer("application/json");
+
+            Assert.NotNull(deserializer);
+            Assert.IsType<CustomTestDeserializer>(deserializer);
+        }
+
+        private sealed class CustomTestDeserializer : IEventDataDeserializer
+        {
+            public string ContentType => "application/json";
+
+            public bool CanDeserialize(string contentType)
+                => contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase);
+
+            public Task<object?> DeserializeAsync(Stream data, CancellationToken cancellationToken)
+                => Task.FromResult<object?>(new Dictionary<string, object?>());
+        }
+    }
+}

--- a/test/Hermodr.Schema.XUnit/Unit/EventSchemaRegistryTests.cs
+++ b/test/Hermodr.Schema.XUnit/Unit/EventSchemaRegistryTests.cs
@@ -1,0 +1,155 @@
+using System.Reflection;
+
+namespace Hermodr
+{
+    public static class EventSchemaRegistryTests
+    {
+        private static EventSchemaRegistry CreateRegistry()
+        {
+            var factory = new EventSchemaFactory();
+            return new EventSchemaRegistry(factory);
+        }
+
+        [Fact]
+        public static void Register_SchemaInstance_CanBeRetrieved()
+        {
+            var registry = CreateRegistry();
+            var schema = new EventSchema("test.event", "1.0", "application/json");
+            registry.Register(schema);
+
+            var retrieved = registry.GetSchema("test.event", "1.0");
+
+            Assert.NotNull(retrieved);
+            Assert.Equal("test.event", retrieved.EventType);
+            Assert.Equal("1.0", retrieved.Version.ToString());
+        }
+
+        [Fact]
+        public static void Register_FromClrType_CanBeRetrieved()
+        {
+            var registry = CreateRegistry();
+            registry.Register<TestEvent>();
+
+            var schema = registry.GetSchema("test.event", "1.0");
+
+            Assert.NotNull(schema);
+            Assert.Equal("test.event", schema.EventType);
+            Assert.Equal("1.0", schema.Version.ToString());
+            Assert.True(schema.Properties.Any(p => p.Name == "name"));
+        }
+
+        [Fact]
+        public static void GetSchema_LatestVersion_WhenNoVersionSpecified()
+        {
+            var registry = CreateRegistry();
+            registry.Register(new EventSchema("test.event", "1.0", "application/json"));
+            registry.Register(new EventSchema("test.event", "2.0", "application/json"));
+
+            var schema = registry.GetSchema("test.event");
+
+            Assert.NotNull(schema);
+            Assert.Equal("2.0", schema.Version.ToString());
+        }
+
+        [Fact]
+        public static void GetSchema_ExactVersion_ReturnsCorrectVersion()
+        {
+            var registry = CreateRegistry();
+            registry.Register(new EventSchema("test.event", "1.0", "application/json"));
+            registry.Register(new EventSchema("test.event", "2.0", "application/json"));
+
+            var schema = registry.GetSchema("test.event", "1.0");
+
+            Assert.NotNull(schema);
+            Assert.Equal("1.0", schema.Version.ToString());
+        }
+
+        [Fact]
+        public static void GetSchema_UnknownEventType_ReturnsNull()
+        {
+            var registry = CreateRegistry();
+            registry.Register(new EventSchema("test.event", "1.0", "application/json"));
+
+            var schema = registry.GetSchema("unknown.event");
+
+            Assert.Null(schema);
+        }
+
+        [Fact]
+        public static void GetSchema_UnknownVersion_ReturnsNull()
+        {
+            var registry = CreateRegistry();
+            registry.Register(new EventSchema("test.event", "1.0", "application/json"));
+
+            var schema = registry.GetSchema("test.event", "99.0");
+
+            Assert.Null(schema);
+        }
+
+        [Fact]
+        public static void GetAllVersions_ReturnsAllVersionsOrdered()
+        {
+            var registry = CreateRegistry();
+            registry.Register(new EventSchema("test.event", "1.0", "application/json"));
+            registry.Register(new EventSchema("test.event", "3.0", "application/json"));
+            registry.Register(new EventSchema("test.event", "2.0", "application/json"));
+
+            var versions = registry.GetAllVersions("test.event");
+
+            Assert.Equal(3, versions.Count);
+            Assert.Equal("3.0", versions[0].Version.ToString());
+            Assert.Equal("2.0", versions[1].Version.ToString());
+            Assert.Equal("1.0", versions[2].Version.ToString());
+        }
+
+        [Fact]
+        public static void GetAllVersions_UnknownEventType_ReturnsEmpty()
+        {
+            var registry = CreateRegistry();
+
+            var versions = registry.GetAllVersions("unknown.event");
+
+            Assert.Empty(versions);
+        }
+
+        [Fact]
+        public static void ScanAssembly_RegistersAllEventTypes()
+        {
+            var registry = CreateRegistry();
+            var assembly = typeof(EventSchemaRegistryTests).Assembly;
+
+            registry.ScanAssembly(assembly);
+
+            // TestEvent is defined in this file
+            var schema = registry.GetSchema("test.event", "1.0");
+            Assert.NotNull(schema);
+        }
+
+        [Fact]
+        public static void Register_MultipleEventTypes_AllRetrievable()
+        {
+            var registry = CreateRegistry();
+            registry.Register(new EventSchema("order.placed", "1.0", "application/json"));
+            registry.Register(new EventSchema("user.registered", "1.0", "application/json"));
+
+            Assert.NotNull(registry.GetSchema("order.placed", "1.0"));
+            Assert.NotNull(registry.GetSchema("user.registered", "1.0"));
+        }
+
+        [Fact]
+        public static void GetSchema_NullEventType_ReturnsNull()
+        {
+            var registry = CreateRegistry();
+
+            Assert.Null(registry.GetSchema(null!));
+            Assert.Null(registry.GetSchema(""));
+        }
+
+        [Event("test.event", "1.0")]
+        private sealed class TestEvent
+        {
+            [EventProperty("name")]
+            public string Name { get; set; } = "";
+        }
+    }
+}

--- a/test/Hermodr.Schema.XUnit/Unit/EventSchemaValidatorTests.cs
+++ b/test/Hermodr.Schema.XUnit/Unit/EventSchemaValidatorTests.cs
@@ -1,0 +1,822 @@
+using CloudNative.CloudEvents;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
+namespace Hermodr
+{
+    public static class EventSchemaValidatorTests
+    {
+        private static EventSchemaValidator CreateValidator()
+        {
+            var deserializerRegistry = new EventDataDeserializerRegistry();
+            deserializerRegistry.Register(new JsonEventDataDeserializer());
+            deserializerRegistry.Register(new XmlEventDataDeserializer());
+
+            var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<EventSchemaValidator>.Instance;
+
+            return new EventSchemaValidator(deserializerRegistry, logger);
+        }
+
+        private static CloudEvent CreateCloudEvent(string data, string contentType = "application/json")
+        {
+            return new CloudEvent
+            {
+                Type = "test.event",
+                Source = new Uri("https://test.com"),
+                Id = "test-id",
+                DataContentType = contentType,
+                Data = data
+            };
+        }
+
+        private static CloudEvent CreateCloudEventFromBytes(byte[] data, string contentType = "application/json")
+        {
+            return new CloudEvent
+            {
+                Type = "test.event",
+                Source = new Uri("https://test.com"),
+                Id = "test-id",
+                DataContentType = contentType,
+                Data = data
+            };
+        }
+
+        [Fact]
+        public static async Task Validate_RequiredFieldMissing_ReturnsError()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .AddProperty("email", prop => prop.OfType("string").Required())
+                .Build();
+
+            var json = """{"name": "John"}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Single(errors);
+            Assert.Contains("email", errors[0].ErrorMessage);
+            Assert.Contains("email", errors[0].MemberNames.First());
+        }
+
+        [Fact]
+        public static async Task Validate_RangeConstraintViolated_ReturnsError()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("age", prop => prop.OfType("int").WithConstraint(new RangeConstraint<int>(0, 150)))
+                .Build();
+
+            var json = """{"age": 200}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Single(errors);
+            Assert.Contains("200", errors[0].ErrorMessage);
+            Assert.Contains("0", errors[0].ErrorMessage);
+            Assert.Contains("150", errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task Validate_EnumValueNotAllowed_ReturnsError()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("status", prop => prop.OfType("string")
+                    .WithConstraint(new EnumMemberConstraint<string>(new[] { "Active", "Inactive", "Pending" })))
+                .Build();
+
+            var json = """{"status": "Deleted"}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Single(errors);
+            Assert.Contains("Deleted", errors[0].ErrorMessage);
+            Assert.Contains("Active", errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task Validate_NullableFalseWithNull_ReturnsError()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .AddProperty("email", prop => prop.OfType("string").Nullable())
+                .Build();
+
+            var json = """{"name": null, "email": "test@test.com"}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Single(errors);
+            Assert.Contains("name", errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task Validate_NestedObject_ValidatesRecursively()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("user", prop => prop.OfType("object")
+                    .AddProperty("name", sub => sub.OfType("string").Required())
+                    .AddProperty("email", sub => sub.OfType("string").Required()))
+                .Build();
+
+            var json = """{"user": {"name": "Alice"}}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Single(errors);
+            Assert.Contains("email", errors[0].ErrorMessage);
+            Assert.Contains("user.email", errors[0].MemberNames.First());
+        }
+
+        [Fact]
+        public static async Task Validate_MultipleErrors_ReturnsAll()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .AddProperty("age", prop => prop.OfType("int").WithConstraint(new RangeConstraint<int>(0, 150)))
+                .AddProperty("status", prop => prop.OfType("string")
+                    .WithConstraint(new EnumMemberConstraint<string>(new[] { "Active", "Inactive" })))
+                .Build();
+
+            var json = """{"age": 200, "status": "Unknown"}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Equal(3, errors.Count);
+        }
+
+        [Fact]
+        public static async Task Validate_ValidEvent_ReturnsNoErrors()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .AddProperty("age", prop => prop.OfType("int").WithConstraint(new RangeConstraint<int>(0, 150)))
+                .Build();
+
+            var json = """{"name": "John", "age": 30}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public static async Task Validate_UnsupportedContentType_ReturnsNoErrors()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .Build();
+
+            var data = "some binary data";
+            var cloudEvent = CreateCloudEvent(data, "application/octet-stream");
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public static async Task Validate_XmlContentType_ValidatesCorrectly()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .AddProperty("age", prop => prop.OfType("int"))
+                .Build();
+
+            var xml = """<root><name>Alice</name><age>25</age></root>""";
+            var cloudEvent = CreateCloudEvent(xml, "application/xml");
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public static async Task Validate_XmlWithMissingRequiredField_ReturnsError()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .AddProperty("email", prop => prop.OfType("string").Required())
+                .Build();
+
+            var xml = """<root><name>Alice</name></root>""";
+            var cloudEvent = CreateCloudEvent(xml, "application/xml");
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Single(errors);
+            Assert.Contains("email", errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task Validate_NullEventData_ReturnsNoErrors()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .Build();
+
+            var cloudEvent = new CloudEvent
+            {
+                Type = "test.event",
+                Source = new Uri("https://test.com"),
+                Id = "test-id",
+                DataContentType = "application/json",
+                Data = null
+            };
+
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+
+            Assert.Empty(errors);
+        }
+
+        // ─── Range edge cases ──────────────────────────────────────────────
+
+        [Fact]
+        public static async Task Validate_RangeBelowMinimum_ReturnsError()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("age", prop => prop.OfType("int").WithConstraint(new RangeConstraint<int>(18, 150)))
+                .Build();
+
+            var json = """{"age": 15}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Single(errors);
+            Assert.Contains("15", errors[0].ErrorMessage);
+            Assert.Contains("18", errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task Validate_RangeMinOnly_ValidPasses()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("score", prop => prop.OfType("int").WithConstraint(new RangeConstraint<int>(0, null)))
+                .Build();
+
+            var json = """{"score": 42}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public static async Task Validate_RangeMinOnly_BelowFails()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("score", prop => prop.OfType("int").WithConstraint(new RangeConstraint<int>(0, null)))
+                .Build();
+
+            var json = """{"score": -5}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Single(errors);
+            Assert.Contains("-5", errors[0].ErrorMessage);
+            Assert.Contains("0", errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task Validate_RangeMaxOnly_ValidPasses()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("score", prop => prop.OfType("int").WithConstraint(new RangeConstraint<int>(null, 100)))
+                .Build();
+
+            var json = """{"score": 50}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public static async Task Validate_RangeMaxOnly_AboveFails()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("score", prop => prop.OfType("int").WithConstraint(new RangeConstraint<int>(null, 100)))
+                .Build();
+
+            var json = """{"score": 150}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Single(errors);
+            Assert.Contains("150", errors[0].ErrorMessage);
+            Assert.Contains("100", errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task Validate_RangeBorderlineValues_Valid()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("age", prop => prop.OfType("int").WithConstraint(new RangeConstraint<int>(0, 150)))
+                .Build();
+
+            var errors0 = await CollectErrors(validator, schema, CreateCloudEvent("""{"age": 0}"""));
+            var errors150 = await CollectErrors(validator, schema, CreateCloudEvent("""{"age": 150}"""));
+
+            Assert.Empty(errors0);
+            Assert.Empty(errors150);
+        }
+
+        [Fact]
+        public static async Task Validate_DecimalRange_Valid()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("price", prop => prop.OfType("money").WithConstraint(new RangeConstraint<decimal>(0.00m, 999.99m)))
+                .Build();
+
+            var json = """{"price": 49.99}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        // ─── Enum edge cases ──────────────────────────────────────────────
+
+        [Fact]
+        public static async Task Validate_EnumValidValue_Passes()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("status", prop => prop.OfType("string")
+                    .WithConstraint(new EnumMemberConstraint<string>(new[] { "Active", "Inactive", "Pending" })))
+                .Build();
+
+            var errorsActive = await CollectErrors(validator, schema, CreateCloudEvent("""{"status": "Active"}"""));
+            var errorsInactive = await CollectErrors(validator, schema, CreateCloudEvent("""{"status": "Inactive"}"""));
+            var errorsPending = await CollectErrors(validator, schema, CreateCloudEvent("""{"status": "Pending"}"""));
+
+            Assert.Empty(errorsActive);
+            Assert.Empty(errorsInactive);
+            Assert.Empty(errorsPending);
+        }
+
+        [Fact]
+        public static async Task Validate_EnumWithEmptyString_Fails()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("status", prop => prop.OfType("string")
+                    .WithConstraint(new EnumMemberConstraint<string>(new[] { "Active", "Inactive" })))
+                .Build();
+
+            var json = """{"status": ""}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Single(errors);
+            Assert.Contains("not in allowed set", errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task Validate_EnumNumericValue_Fails()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("status", prop => prop.OfType("string")
+                    .WithConstraint(new EnumMemberConstraint<string>(new[] { "Active", "Inactive" })))
+                .Build();
+
+            var json = """{"status": 42}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Single(errors);
+        }
+
+        // ─── Nullable property scenarios ──────────────────────────────────
+
+        [Fact]
+        public static async Task Validate_NullableFieldNullValue_Passes()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .AddProperty("email", prop => prop.OfType("string").Nullable())
+                .Build();
+
+            var json = """{"name": "John", "email": null}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public static async Task Validate_AllFieldsNullableMissing_Passes()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Nullable())
+                .AddProperty("email", prop => prop.OfType("string").Nullable())
+                .Build();
+
+            var json = """{}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        // ─── Deeply nested object scenarios ───────────────────────────────
+
+        [Fact]
+        public static async Task Validate_DeeplyNestedObject_ThreeLevels()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("order", prop => prop.OfType("object")
+                    .AddProperty("id", sub => sub.OfType("string").Required())
+                    .AddProperty("customer", sub => sub.OfType("object")
+                        .AddProperty("name", sub2 => sub2.OfType("string").Required())
+                        .AddProperty("address", sub2 => sub2.OfType("object")
+                            .AddProperty("street", sub3 => sub3.OfType("string").Required())
+                            .AddProperty("city", sub3 => sub3.OfType("string").Required()))))
+                .Build();
+
+            var json = """{"order": {"id": "123", "customer": {"name": "Alice", "address": {"street": "Main St"}}}}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Single(errors);
+            Assert.Contains("order.customer.address.city", errors[0].MemberNames.First());
+        }
+
+        [Fact]
+        public static async Task Validate_DeeplyNestedAllValid_Passes()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("order", prop => prop.OfType("object")
+                    .AddProperty("id", sub => sub.OfType("string").Required())
+                    .AddProperty("customer", sub => sub.OfType("object")
+                        .AddProperty("name", sub2 => sub2.OfType("string").Required())
+                        .AddProperty("address", sub2 => sub2.OfType("object")
+                            .AddProperty("street", sub3 => sub3.OfType("string").Required())
+                            .AddProperty("city", sub3 => sub3.OfType("string").Required()))))
+                .Build();
+
+            var json = """{"order": {"id": "123", "customer": {"name": "Alice", "address": {"street": "Main St", "city": "Springfield"}}}}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public static async Task Validate_MultipleNestedObjects_ErrorsInEach()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("shipping", prop => prop.OfType("object")
+                    .AddProperty("street", sub => sub.OfType("string").Required())
+                    .AddProperty("city", sub => sub.OfType("string").Required()))
+                .AddProperty("billing", prop => prop.OfType("object")
+                    .AddProperty("street", sub => sub.OfType("string").Required())
+                    .AddProperty("city", sub => sub.OfType("string").Required()))
+                .Build();
+
+            var json = """{"shipping": {"street": "123 Main"}, "billing": {"city": "Springfield"}}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Equal(2, errors.Count);
+            Assert.Contains(errors, e => e.MemberNames.First() == "shipping.city");
+            Assert.Contains(errors, e => e.MemberNames.First() == "billing.street");
+        }
+
+        // ─── Multiple required fields missing ─────────────────────────────
+
+        [Fact]
+        public static async Task Validate_MultipleRequiredFieldsMissing_ReturnsAllErrors()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .AddProperty("email", prop => prop.OfType("string").Required())
+                .AddProperty("phone", prop => prop.OfType("string").Required())
+                .AddProperty("age", prop => prop.OfType("int").Required())
+                .Build();
+
+            var json = """{}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Equal(4, errors.Count);
+            Assert.Contains(errors, e => e.MemberNames.First() == "name");
+            Assert.Contains(errors, e => e.MemberNames.First() == "email");
+            Assert.Contains(errors, e => e.MemberNames.First() == "phone");
+            Assert.Contains(errors, e => e.MemberNames.First() == "age");
+        }
+
+        // ─── Byte array data ──────────────────────────────────────────────
+
+        [Fact]
+        public static async Task Validate_ByteArrayData_ValidatesCorrectly()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .Build();
+
+            var json = """{"name": "Alice"}""";
+            var bytes = Encoding.UTF8.GetBytes(json);
+            var cloudEvent = CreateCloudEventFromBytes(bytes);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        // ─── Extra properties in data (not in schema) ────────────────────
+
+        [Fact]
+        public static async Task Validate_ExtraPropertiesInData_Ignored()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .Build();
+
+            var json = """{"name": "John", "extra1": "value1", "extra2": 42, "extra3": {"nested": true}}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        // ─── Empty schema (no properties) ────────────────────────────────
+
+        [Fact]
+        public static async Task Validate_EmptySchema_ReturnsNoErrors()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .Build();
+
+            var json = """{"anything": "goes"}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        // ─── Boolean values ───────────────────────────────────────────────
+
+        [Fact]
+        public static async Task Validate_BooleanRequired_Passes()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("active", prop => prop.OfType("boolean").Required())
+                .Build();
+
+            var errorsTrue = await CollectErrors(validator, schema, CreateCloudEvent("""{"active": true}"""));
+            var errorsFalse = await CollectErrors(validator, schema, CreateCloudEvent("""{"active": false}"""));
+
+            Assert.Empty(errorsTrue);
+            Assert.Empty(errorsFalse);
+        }
+
+        // ─── Property name case sensitivity ──────────────────────────────
+
+        [Fact]
+        public static async Task Validate_PropertyNameCaseMismatch_ReturnsError()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("Name", prop => prop.OfType("string").Required())
+                .Build();
+
+            var json = """{"name": "John"}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Single(errors);
+            Assert.Contains("Name", errors[0].ErrorMessage);
+        }
+
+        // ─── Data as Stream ───────────────────────────────────────────────
+
+        [Fact]
+        public static async Task Validate_DataAsStream_ValidatesCorrectly()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .Build();
+
+            var json = """{"name": "StreamTest"}""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            var cloudEvent = new CloudEvent
+            {
+                Type = "test.event",
+                Source = new Uri("https://test.com"),
+                Id = "test-id",
+                DataContentType = "application/json",
+                Data = stream
+            };
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        // ─── CloudEvents structured content type ─────────────────────────
+
+        [Fact]
+        public static async Task Validate_CloudEventsStructuredContentType_Validates()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .Build();
+
+            var json = """{"name": "Alice"}""";
+            var cloudEvent = CreateCloudEvent(json, "application/cloudevents+json");
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Empty(errors);
+        }
+
+        // ─── Mixed constraint types on single property ───────────────────
+
+        [Fact]
+        public static async Task Validate_MixedConstraints_RangeAndEnum()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("priority", prop => prop.OfType("int")
+                    .WithConstraint(new RangeConstraint<int>(1, 5))
+                    .WithConstraint(new EnumMemberConstraint<int>(new[] { 1, 2, 3, 4, 5 })))
+                .Build();
+
+            var errorsValid = await CollectErrors(validator, schema, CreateCloudEvent("""{"priority": 3}"""));
+            var errorsOutOfRange = await CollectErrors(validator, schema, CreateCloudEvent("""{"priority": 6}"""));
+            var errorsNotAllowed = await CollectErrors(validator, schema, CreateCloudEvent("""{"priority": 0}"""));
+
+            Assert.Empty(errorsValid);
+            Assert.NotEmpty(errorsOutOfRange);
+            Assert.NotEmpty(errorsNotAllowed);
+        }
+
+        [Fact]
+        public static async Task Validate_RequiredAndRange_MissingField()
+        {
+            var validator = CreateValidator();
+            var schema = EventSchema.Build("test.event")
+                .WithVersion("1.0")
+                .AddProperty("name", prop => prop.OfType("string").Required())
+                .AddProperty("age", prop => prop.OfType("int").Required()
+                    .WithConstraint(new RangeConstraint<int>(0, 150)))
+                .Build();
+
+            var json = """{"name": "John"}""";
+            var cloudEvent = CreateCloudEvent(json);
+
+            var errors = await CollectErrors(validator, schema, cloudEvent);
+
+            Assert.Single(errors);
+            Assert.Contains("age", errors[0].ErrorMessage);
+        }
+
+        // ─── Helper ──────────────────────────────────────────────────────
+
+        private static async Task<List<ValidationResult>> CollectErrors(
+            EventSchemaValidator validator,
+            IEventSchema schema,
+            CloudEvent cloudEvent)
+        {
+            var errors = new List<ValidationResult>();
+            await foreach (var error in validator.ValidateEventAsync(schema, cloudEvent))
+            {
+                errors.Add(error);
+            }
+            return errors;
+        }
+    }
+}

--- a/test/Hermodr.Schema.XUnit/Unit/JsonEventDataDeserializerTests.cs
+++ b/test/Hermodr.Schema.XUnit/Unit/JsonEventDataDeserializerTests.cs
@@ -10,7 +10,7 @@ namespace Hermodr
         public static async Task Deserialize_SimpleObject_ReturnsDictionary()
         {
             var json = """{"name": "John", "age": 30}""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -23,7 +23,7 @@ namespace Hermodr
         public static async Task Deserialize_NestedObject_ReturnsNestedDictionary()
         {
             var json = """{"user": {"name": "Alice", "email": "alice@test.com"}}""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -37,7 +37,7 @@ namespace Hermodr
         public static async Task Deserialize_Array_ReturnsList()
         {
             var json = """{"tags": ["a", "b", "c"]}""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -53,7 +53,7 @@ namespace Hermodr
         public static async Task Deserialize_NullValue_ReturnsNull()
         {
             var json = """{"value": null}""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -65,7 +65,7 @@ namespace Hermodr
         public static async Task Deserialize_BooleanValues_ReturnsBool()
         {
             var json = """{"active": true, "verified": false}""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -78,7 +78,7 @@ namespace Hermodr
         public static async Task Deserialize_NumberValues_ReturnsDouble()
         {
             var json = """{"int_val": 42, "float_val": 3.14}""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -107,7 +107,7 @@ namespace Hermodr
         [Fact]
         public static async Task Deserialize_EmptyStream_Throws()
         {
-            var stream = new MemoryStream(Array.Empty<byte>());
+            using var stream = new MemoryStream(Array.Empty<byte>());
             var exception = await Record.ExceptionAsync(() =>
                 Deserializer.DeserializeAsync(stream, CancellationToken.None));
             Assert.NotNull(exception);

--- a/test/Hermodr.Schema.XUnit/Unit/JsonEventDataDeserializerTests.cs
+++ b/test/Hermodr.Schema.XUnit/Unit/JsonEventDataDeserializerTests.cs
@@ -1,0 +1,116 @@
+using System.Text;
+
+namespace Hermodr
+{
+    public static class JsonEventDataDeserializerTests
+    {
+        private static readonly JsonEventDataDeserializer Deserializer = new();
+
+        [Fact]
+        public static async Task Deserialize_SimpleObject_ReturnsDictionary()
+        {
+            var json = """{"name": "John", "age": 30}""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.Equal("John", dict["name"]);
+            Assert.Equal(30.0, dict["age"]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_NestedObject_ReturnsNestedDictionary()
+        {
+            var json = """{"user": {"name": "Alice", "email": "alice@test.com"}}""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            var user = Assert.IsType<Dictionary<string, object?>>(dict["user"]);
+            Assert.Equal("Alice", user["name"]);
+            Assert.Equal("alice@test.com", user["email"]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_Array_ReturnsList()
+        {
+            var json = """{"tags": ["a", "b", "c"]}""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            var tags = Assert.IsType<List<object?>>(dict["tags"]);
+            Assert.Equal(3, tags.Count);
+            Assert.Equal("a", tags[0]);
+            Assert.Equal("b", tags[1]);
+            Assert.Equal("c", tags[2]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_NullValue_ReturnsNull()
+        {
+            var json = """{"value": null}""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.Null(dict["value"]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_BooleanValues_ReturnsBool()
+        {
+            var json = """{"active": true, "verified": false}""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.True((bool)dict["active"]!);
+            Assert.False((bool)dict["verified"]!);
+        }
+
+        [Fact]
+        public static async Task Deserialize_NumberValues_ReturnsDouble()
+        {
+            var json = """{"int_val": 42, "float_val": 3.14}""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.Equal(42.0, dict["int_val"]);
+            Assert.Equal(3.14, (double)dict["float_val"]!, 2);
+        }
+
+        [Fact]
+        public static async Task CanDeserialize_JsonContentType_ReturnsTrue()
+        {
+            Assert.True(Deserializer.CanDeserialize("application/json"));
+            Assert.True(Deserializer.CanDeserialize("application/cloudevents+json"));
+            Assert.True(Deserializer.CanDeserialize("APPLICATION/JSON"));
+        }
+
+        [Fact]
+        public static async Task CanDeserialize_NonJsonContentType_ReturnsFalse()
+        {
+            Assert.False(Deserializer.CanDeserialize("application/xml"));
+            Assert.False(Deserializer.CanDeserialize("text/plain"));
+            Assert.False(Deserializer.CanDeserialize(""));
+            Assert.False(Deserializer.CanDeserialize(null!));
+        }
+
+        [Fact]
+        public static async Task Deserialize_EmptyStream_Throws()
+        {
+            var stream = new MemoryStream(Array.Empty<byte>());
+            var exception = await Record.ExceptionAsync(() =>
+                Deserializer.DeserializeAsync(stream, CancellationToken.None));
+            Assert.NotNull(exception);
+        }
+    }
+}

--- a/test/Hermodr.Schema.XUnit/Unit/XmlEventDataDeserializerTests.cs
+++ b/test/Hermodr.Schema.XUnit/Unit/XmlEventDataDeserializerTests.cs
@@ -1,0 +1,123 @@
+using System.Text;
+
+namespace Hermodr
+{
+    public static class XmlEventDataDeserializerTests
+    {
+        private static readonly XmlEventDataDeserializer Deserializer = new();
+
+        [Fact]
+        public static async Task Deserialize_SimpleElement_ReturnsDictionary()
+        {
+            var xml = """<root><name>John</name><age>30</age></root>""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.Equal("John", dict["name"]);
+            Assert.Equal("30", dict["age"]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_NestedElements_ReturnsNestedDictionary()
+        {
+            var xml = """<root><user><name>Alice</name><email>alice@test.com</email></user></root>""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            var user = Assert.IsType<Dictionary<string, object?>>(dict["user"]);
+            Assert.Equal("Alice", user["name"]);
+            Assert.Equal("alice@test.com", user["email"]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_AttributesAsProperties_ReturnsDictionary()
+        {
+            var xml = """<order id="123" status="active"></order>""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.Equal("123", dict["id"]);
+            Assert.Equal("active", dict["status"]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_AttributeAndElementConflict_AttributeWins()
+        {
+            var xml = """<order id="attr-value"><id>element-value</id></order>""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.Equal("attr-value", dict["id"]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_ElementWithAttributes_ReturnsDictionary()
+        {
+            var xml = """<person id="1"><name>Bob</name><age>25</age></person>""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.Equal("1", dict["id"]);
+            Assert.Equal("Bob", dict["name"]);
+            Assert.Equal("25", dict["age"]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_EmptyElement_ReturnsEmptyString()
+        {
+            var xml = """<root><value></value></root>""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.Equal("", dict["value"]);
+        }
+
+        [Fact]
+        public static async Task Deserialize_ElementWithText_ReturnsString()
+        {
+            var xml = """<root><message>Hello World</message></root>""";
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+            var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
+
+            var dict = Assert.IsType<Dictionary<string, object?>>(result);
+            Assert.Equal("Hello World", dict["message"]);
+        }
+
+        [Fact]
+        public static async Task CanDeserialize_XmlContentType_ReturnsTrue()
+        {
+            Assert.True(Deserializer.CanDeserialize("application/xml"));
+            Assert.True(Deserializer.CanDeserialize("APPLICATION/XML"));
+        }
+
+        [Fact]
+        public static async Task CanDeserialize_NonXmlContentType_ReturnsFalse()
+        {
+            Assert.False(Deserializer.CanDeserialize("application/json"));
+            Assert.False(Deserializer.CanDeserialize("text/plain"));
+            Assert.False(Deserializer.CanDeserialize(""));
+            Assert.False(Deserializer.CanDeserialize(null!));
+        }
+
+        [Fact]
+        public static async Task Deserialize_EmptyStream_Throws()
+        {
+            var stream = new MemoryStream(Array.Empty<byte>());
+            await Assert.ThrowsAsync<System.Xml.XmlException>(() =>
+                Deserializer.DeserializeAsync(stream, CancellationToken.None));
+        }
+    }
+}

--- a/test/Hermodr.Schema.XUnit/Unit/XmlEventDataDeserializerTests.cs
+++ b/test/Hermodr.Schema.XUnit/Unit/XmlEventDataDeserializerTests.cs
@@ -10,7 +10,7 @@ namespace Hermodr
         public static async Task Deserialize_SimpleElement_ReturnsDictionary()
         {
             var xml = """<root><name>John</name><age>30</age></root>""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -23,7 +23,7 @@ namespace Hermodr
         public static async Task Deserialize_NestedElements_ReturnsNestedDictionary()
         {
             var xml = """<root><user><name>Alice</name><email>alice@test.com</email></user></root>""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -37,7 +37,7 @@ namespace Hermodr
         public static async Task Deserialize_AttributesAsProperties_ReturnsDictionary()
         {
             var xml = """<order id="123" status="active"></order>""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -50,7 +50,7 @@ namespace Hermodr
         public static async Task Deserialize_AttributeAndElementConflict_AttributeWins()
         {
             var xml = """<order id="attr-value"><id>element-value</id></order>""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -62,7 +62,7 @@ namespace Hermodr
         public static async Task Deserialize_ElementWithAttributes_ReturnsDictionary()
         {
             var xml = """<person id="1"><name>Bob</name><age>25</age></person>""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -76,7 +76,7 @@ namespace Hermodr
         public static async Task Deserialize_EmptyElement_ReturnsEmptyString()
         {
             var xml = """<root><value></value></root>""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -88,7 +88,7 @@ namespace Hermodr
         public static async Task Deserialize_ElementWithText_ReturnsString()
         {
             var xml = """<root><message>Hello World</message></root>""";
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
 
             var result = await Deserializer.DeserializeAsync(stream, CancellationToken.None);
 
@@ -115,7 +115,7 @@ namespace Hermodr
         [Fact]
         public static async Task Deserialize_EmptyStream_Throws()
         {
-            var stream = new MemoryStream(Array.Empty<byte>());
+            using var stream = new MemoryStream(Array.Empty<byte>());
             await Assert.ThrowsAsync<System.Xml.XmlException>(() =>
                 Deserializer.DeserializeAsync(stream, CancellationToken.None));
         }


### PR DESCRIPTION
This pull request introduces a major new feature: automatic schema validation at publish time via the new `Hermodr.Publisher.EventSchema` package. It also includes supporting documentation updates, test coverage, and minor dependency updates. The most important changes are summarized below:

**Schema Validation Middleware:**

* Added the `Hermodr.Publisher.EventSchema` package, providing middleware that automatically validates event payloads against registered schemas before dispatch in the publish pipeline. This includes version-aware validation, format-agnostic deserialization (JSON, XML), and configurable behaviors for missing schemas and validation failures. (`Hermodr.sln`, `CHANGELOG.md`, `docs/packages.md`, `docs/schema/validation-at-publish.md`, `docs/schema/README.md`, `docs/schema/validation.md`, `docs/concepts/publish-pipeline.md`, [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R18) [[2]](diffhunk://#diff-1a1c78374c9e0f8bfe492f6c30e453c32d0e5271bf02b1b9504c9fa2a81d32e3R132-R135) [[3]](diffhunk://#diff-1a1c78374c9e0f8bfe492f6c30e453c32d0e5271bf02b1b9504c9fa2a81d32e3R770-R793) [[4]](diffhunk://#diff-1a1c78374c9e0f8bfe492f6c30e453c32d0e5271bf02b1b9504c9fa2a81d32e3R855-R856) [[5]](diffhunk://#diff-492f4fe6d732168c58e78f2a627614dc59f1e41a5d12da3d8347d3957e9673f6R49) [[6]](diffhunk://#diff-190d7f0e78654966ec10127520758ad8a34f2d393adfac7c94bbbcfd49535a4cR59) [[7]](diffhunk://#diff-190d7f0e78654966ec10127520758ad8a34f2d393adfac7c94bbbcfd49535a4cR408-R421) [[8]](diffhunk://#diff-d67e991a9ecb4072b81a44921f423dfeeec45f82b9d21ead36497e7bcf831fceR33) [[9]](diffhunk://#diff-6b96f32ce039f3dc279b82489b3fc3af048b9df8220a2c032615061b0a223f31R1-R122) [[10]](diffhunk://#diff-e55d0c2ee51e266b1e8a91a16dd78b4ddc0bb58642dfe11982da4e3559a7011aR108-R114) [[11]](diffhunk://#diff-96ca1c5a6fea96b942ef412cf3f90ed1b0c3ea0e20de471d6a747caa7c9ee285R311)

**Documentation:**

* Added a new guide, [Schema Validation at Publish Time](docs/schema/validation-at-publish.md), with setup instructions, configuration options, and usage examples for the new middleware. Linked this guide throughout the documentation and updated package listings. [[1]](diffhunk://#diff-6b96f32ce039f3dc279b82489b3fc3af048b9df8220a2c032615061b0a223f31R1-R122) [[2]](diffhunk://#diff-190d7f0e78654966ec10127520758ad8a34f2d393adfac7c94bbbcfd49535a4cR408-R421) [[3]](diffhunk://#diff-d67e991a9ecb4072b81a44921f423dfeeec45f82b9d21ead36497e7bcf831fceR33) [[4]](diffhunk://#diff-e55d0c2ee51e266b1e8a91a16dd78b4ddc0bb58642dfe11982da4e3559a7011aR108-R114) [[5]](diffhunk://#diff-190d7f0e78654966ec10127520758ad8a34f2d393adfac7c94bbbcfd49535a4cR59) [[6]](diffhunk://#diff-96ca1c5a6fea96b942ef412cf3f90ed1b0c3ea0e20de471d6a747caa7c9ee285R311)

**Testing:**

* Added 212 new tests (200 in `Hermodr.Schema.XUnit`, 12 in `Hermodr.Publisher.EventSchema.XUnit`) covering middleware behaviors, version-aware lookup, and error handling. (`CHANGELOG.md`, [CHANGELOG.mdR3-R18](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R18))

**Dependency Updates:**

* Updated `Kista` dependencies in `Hermodr.AuditTrail`, `Hermodr.AuditTrail.InMemory`, and `Hermodr.AuditTrail.EntityFramework` projects from version 1.6.4 to 1.6.7. [[1]](diffhunk://#diff-d8c218300b2d26bd2dddc5d9f77652e7274cee947bf94790b3ae239d9024ba29L14-R14) [[2]](diffhunk://#diff-0c8a1d2435fdc533b4c4fb1c5e1e0d2374c21b9f8ba5dea60d265055d4c74430L14-R14) [[3]](diffhunk://#diff-9bb0084c2bb3c2a683db3e2fed03468ee8a7f2a4b594fe91238eb9c2e11300caL12-R12)

**Internal Refactoring:**

* Refactored publish channel constructors in `Hermodr.Publisher.AuditTrail` and `Hermodr.Publisher.AzureServiceBus` to accept `IServiceProvider` instead of explicit validators, simplifying dependency injection and aligning with new middleware patterns. [[1]](diffhunk://#diff-dcf16a00f4c8d34b89c325e74c40fb5a390085177f7bccd22e9c427627174a51R5) [[2]](diffhunk://#diff-dcf16a00f4c8d34b89c325e74c40fb5a390085177f7bccd22e9c427627174a51L40-R49) [[3]](diffhunk://#diff-c2be98b786c70650653d33ce133cbabf5b7047799a09627f6d02bd911e6d406bR3) [[4]](diffhunk://#diff-c2be98b786c70650653d33ce133cbabf5b7047799a09627f6d02bd911e6d406bL30-R39) [[5]](diffhunk://#diff-62bfe927e5e613b730fcecd252956d3ef15827d7a56bc2e98c6cc0481373aaa3R13) [[6]](diffhunk://#diff-62bfe927e5e613b730fcecd252956d3ef15827d7a56bc2e98c6cc0481373aaa3L46-R56) [[7]](diffhunk://#diff-fbf93c3df3b3d4ec17bb6432f012c491408136595906ff233622798d690f3855R6) [[8]](diffhunk://#diff-fbf93c3df3b3d4ec17bb6432f012c491408136595906ff233622798d690f3855L48-R61)

These changes collectively enable robust, configurable schema validation for all published events, improving reliability and developer experience.