### PR TITLE
chore(deps): bump Kista references from 1.7.2 to 1.7.3

### DIFF
--- a/src/Hermodr.AuditTrail.EntityFramework/Hermodr.AuditTrail.EntityFramework.csproj
+++ b/src/Hermodr.AuditTrail.EntityFramework/Hermodr.AuditTrail.EntityFramework.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.EntityFramework" Version="1.7.2" />
+    <PackageReference Include="Kista.EntityFramework" Version="1.7.3" />
   </ItemGroup>
 </Project>

--- a/src/Hermodr.AuditTrail.InMemory/Hermodr.AuditTrail.InMemory.csproj
+++ b/src/Hermodr.AuditTrail.InMemory/Hermodr.AuditTrail.InMemory.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.InMemory" Version="1.7.2" />
+    <PackageReference Include="Kista.InMemory" Version="1.7.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Hermodr.AuditTrail/Hermodr.AuditTrail.csproj
+++ b/src/Hermodr.AuditTrail/Hermodr.AuditTrail.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CloudNative.CloudEvents" Version="2.9.0" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.9.0" />
-    <PackageReference Include="Kista" Version="1.7.2" />
+    <PackageReference Include="Kista" Version="1.7.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Hermodr.Publisher.DeadLetter.EntityFramework/DeadLetterBuilderExtensions.cs
+++ b/src/Hermodr.Publisher.DeadLetter.EntityFramework/DeadLetterBuilderExtensions.cs
@@ -28,7 +28,8 @@ public static class DeadLetterBuilderExtensions
 
         builder.Services.AddDbContext<DeadLetterDbContext>(configure, lifetime);
         builder.UseRepository<DbDeadLetterMessage, EntityDeadLetterMessageStore<DbDeadLetterMessage>>(lifetime);
-        builder.Services.AddRepository<EntityDeadLetterMessageStore<DbDeadLetterMessage>>();
+        builder.Services.AddRepositoryContext()
+            .AddRepository<EntityDeadLetterMessageStore<DbDeadLetterMessage>>();
         builder.WithFactory<DbDeadLetterMessage, DeadLetterMessageEntityFactory<DbDeadLetterMessage>>();
         return builder;
     }

--- a/src/Hermodr.Publisher.DeadLetter.EntityFramework/Hermodr.Publisher.DeadLetter.EntityFramework.csproj
+++ b/src/Hermodr.Publisher.DeadLetter.EntityFramework/Hermodr.Publisher.DeadLetter.EntityFramework.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.EntityFramework" Version="1.7.2" />
+    <PackageReference Include="Kista.EntityFramework" Version="1.7.3" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">

--- a/src/Hermodr.Publisher.DeliveryLog.EntityFramework/Hermodr.Publisher.DeliveryLog.EntityFramework.csproj
+++ b/src/Hermodr.Publisher.DeliveryLog.EntityFramework/Hermodr.Publisher.DeliveryLog.EntityFramework.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.EntityFramework" Version="1.7.2" />
+    <PackageReference Include="Kista.EntityFramework" Version="1.7.3" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">

--- a/src/Hermodr.Publisher.DeliveryLog.InMemory/Hermodr.Publisher.DeliveryLog.InMemory.csproj
+++ b/src/Hermodr.Publisher.DeliveryLog.InMemory/Hermodr.Publisher.DeliveryLog.InMemory.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kista.InMemory" Version="1.7.2" />
+    <PackageReference Include="Kista.InMemory" Version="1.7.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Hermodr.Publisher.Outbox.EntityFramework/Hermodr.Publisher.Outbox.EntityFramework.csproj
+++ b/src/Hermodr.Publisher.Outbox.EntityFramework/Hermodr.Publisher.Outbox.EntityFramework.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Kista.EntityFramework" Version="1.7.2" />
+        <PackageReference Include="Kista.EntityFramework" Version="1.7.3" />
     </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">


### PR DESCRIPTION
Bumps Kista package references from 1.7.2 to 1.7.3 across the solution and adapts the DeadLetter EF registration to the new `AddRepositoryContext()` API introduced in Kista 1.7.3.

**Changes:**
- Bump `Kista`, `Kista.EntityFramework`, and `Kista.InMemory` from 1.7.2 to 1.7.3
- Update `DeadLetterBuilderExtensions` to use `AddRepositoryContext().AddRepository<...>()`