### PR TITLE
feat(webhook): CloudEvents HTTP binding compliance for the Webhook Publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ## [Unreleased]
 
+### 🚀 Features
+
+- **CloudEvents binary HTTP content mode for the Webhook publisher** (roadmap item 12):
+  - New `EventMessageFormat.CloudEventsBinary` (`"cloudevents+binary"`) format
+    constant in `Hermodr.Publisher`.
+  - New `CloudEventsBinarySerializer` — emits the raw event `data` as the
+    request body via `JsonEventFormatter.EncodeBinaryModeEventData`.
+  - New `CloudEventHttpHeadersMapper` (internal) — projects every CloudEvent
+    context attribute (including extensions) onto `ce-*` HTTP headers per the
+    [CloudEvents HTTP binding §3.1](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md#31-binary-content-mode).
+  - The channel sets the request `Content-Type` to the event's
+    `datacontenttype` (falling back to `application/json`), so `data` may be
+    any content type (e.g. `application/protobuf`).
+  - Batch delivery in binary mode throws `NotSupportedException` (the HTTP
+    binding defines no binary batch).
+  - HMAC signing still covers the raw body bytes only; `IWebhookSignatureProvider`
+    is unchanged.
+
+- **WebHook abuse-protection discovery** ([CloudEvents HTTP WebHooks spec](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)):
+  - New `WebhookDiscoveryOptions` (`RequestOrigin`, `RequestCallback`,
+    `RequestRate`, `RequestTimeout`, `RequireSuccessfulHandshake`) on
+    `WebhookPublishOptions.Discovery`.
+  - New `WebhookHandshakeClient` (internal) — lazily issues the `OPTIONS`
+    pre-flight before the first delivery, caches the granted
+    `WebHook-Allowed-Origin` / `WebHook-Allowed-Rate` per endpoint, and gates
+    concurrent first deliveries to a single round-trip.
+  - `WebHook-Request-Origin` attached to every delivery POST after a
+    successful handshake (spec §2.1).
+  - New `WebhookDiscoveryPermission` (cached handshake result, queryable by
+    the host) and `WebhookHandshakeException` (strict-mode refusal/failure).
+  - Best-effort (`RequireSuccessfulHandshake = false`, default) logs refusal
+    and proceeds; strict (`true`) throws and suppresses the POST.
+  - The granted `WebHook-Allowed-Rate` is tagged on the publish `Activity`
+    but **not auto-enforced** — the host applies its own throttling policy.
+  - The publisher does **not** host the `WebHook-Request-Callback` endpoint;
+    it only advertises the URL for the receiver to call.
+
+- **`Retry-After` on 429** now honored — when a delivery returns
+  `429 Too Many Requests` with a `Retry-After` header (delta-seconds or
+  HTTP-date), the channel uses it as the next retry delay, overriding the
+  configured exponential backoff for that attempt (spec §2.2).
+
+### 🔒 Security
+
+- **Zero breaking change**: the legacy `"json"` default wire format is
+  preserved (regression-guarded); `Discovery` defaults to `null` (no
+  handshake, no `WebHook-Request-Origin` header). All signing, retry, and
+  subscriber-management behaviour is unchanged.
+
 ## v1.4.0 - Schema Governance & AsyncAPI Export
 
 ### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The framework is still evolving. See the [ROADMAP](ROADMAP.md) for the full desc
 
 ### v1.5 — New Transports
 
-- [ ] **CloudEvents HTTP Binding for the Webhook Publisher** — bring the existing Webhook publisher into full structured/binary content-mode compliance
+- [x] **CloudEvents HTTP Binding for the Webhook Publisher** — structured/binary content-mode compliance + WebHook abuse-protection discovery
 - [ ] **HTTP Publisher Channel** — lightweight, sign-free point-to-point delivery to statically-configured endpoints
 - [ ] **gRPC Publisher Channel** — low-latency service-to-service delivery using the CloudEvents gRPC protocol binding
 - [ ] **Apache Kafka Publisher Channel** — publish CloudEvents to Kafka topics with partition key control and Schema Registry support

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -269,6 +269,8 @@ The table below maps each roadmap item to the release milestone in which it is p
 
 ### 12. CloudEvents HTTP Binding Compliance for the Webhook Publisher
 
+> ✅ **Delivered in v1.5.0.** See [Webhook Channel](publishers/webhook.md) for usage.
+
 > *Bring the existing Webhook publisher into full CloudEvents HTTP binding specification compliance — structured and binary content modes, correct `Content-Type` and `ce-*` headers — without changing its delivery semantics.*
 
 **The problem today:** `Hermodr.Publisher.Webhook` delivers events over HTTP, but sends a raw JSON payload rather than a CloudEvents-structured or binary-mode message. Receivers that expect the canonical CloudEvents envelope — correct `Content-Type: application/cloudevents+json` header in structured mode, or `ce-*` attribute headers in binary mode — must perform custom remapping before they can process the payload.

--- a/docs/publishers/webhook.md
+++ b/docs/publishers/webhook.md
@@ -62,12 +62,13 @@ Delivery settings (nullable — `null` in a per-call override inherits the chann
 | `EndpointUrl` | `string?` | _(required)_ | URL of the webhook endpoint |
 | `SigningSecret` | `string?` | `null` | Shared secret for HMAC signing; no signature header is sent when omitted |
 | `SignatureAlgorithm` | `WebhookSignatureAlgorithm?` | `HmacSha256` | HMAC algorithm used to sign the body |
-| `MessageFormat` | `string?` | `"json"` | Serialisation format. Use `EventMessageFormat` constants (for built-ins: `"json"`, `"xml"`, `"cloudevents+json"`, `"cloudevents+xml"`) or a custom serializer format key |
+| `MessageFormat` | `string?` | `"json"` | Serialisation format. Use `EventMessageFormat` constants (for built-ins: `"json"`, `"xml"`, `"cloudevents+json"`, `"cloudevents+xml"`, `"cloudevents+binary"`) or a custom serializer format key |
 | `MaxRetryCount` | `int?` | `3` | Maximum delivery attempts; `0` disables retries |
 | `RetryDelay` | `TimeSpan?` | 1 s | Initial delay between retries |
 | `RetryBackoffMultiplier` | `double?` | `2.0` | Multiplier for exponential backoff |
 | `RequestTimeout` | `TimeSpan?` | 30 s | Timeout per individual HTTP request |
 | `AdditionalHeaders` | `IDictionary<string, string>` | `{}` | Extra HTTP headers merged into every request; per-call entries win on key collision |
+| `Discovery` | `WebhookDiscoveryOptions?` | `null` | CloudEvents WebHooks abuse-protection handshake (lazy `OPTIONS` pre-flight + `WebHook-Request-Origin` on every POST); see [WebHook discovery](#webhook-discovery-abuse-protection) below |
 
 Channel-structural settings (always taken from the channel-level defaults; ignored in per-call overrides):
 
@@ -157,6 +158,122 @@ Use `EventMessageFormat` constants when selecting a built-in format.
 | `"xml"` (`EventMessageFormat.Xml`) | `application/xml` | Plain XML payload |
 | `"cloudevents+json"` (`EventMessageFormat.CloudEventsJson`) | `application/cloudevents+json` | Full CloudEvents JSON envelope |
 | `"cloudevents+xml"` (`EventMessageFormat.CloudEventsXml`) | `application/cloudevents+xml` | Full CloudEvents XML envelope |
+| `"cloudevents+binary"` (`EventMessageFormat.CloudEventsBinary`) | event's `datacontenttype` (fallback `application/json`) | CloudEvents [binary HTTP content mode](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md#31-binary-content-mode) — `ce-*` attribute headers + data-only body; single-event only (batch throws `NotSupportedException`) |
+
+In binary content mode the channel maps every CloudEvent context attribute
+(including extensions) to a `ce-*` HTTP header, sets the request `Content-Type`
+to the event's `datacontenttype`, and sends the raw `data` as the body. This
+lets receivers compliant with the CloudEvents HTTP binding (Azure Event Grid,
+Knative Eventing, etc.) route on attributes without deserialising the body,
+and allows `data` to be any content type (e.g. `application/protobuf`).
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .AddWebhooks(options =>
+    {
+        options.EndpointUrl   = "https://partner.example.com/events";
+        options.MessageFormat = EventMessageFormat.CloudEventsBinary;
+    });
+```
+
+> **Batch + binary:** the CloudEvents HTTP binding defines no binary batch
+> mode; `PublishBatchAsync` throws `NotSupportedException` when the effective
+> format is `cloudevents+binary`. Use `cloudevents+json` for batched delivery.
+
+## WebHook discovery (abuse protection)
+
+When the delivery target supports and requires
+[CloudEvents HTTP WebHooks](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)
+abuse protection, the channel can perform an `OPTIONS` validation handshake
+before the first delivery and attach the `WebHook-Request-Origin` header to
+every subsequent POST.  Enable it by setting `WebhookPublishOptions.Discovery`
+to a `WebhookDiscoveryOptions` instance.
+
+### `WebhookDiscoveryOptions`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `RequestOrigin` | `string` | _(required)_ | DNS name identifying the sending system, sent as `WebHook-Request-Origin` on the `OPTIONS` request and on every delivery POST |
+| `RequestCallback` | `string?` | `null` | Optional HTTPS URL advertised via `WebHook-Request-Callback`; the receiver may call it asynchronously to grant permission. The channel does **not** host this endpoint. |
+| `RequestRate` | `int?` | `null` | Desired request rate (requests per minute), sent via `WebHook-Request-Rate`; the receiver may grant a different rate |
+| `RequestTimeout` | `TimeSpan?` | `null` | Timeout for the `OPTIONS` request; falls back to `RequestTimeout` (default 30 s) when `null` |
+| `RequireSuccessfulHandshake` | `bool` | `false` | `false` (best-effort): a refused or faulted handshake is logged and the delivery proceeds. `true` (strict): throws `WebhookHandshakeException` and suppresses the POST. |
+
+### How the handshake works
+
+1. Before the first delivery to an endpoint, the channel issues an `OPTIONS`
+   request carrying `WebHook-Request-Origin` (and, when set,
+   `WebHook-Request-Callback` / `WebHook-Request-Rate`).
+2. The target grants permission by returning `WebHook-Allowed-Origin`
+   (the origin name, or `*` for all origins) and optionally
+   `WebHook-Allowed-Rate` (an integer, or `*` for unlimited).  The granted
+   permission is cached per endpoint and reused for subsequent deliveries;
+   concurrent first deliveries share a single round-trip.
+3. After a successful handshake, `WebHook-Request-Origin` is attached to
+   every delivery POST, matching the value used in the handshake (spec §2.1).
+4. The granted `WebHook-Allowed-Rate` is tagged on the publish
+   [`Activity`](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity)
+   (`webhook.allowed_origin`, `webhook.allowed_rate`) and cached as a
+   `WebhookDiscoveryPermission`, but **not auto-enforced** — the host can
+   read it to apply its own throttling policy.
+
+### Best-effort vs. strict
+
+- `RequireSuccessfulHandshake = false` (default) — a refused handshake (no
+  `WebHook-Allowed-Origin`) or a faulted request is logged and the delivery
+  proceeds.  Use this when the target may not implement the handshake.
+- `RequireSuccessfulHandshake = true` — a refused or faulted handshake throws
+  `WebhookHandshakeException` (carrying the `EndpointUrl` and, when
+  applicable, the `StatusCode`) and the delivery POST is not sent.
+
+### `Retry-After` on 429
+
+When a delivery returns `429 Too Many Requests` with a
+[`Retry-After`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Retry-After)
+header (delta-seconds or HTTP-date), the channel uses it as the delay before
+the next retry attempt, overriding the configured exponential backoff for
+that attempt (spec §2.2).  An absent or unparseable `Retry-After` falls back
+to the normal backoff.
+
+### Configuration
+
+```csharp
+builder.Services
+    .AddEventPublisher()
+    .AddWebhooks(options =>
+    {
+        options.EndpointUrl   = "https://partner.example.com/events";
+        options.SigningSecret  = "s3cr3t";
+        options.Discovery = new WebhookDiscoveryOptions
+        {
+            RequestOrigin              = "eventemitter.example.com",
+            RequestRate                 = 120,
+            RequireSuccessfulHandshake = true
+        };
+    });
+```
+
+```json
+{
+  "Events": {
+    "Webhook": {
+      "EndpointUrl": "https://partner.example.com/events",
+      "SigningSecret": "s3cr3t",
+      "Discovery": {
+        "RequestOrigin": "eventemitter.example.com",
+        "RequestRate": 120,
+        "RequireSuccessfulHandshake": true
+      }
+    }
+  }
+}
+```
+
+> The publisher does **not** host the `WebHook-Request-Callback` endpoint:
+> it only advertises the callback URL so the receiver (or an administrator)
+> can grant permission out-of-band.  Hosting a callback receiver belongs to
+> the subscription-management layer.
 
 ## Per-delivery options
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -269,6 +269,8 @@ The table below maps each roadmap item to the release milestone in which it is p
 
 ### 12. CloudEvents HTTP Binding Compliance for the Webhook Publisher
 
+> ✅ **Delivered in v1.5.0.** See [Webhook Channel](publishers/webhook.md) for usage.
+
 > *Bring the existing Webhook publisher into full CloudEvents HTTP binding specification compliance — structured and binary content modes, correct `Content-Type` and `ce-*` headers — without changing its delivery semantics.*
 
 **The problem today:** `Hermodr.Publisher.Webhook` delivers events over HTTP, but sends a raw JSON payload rather than a CloudEvents-structured or binary-mode message. Receivers that expect the canonical CloudEvents envelope — correct `Content-Type: application/cloudevents+json` header in structured mode, or `ce-*` attribute headers in binary mode — must perform custom remapping before they can process the payload.

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -4,4 +4,16 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage" />
   </ItemGroup>
 
+  <!--
+    Security override: forces SQLitePCLRaw.lib.e_sqlite3 to 2.1.12 (bundles
+    SQLite >= 3.50.2, fixing CVE-2025-6965 / GHSA-2m69-gcr7-jv3q) for the sample
+    projects that pull in Microsoft.EntityFrameworkCore.Sqlite transitively via
+    SQLitePCLRaw.bundle_e_sqlite3 2.1.11. NuGet's nearest-wins rule overrides
+    the transitive pin. Remove once EF Sqlite ships a bundle that references
+    >= 2.1.12.
+  -->
+  <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
+  </ItemGroup>
+
 </Project>

--- a/src/Hermodr.Publisher.Webhook/CloudEventHttpHeadersMapper.cs
+++ b/src/Hermodr.Publisher.Webhook/CloudEventHttpHeadersMapper.cs
@@ -1,0 +1,91 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Collections.ObjectModel;
+
+using CloudNative.CloudEvents;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Maps the context attributes of a <see cref="CloudEvent"/> onto the
+    /// <c>ce-*</c> HTTP request headers mandated by the
+    /// <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md#321-binary-content-mode">CloudEvents HTTP binary content mode</see>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Per the HTTP binding specification, every CloudEvent context attribute
+    /// — required or extension — is serialized as a single HTTP header named
+    /// <c>ce-{attribute}</c>, using the ASCII-lowercased attribute name.
+    /// Required attributes (<c>specversion</c>, <c>id</c>, <c>type</c>,
+    /// <c>source</c>, <c>time</c>) and the commonly-populated
+    /// <c>datacontenttype</c> / <c>subject</c> are always emitted when set;
+    /// every other populated extension attribute is emitted with the same
+    /// <c>ce-</c> prefix.
+    /// </para>
+    /// <para>
+    /// This mapper is intentionally stateless and read-only with respect to
+    /// the <see cref="CloudEvent"/>; it produces only the header dictionary,
+    /// leaving the request body and <c>Content-Type</c> to the calling channel.
+    /// </para>
+    /// </remarks>
+    internal static class CloudEventHttpHeadersMapper
+    {
+        // The core attribute names that are always handled explicitly (so they
+        // can be skipped in the extension-attribute loop below).
+        private static readonly HashSet<string> CoreAttributes =
+            new(StringComparer.Ordinal)
+            {
+                "specversion", "id", "type", "source", "time",
+                "datacontenttype", "subject"
+            };
+
+        /// <summary>
+        /// Builds the <c>ce-*</c> HTTP header bag for <paramref name="event"/>.
+        /// </summary>
+        /// <param name="event">The event whose attributes are to be projected.</param>
+        /// <returns>
+        /// A read-only dictionary of <c>ce-{attribute}</c> header names to
+        /// their string representations. Attributes whose value is <c>null</c>
+        /// are omitted. Returns an empty dictionary when
+        /// <paramref name="event"/> has no populated attributes.
+        /// </returns>
+        public static IReadOnlyDictionary<string, string> Map(CloudEvent @event)
+        {
+            if (@event is null)
+                return ReadOnlyDictionary<string, string>.Empty;
+
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (@event.SpecVersion is not null)
+                headers["ce-specversion"] = @event.SpecVersion.VersionId;
+            if (@event.Id is not null)
+                headers["ce-id"] = @event.Id;
+            if (@event.Type is not null)
+                headers["ce-type"] = @event.Type;
+            if (@event.Source is not null)
+                headers["ce-source"] = @event.Source.ToString();
+            if (@event.Time.HasValue)
+                headers["ce-time"] = @event.Time.Value.ToString("O");
+            if (@event.DataContentType is not null)
+                headers["ce-datacontenttype"] = @event.DataContentType;
+            if (@event.Subject is not null)
+                headers["ce-subject"] = @event.Subject;
+
+            // Every remaining populated extension attribute becomes ce-{name}.
+            foreach (var (attr, value) in @event.GetPopulatedAttributes())
+            {
+                if (CoreAttributes.Contains(attr.Name))
+                    continue;
+                if (value is null)
+                    continue;
+
+                headers[$"ce-{attr.Name}"] = value.ToString() ?? string.Empty;
+            }
+
+            return headers;
+        }
+    }
+}

--- a/src/Hermodr.Publisher.Webhook/EventPublisherBuilderExtensions.cs
+++ b/src/Hermodr.Publisher.Webhook/EventPublisherBuilderExtensions.cs
@@ -40,6 +40,8 @@ namespace Hermodr
                 ServiceDescriptor.Singleton<IEventSerializer, CloudEventsJsonSerializer>());
             builder.Services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<IEventSerializer, CloudEventsXmlSerializer>());
+            builder.Services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IEventSerializer, CloudEventsBinarySerializer>());
 
             return builder;
         }

--- a/src/Hermodr.Publisher.Webhook/Hermodr.Publisher.Webhook.csproj
+++ b/src/Hermodr.Publisher.Webhook/Hermodr.Publisher.Webhook.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Title>Hermodr Webhook Publisher</Title>
-    <Description>Provides a publisher of CloudEvents through HTTP POST webhooks with signature verification, delivery tracking and retry support</Description>
+    <Description>Provides a publisher of CloudEvents through HTTP POST webhooks with HMAC signing, delivery tracking, retry support, CloudEvents binary HTTP content mode, and WebHook abuse-protection discovery.</Description>
     <PackageTags>event;events;ddd;publisher;webhook;http;cloudevents</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Hermodr.Publisher.Webhook/LoggerExtensions.cs
+++ b/src/Hermodr.Publisher.Webhook/LoggerExtensions.cs
@@ -112,5 +112,37 @@ namespace Hermodr
             this ILogger logger,
             string       deliveryId,
             int          totalAttempts);
+
+        // ── WebHook discovery handshake ────────────────────────────────────
+
+        /// <summary>Logs that the WebHook validation handshake was granted.</summary>
+        [LoggerMessage(
+            EventId  = 4009,
+            Level    = LogLevel.Information,
+            Message  = "WebHook handshake to {Url} granted (allowed-origin={AllowedOrigin}, allowed-rate={AllowedRate})")]
+        public static partial void LogHandshakeGranted(
+            this ILogger logger,
+            string       url,
+            string       allowedOrigin,
+            int?         allowedRate);
+
+        /// <summary>Logs that the WebHook validation handshake was refused by the target.</summary>
+        [LoggerMessage(
+            EventId  = 4010,
+            Level    = LogLevel.Warning,
+            Message  = "WebHook handshake to {Url} was refused: the target did not return WebHook-Allowed-Origin")]
+        public static partial void LogHandshakeRefused(
+            this ILogger logger,
+            string       url);
+
+        /// <summary>Logs that the WebHook validation request itself faulted.</summary>
+        [LoggerMessage(
+            EventId  = 4011,
+            Level    = LogLevel.Warning,
+            Message  = "WebHook handshake to {Url} failed: {ErrorMessage}")]
+        public static partial void LogHandshakeFailed(
+            this ILogger logger,
+            string       url,
+            string       errorMessage);
     }
 }

--- a/src/Hermodr.Publisher.Webhook/WebhookDiscoveryOptions.cs
+++ b/src/Hermodr.Publisher.Webhook/WebhookDiscoveryOptions.cs
@@ -1,0 +1,80 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Configures the
+    /// <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md">CloudEvents HTTP WebHooks</see>
+    /// abuse-protection handshake performed by the webhook publisher.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When attached to <see cref="WebhookPublishOptions.Discovery"/>, the channel
+    /// lazily issues an <c>OPTIONS</c> pre-flight validation request to the
+    /// endpoint before the first delivery, sending
+    /// <see cref="RequestOrigin"/> and (when set)
+    /// <see cref="RequestCallback"/> / <see cref="RequestRate"/>.
+    /// The receiver grants permission by returning
+    /// <c>WebHook-Allowed-Origin</c> and <c>WebHook-Allowed-Rate</c> headers;
+    /// the result is cached per endpoint and reused for subsequent deliveries.
+    /// </para>
+    /// <para>
+    /// After a successful handshake, <see cref="RequestOrigin"/> is attached
+    /// to every delivery POST as the <c>WebHook-Request-Origin</c> header,
+    /// as required by §2.1 of the WebHooks specification.
+    /// </para>
+    /// <para>
+    /// The channel does <b>not</b> host the
+    /// <c>WebHook-Request-Callback</c> endpoint: the callback URL is merely
+    /// advertised to the receiver (which may invoke it asynchronously to
+    /// grant permission), and is typically pointed at a separate receiver
+    /// /subscription service.
+    /// </para>
+    /// </remarks>
+    public class WebhookDiscoveryOptions
+    {
+        /// <summary>
+        /// The DNS name that identifies the sending system, sent as the
+        /// <c>WebHook-Request-Origin</c> header of the <c>OPTIONS</c>
+        /// validation request and of every subsequent delivery POST.
+        /// Required.
+        /// </summary>
+        public string RequestOrigin { get; set; } = string.Empty;
+
+        /// <summary>
+        /// An optional HTTPS URL advertised via the
+        /// <c>WebHook-Request-Callback</c> header, allowing the delivery
+        /// target to grant send permission asynchronously (e.g. via a browser
+        /// or out-of-band request). The channel does not host this endpoint.
+        /// </summary>
+        public string? RequestCallback { get; set; }
+
+        /// <summary>
+        /// An optional desired request rate (requests per minute) sent via the
+        /// <c>WebHook-Request-Rate</c> header. The receiver may grant a
+        /// different rate in <c>WebHook-Allowed-Rate</c>.
+        /// </summary>
+        public int? RequestRate { get; set; }
+
+        /// <summary>
+        /// The timeout for the <c>OPTIONS</c> validation request.
+        /// When <c>null</c> the channel uses the same timeout as delivery
+        /// requests (<see cref="WebhookPublishOptions.RequestTimeout"/>,
+        /// default 30 s).
+        /// </summary>
+        public TimeSpan? RequestTimeout { get; set; }
+
+        /// <summary>
+        /// When <c>true</c> the channel requires a successful validation
+        /// handshake before any delivery is attempted; a refused or failed
+        /// handshake causes <see cref="Hermodr.WebhookPublishChannel"/>
+        /// to throw a <see cref="WebhookHandshakeException"/> and the delivery
+        /// is not sent. When <c>false</c> (the default) a failed handshake
+        /// is logged but the delivery proceeds (best-effort compliance).
+        /// </summary>
+        public bool RequireSuccessfulHandshake { get; set; }
+    }
+}

--- a/src/Hermodr.Publisher.Webhook/WebhookDiscoveryPermission.cs
+++ b/src/Hermodr.Publisher.Webhook/WebhookDiscoveryPermission.cs
@@ -1,0 +1,59 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Hermodr
+{
+    /// <summary>
+    /// The result of a
+    /// <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md">CloudEvents HTTP WebHooks</see>
+    /// <c>OPTIONS</c> validation handshake — i.e. the permission granted by
+    /// the delivery target via the <c>WebHook-Allowed-Origin</c> and
+    /// <c>WebHook-Allowed-Rate</c> response headers.
+    /// </summary>
+    /// <remarks>
+    /// Instances are produced by the webhook channel's handshake client and
+    /// cached per endpoint so that subsequent deliveries reuse the granted
+    /// permission. The host can inspect the granted
+    /// <see cref="AllowedRate"/> to apply its own throttling policy; the
+    /// channel itself does not auto-throttle.
+    /// </remarks>
+    public sealed class WebhookDiscoveryPermission
+    {
+        /// <summary>
+        /// Creates a new permission record from a handshake response.
+        /// </summary>
+        /// <param name="allowedOrigin">
+        /// The value of the <c>WebHook-Allowed-Origin</c> header returned by
+        /// the target, or <c>"*"</c> indicating permission from all origins.
+        /// </param>
+        /// <param name="allowedRate">
+        /// The value of the <c>WebHook-Allowed-Rate</c> header returned by the
+        /// target, expressed as requests per minute, or <c>null</c> when the
+        /// target did not return the header (or returned <c>*</c>).
+        /// </param>
+        public WebhookDiscoveryPermission(string allowedOrigin, int? allowedRate)
+        {
+            AllowedOrigin = allowedOrigin ?? throw new ArgumentNullException(nameof(allowedOrigin));
+            AllowedRate = allowedRate;
+        }
+
+        /// <summary>
+        /// The origin the delivery target has agreed to receive notifications
+        /// from. May be <c>"*"</c> to indicate permission from all origins.
+        /// </summary>
+        public string AllowedOrigin { get; }
+
+        /// <summary>
+        /// The maximum request rate (requests per minute) granted by the
+        /// target, or <c>null</c> when the target did not constrain the rate.
+        /// </summary>
+        public int? AllowedRate { get; }
+
+        /// <summary>
+        /// The UTC time at which the handshake response was received.
+        /// </summary>
+        public DateTimeOffset GrantedAt { get; } = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/Hermodr.Publisher.Webhook/WebhookHandshakeClient.cs
+++ b/src/Hermodr.Publisher.Webhook/WebhookHandshakeClient.cs
@@ -1,0 +1,249 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Collections.Concurrent;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Performs the
+    /// <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md">CloudEvents HTTP WebHooks</see>
+    /// <c>OPTIONS</c> validation handshake against a delivery endpoint and
+    /// caches the granted permission so that subsequent deliveries reuse it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The client is stateful: a single instance per channel owns a
+    /// per-endpoint cache of <see cref="WebhookDiscoveryPermission"/>
+    /// records. The cache is keyed by the normalized endpoint URL so that
+    /// options-driven endpoint changes do not return stale permissions.
+    /// </para>
+    /// <para>
+    /// All public members are safe for concurrent use: the cache uses a
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/> and a single
+    /// sema­phore per endpoint gates the <c>OPTIONS</c> round-trip so that
+    /// concurrent first deliveries to the same endpoint produce exactly one
+    /// validation request.
+    /// </para>
+    /// </remarks>
+    internal sealed class WebhookHandshakeClient
+    {
+        // Header constants from the CloudEvents HTTP WebHooks spec.
+        internal const string RequestOriginHeader   = "WebHook-Request-Origin";
+        internal const string RequestCallbackHeader = "WebHook-Request-Callback";
+        internal const string RequestRateHeader     = "WebHook-Request-Rate";
+        internal const string AllowedOriginHeader   = "WebHook-Allowed-Origin";
+        internal const string AllowedRateHeader     = "WebHook-Allowed-Rate";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger _logger;
+
+        // Per-endpoint permission cache: endpoint URL → permission.
+        private readonly ConcurrentDictionary<string, WebhookDiscoveryPermission> _cache =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        // Per-endpoint in-flight handshake gates: ensures exactly one OPTIONS
+        // request per endpoint even under concurrent first deliveries.
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _gates =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Creates a new handshake client.
+        /// </summary>
+        /// <param name="httpClientFactory">
+        /// The <see cref="IHttpClientFactory"/> used to resolve the named
+        /// <see cref="HttpClient"/> for the <c>OPTIONS</c> request.
+        /// </param>
+        /// <param name="logger">An optional logger.</param>
+        public WebhookHandshakeClient(
+            IHttpClientFactory httpClientFactory,
+            ILogger? logger = null)
+        {
+            _httpClientFactory = httpClientFactory
+                ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _logger = logger ?? NullLogger<WebhookHandshakeClient>.Instance;
+        }
+
+        /// <summary>
+        /// Returns the cached permission for <paramref name="endpointUrl"/>,
+        /// or <c>null</c> when no successful handshake has been recorded.
+        /// </summary>
+        public WebhookDiscoveryPermission? GetCached(string endpointUrl)
+            => _cache.TryGetValue(Normalize(endpointUrl), out var p) ? p : null;
+
+        /// <summary>
+        /// Evicts the cached permission for <paramref name="endpointUrl"/>,
+        /// forcing the next delivery to re-handshake. Safe to call when no
+        /// permission is cached.
+        /// </summary>
+        public void Evict(string endpointUrl)
+            => _cache.TryRemove(Normalize(endpointUrl), out _);
+
+        /// <summary>
+        /// Performs the <c>OPTIONS</c> validation handshake against
+        /// <paramref name="endpointUrl"/> when no cached permission is
+        /// available, and returns the granted permission. A cached permission
+        /// is returned without issuing a request.
+        /// </summary>
+        /// <param name="endpointUrl">The exact delivery target URI to validate.</param>
+        /// <param name="options">The discovery configuration to apply.</param>
+        /// <param name="httpClientName">
+        /// The named <see cref="HttpClient"/> to use (typically
+        /// <see cref="WebhookDefaults.HttpClientName"/>).
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Token to cancel the handshake request.
+        /// </param>
+        /// <returns>
+        /// The granted <see cref="WebhookDiscoveryPermission"/> when the
+        /// target returns <c>WebHook-Allowed-Origin</c>; otherwise
+        /// <c>null</c> (the target did not grant permission).
+        /// </returns>
+        /// <exception cref="WebhookHandshakeException">
+        /// Thrown only when the caller requests a strict handshake
+        /// (<see cref="WebhookDiscoveryOptions.RequireSuccessfulHandshake"/>)
+        /// and the target refuses permission or the request faults.
+        /// </exception>
+        public async Task<WebhookDiscoveryPermission?> EnsureHandshakeAsync(
+            string endpointUrl,
+            WebhookDiscoveryOptions options,
+            string? httpClientName,
+            CancellationToken cancellationToken)
+        {
+            if (options is null)
+                throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrWhiteSpace(endpointUrl))
+                throw new ArgumentException("endpointUrl is required.", nameof(endpointUrl));
+
+            var key = Normalize(endpointUrl);
+
+            // Fast path: cached permission still valid.
+            if (_cache.TryGetValue(key, out var cached))
+                return cached;
+
+            // Gate per endpoint so concurrent first deliveries share one round-trip.
+            var gate = _gates.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+            await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // Re-check inside the gate: another caller may have completed it.
+                if (_cache.TryGetValue(key, out cached))
+                    return cached;
+
+                var permission = await SendOptionsAsync(endpointUrl, options, httpClientName, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (permission is not null)
+                {
+                    _cache[key] = permission;
+                    _logger.LogHandshakeGranted(endpointUrl, permission.AllowedOrigin, permission.AllowedRate);
+                }
+                else
+                {
+                    _logger.LogHandshakeRefused(endpointUrl);
+
+                    if (options.RequireSuccessfulHandshake)
+                    {
+                        throw new WebhookHandshakeException(
+                            $"Webhook validation handshake was refused by '{endpointUrl}': " +
+                            "the target did not return WebHook-Allowed-Origin.",
+                            endpointUrl);
+                    }
+                }
+
+                return permission;
+            }
+            catch (WebhookHandshakeException)
+            {
+                // Strict-mode refusal already logged above; rethrow.
+                throw;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogHandshakeFailed(endpointUrl, ex.Message);
+
+                if (options.RequireSuccessfulHandshake)
+                {
+                    throw new WebhookHandshakeException(
+                        $"Webhook validation handshake to '{endpointUrl}' failed: {ex.Message}",
+                        endpointUrl, innerException: ex);
+                }
+
+                return null;
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+
+        private async Task<WebhookDiscoveryPermission?> SendOptionsAsync(
+            string endpointUrl,
+            WebhookDiscoveryOptions options,
+            string? httpClientName,
+            CancellationToken cancellationToken)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Options, endpointUrl);
+
+            // Mandatory: WebHook-Request-Origin.
+            request.Headers.TryAddWithoutValidation(RequestOriginHeader, options.RequestOrigin);
+
+            // Optional: WebHook-Request-Callback (URL advertised for async grant).
+            if (!string.IsNullOrWhiteSpace(options.RequestCallback))
+                request.Headers.TryAddWithoutValidation(RequestCallbackHeader, options.RequestCallback);
+
+            // Optional: WebHook-Request-Rate (requests per minute).
+            if (options.RequestRate is int rate && rate > 0)
+                request.Headers.TryAddWithoutValidation(RequestRateHeader, rate.ToString());
+
+            var client = _httpClientFactory.CreateClient(
+                string.IsNullOrEmpty(httpClientName) ? WebhookDefaults.HttpClientName : httpClientName!);
+
+            var timeout = options.RequestTimeout ?? TimeSpan.FromSeconds(30);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(timeout);
+
+            using var response = await client.SendAsync(request, cts.Token).ConfigureAwait(false);
+
+            // The spec says the handshake cannot rely on status codes alone:
+            // a target that does not handle OPTIONS returns 405, while a target
+            // that does handle it but refuses may still return 200 without the
+            // allowed-origin header. We therefore only consult the headers.
+            var hasAllowedOrigin =
+                response.Headers.TryGetValues(AllowedOriginHeader, out var originValues);
+
+            if (!hasAllowedOrigin)
+                return null;
+
+            var allowedOrigin = originValues!.FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(allowedOrigin))
+                return null;
+
+            int? allowedRate = null;
+            if (response.Headers.TryGetValues(AllowedRateHeader, out var rateValues))
+            {
+                var rateStr = rateValues.FirstOrDefault();
+                if (rateStr is not null && rateStr.Trim() != "*")
+                {
+                    rateStr = rateStr.Trim();
+                    if (int.TryParse(rateStr, out var parsed) && parsed > 0)
+                        allowedRate = parsed;
+                }
+            }
+
+            return new WebhookDiscoveryPermission(allowedOrigin!, allowedRate);
+        }
+
+        private static string Normalize(string endpointUrl)
+            => endpointUrl.Trim();
+    }
+}

--- a/src/Hermodr.Publisher.Webhook/WebhookHandshakeException.cs
+++ b/src/Hermodr.Publisher.Webhook/WebhookHandshakeException.cs
@@ -1,0 +1,54 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Thrown when the
+    /// <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md">CloudEvents HTTP WebHooks</see>
+    /// <c>OPTIONS</c> validation handshake fails and
+    /// <see cref="WebhookDiscoveryOptions.RequireSuccessfulHandshake"/> is set.
+    /// </summary>
+    /// <remarks>
+    /// A handshake is considered failed when the target explicitly refuses
+    /// permission (does not return <c>WebHook-Allowed-Origin</c>), responds
+    /// with a non-success status code, or the request itself faults.
+    /// When <see cref="WebhookDiscoveryOptions.RequireSuccessfulHandshake"/>
+    /// is <c>false</c> the channel logs the failure and proceeds with the
+    /// delivery instead of throwing.
+    /// </remarks>
+    public class WebhookHandshakeException : Exception
+    {
+        /// <summary>
+        /// Creates a new handshake exception.
+        /// </summary>
+        /// <param name="message">The reason the handshake failed.</param>
+        /// <param name="endpointUrl">The endpoint that was being validated.</param>
+        /// <param name="statusCode">
+        /// The HTTP status code returned by the target, when applicable.
+        /// </param>
+        /// <param name="innerException">
+        /// The underlying exception, when the handshake request itself faulted.
+        /// </param>
+        public WebhookHandshakeException(
+            string message,
+            string endpointUrl,
+            int? statusCode = null,
+            Exception? innerException = null)
+            : base(message, innerException)
+        {
+            EndpointUrl = endpointUrl;
+            StatusCode = statusCode;
+        }
+
+        /// <summary>The endpoint that was being validated.</summary>
+        public string EndpointUrl { get; }
+
+        /// <summary>
+        /// The HTTP status code returned by the target, when applicable.
+        /// </summary>
+        public int? StatusCode { get; }
+    }
+}

--- a/src/Hermodr.Publisher.Webhook/WebhookPublishChannel.cs
+++ b/src/Hermodr.Publisher.Webhook/WebhookPublishChannel.cs
@@ -53,6 +53,8 @@ namespace Hermodr
         private readonly IEventSystemTime _systemTime;
         private readonly ILogger _logger;
 
+        private readonly WebhookHandshakeClient _handshakeClient;
+
         private IDictionary<WebhookSignatureAlgorithm, IWebhookSignatureProvider>? _signatureProviders;
         private IDictionary<string, IEventSerializer>? _serializers;
 
@@ -83,6 +85,10 @@ namespace Hermodr
             _httpClientFactory = httpClientFactory;
             _systemTime        = EventSystemTime.Instance;
             _logger            = logger ?? NullLogger<WebhookPublishChannel>.Instance;
+
+            // The WebHook discovery handshake client is owned by the channel so
+            // that the per-endpoint permission cache persists across deliveries.
+            _handshakeClient = new WebhookHandshakeClient(httpClientFactory, logger);
 
             // Build the default pipeline lazily from the channel-level options.
             // LazyThreadSafetyMode.ExecutionAndPublication guarantees exactly-once
@@ -131,10 +137,11 @@ namespace Hermodr
                 {
                     var serializers = new Dictionary<string, IEventSerializer>(StringComparer.OrdinalIgnoreCase)
                     {
-                        [EventMessageFormat.Json]            = JsonEventSerializer.Default,
-                        [EventMessageFormat.Xml]             = XmlEventSerializer.Default,
-                        [EventMessageFormat.CloudEventsJson] = CloudEventsJsonSerializer.Default,
-                        [EventMessageFormat.CloudEventsXml]  = CloudEventsXmlSerializer.Default,
+                        [EventMessageFormat.Json]              = JsonEventSerializer.Default,
+                        [EventMessageFormat.Xml]               = XmlEventSerializer.Default,
+                        [EventMessageFormat.CloudEventsJson]   = CloudEventsJsonSerializer.Default,
+                        [EventMessageFormat.CloudEventsXml]    = CloudEventsXmlSerializer.Default,
+                        [EventMessageFormat.CloudEventsBinary] = CloudEventsBinarySerializer.Default,
                     };
                     foreach (var s in ServiceProvider.GetServices<IEventSerializer>())
                         serializers[s.Format] = s;
@@ -179,6 +186,7 @@ namespace Hermodr
                 SignatureAlgorithm     = perCallOptions.SignatureAlgorithm     ?? defaults.SignatureAlgorithm,
                 AdditionalHeaders      = mergedHeaders,
                 ScheduleDeliveryAt     = perCallOptions.ScheduleDeliveryAt     ?? defaults.ScheduleDeliveryAt,
+                Discovery              = perCallOptions.Discovery              ?? defaults.Discovery,
                 SignatureHeaderName          = defaults.SignatureHeaderName,
                 DeliveryIdHeaderName         = defaults.DeliveryIdHeaderName,
                 EventTypeHeaderName          = defaults.EventTypeHeaderName,
@@ -198,9 +206,24 @@ namespace Hermodr
             var format     = options.MessageFormat ?? EventMessageFormat.Json;
             var serializer = GetSerializer(format);
             var payload    = serializer.Serialize(@event);
+
+            // Binary content mode: the body is the raw data and the Content-Type
+            // is the event's datacontenttype; the CloudEvent attributes are
+            // projected onto ce-* HTTP headers by CloudEventHttpHeadersMapper.
+            IReadOnlyDictionary<string, string>? ceHeaders = null;
             var contentType = serializer.ContentType;
 
-            return DeliverAsync(payload, contentType, eventType: @event.Type, eventCount: 1, @event.Time, options, cancellationToken);
+            if (string.Equals(format, EventMessageFormat.CloudEventsBinary,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                contentType = !string.IsNullOrWhiteSpace(@event.DataContentType)
+                    ? @event.DataContentType!
+                    : serializer.ContentType;
+                ceHeaders = CloudEventHttpHeadersMapper.Map(@event);
+            }
+
+            return DeliverAsync(payload, contentType, eventType: @event.Type, eventCount: 1,
+                @event.Time, options, cancellationToken, ceHeaders);
         }
 
         // ── IBatchEventPublishChannel ────────────────
@@ -224,12 +247,23 @@ namespace Hermodr
             var effective = MergeOptions(DefaultOptions, options);
             ValidateOptions(effective);
 
-            var format      = effective.MessageFormat ?? EventMessageFormat.Json;
+            var format = effective.MessageFormat ?? EventMessageFormat.Json;
+
+            // Binary content mode is defined by the CloudEvents HTTP binding
+            // specification only for single-event delivery.
+            if (string.Equals(format, EventMessageFormat.CloudEventsBinary,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new NotSupportedException(
+                    "Binary content mode is not defined for batches by the CloudEvents HTTP binding specification.");
+            }
+
             var serializer  = GetSerializer(format);
             var payload     = serializer.SerializeBatch(events);
             var contentType = serializer.BatchContentType;
 
-            return DeliverAsync(payload, contentType, eventType: null, eventCount: events.Count, eventTime: null, effective, cancellationToken);
+            return DeliverAsync(payload, contentType, eventType: null, eventCount: events.Count,
+                eventTime: null, effective, cancellationToken, ceHeaders: null);
         }
 
         // ── Core delivery ───────────────────────────────────────────────────
@@ -241,7 +275,8 @@ namespace Hermodr
             int eventCount,
             DateTimeOffset? eventTime,
             WebhookPublishOptions options,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            IReadOnlyDictionary<string, string>? ceHeaders = null)
         {
             var endpointUrl            = options.EndpointUrl!;
 
@@ -260,6 +295,30 @@ namespace Hermodr
             var provider   = GetSignatureProvider(signatureAlgorithm);
             var timestamp  = (eventTime ?? SystemTime.UtcNow).ToUnixTimeSeconds();
             var algorithm  = signatureAlgorithm.ToString();
+
+            // ── CloudEvents HTTP WebHooks abuse-protection handshake ──────────
+            // When Discovery is configured, lazily perform the OPTIONS pre-flight
+            // validation request (cached per endpoint) and capture the granted
+            // permission for telemetry/metadata. The WebHook-Request-Origin
+            // header is then attached to every delivery POST per §2.1.
+            WebhookDiscoveryPermission? permission = null;
+            string? webHookRequestOrigin = null;
+
+            if (options.Discovery is WebhookDiscoveryOptions discovery)
+            {
+                permission = await _handshakeClient.EnsureHandshakeAsync(
+                    endpointUrl, discovery, httpClientName, cancellationToken)
+                    .ConfigureAwait(false);
+
+                webHookRequestOrigin = discovery.RequestOrigin;
+
+                if (permission is not null)
+                {
+                    activity?.SetTag("webhook.allowed_origin", permission.AllowedOrigin);
+                    if (permission.AllowedRate is int ar)
+                        activity?.SetTag("webhook.allowed_rate", ar);
+                }
+            }
 
             if (eventType != null)
                 _logger.LogDeliveringEvent(eventType, deliveryId, format, algorithm, endpointUrl);
@@ -291,7 +350,8 @@ namespace Hermodr
                 {
                     using var request = BuildRequest(
                         payload, contentType, eventType, deliveryId, timestamp, provider,
-                        endpointUrl, options.SigningSecret, additionalHeaders, options);
+                        endpointUrl, options.SigningSecret, additionalHeaders, options,
+                        ceHeaders, webHookRequestOrigin);
                     using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.CancellationToken);
                     cts.CancelAfter(requestTimeout);
                     return await CreateHttpClient(httpClientName).SendAsync(request, cts.Token);
@@ -349,10 +409,22 @@ namespace Hermodr
                 {
                     MaxRetryAttempts = maxRetryCount,
                     UseJitter        = false,
-                    DelayGenerator   = args => ValueTask.FromResult<TimeSpan?>(
-                        TimeSpan.FromMilliseconds(
+                    // Per the CloudEvents HTTP WebHooks spec §2.2, a 429 response
+                    // with Retry-After MUST be honored. When the response carries
+                    // a Retry-After header (delta-seconds or HTTP-date) we use it
+                    // as the next retry delay; otherwise we fall back to the
+                    // configured exponential backoff.
+                    DelayGenerator = args =>
+                    {
+                        var retryAfter = TryGetRetryAfterDelay(args.Outcome.Result);
+                        if (retryAfter is TimeSpan ra)
+                            return ValueTask.FromResult<TimeSpan?>(ra);
+
+                        var backoff = TimeSpan.FromMilliseconds(
                             retryDelay.TotalMilliseconds *
-                            Math.Pow(retryBackoffMultiplier, args.AttemptNumber))),
+                            Math.Pow(retryBackoffMultiplier, args.AttemptNumber));
+                        return ValueTask.FromResult<TimeSpan?>(backoff);
+                    },
                     // External cancellation is handled by Polly respecting the
                     // CancellationToken in the ResilienceContext; only transport
                     // errors and server-side transient failures are retried here.
@@ -412,6 +484,40 @@ namespace Hermodr
             => _httpClientFactory.CreateClient(
                 string.IsNullOrEmpty(name) ? WebhookDefaults.HttpClientName : name);
 
+        /// <summary>
+        /// Parses the <c>Retry-After</c> response header (RFC 7231 §7.1.3) into
+        /// a delay. Supports both delta-seconds and HTTP-date forms. Returns
+        /// <c>null</c> when the header is absent or unparseable.
+        /// </summary>
+        private static TimeSpan? TryGetRetryAfterDelay(HttpResponseMessage? response)
+        {
+            if (response is null)
+                return null;
+
+            if (!response.Headers.TryGetValues("Retry-After", out var values))
+                return null;
+
+            var raw = values.FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(raw))
+                return null;
+
+            raw = raw.Trim();
+
+            // Form 1: delta-seconds (non-negative integer).
+            if (int.TryParse(raw, out var seconds) && seconds >= 0)
+                return TimeSpan.FromSeconds(Math.Min(seconds, 3600));
+
+            // Form 2: HTTP-date.
+            if (DateTimeOffset.TryParseExact(raw, "R", System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AssumeUniversal, out var date))
+            {
+                var delta = date - DateTimeOffset.UtcNow;
+                return delta > TimeSpan.Zero ? delta : TimeSpan.Zero;
+            }
+
+            return null;
+        }
+
         private HttpRequestMessage BuildRequest(
             byte[] payload,
             string contentType,
@@ -422,11 +528,30 @@ namespace Hermodr
             string endpointUrl,
             string? signingSecret,
             IDictionary<string, string> additionalHeaders,
-            WebhookPublishOptions options)
+            WebhookPublishOptions options,
+            IReadOnlyDictionary<string, string>? cloudEventHeaders = null,
+            string? webHookRequestOrigin = null)
         {
             var request = new HttpRequestMessage(HttpMethod.Post, endpointUrl);
             request.Content = new ByteArrayContent(payload);
             request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
+
+            // CloudEvents binary content mode: ce-* attribute headers are emitted
+            // first so that explicit X-Webhook-* headers and AdditionalHeaders can
+            // still override them on key collision (the spec mandates ce-* names,
+            // but the channel preserves the existing webhook header semantics).
+            if (cloudEventHeaders is not null)
+            {
+                foreach (var h in cloudEventHeaders)
+                    request.Headers.TryAddWithoutValidation(h.Key, h.Value);
+            }
+
+            // CloudEvents HTTP WebHooks §2.1: when the target requires abuse
+            // protection, every delivery POST carries WebHook-Request-Origin
+            // (with the value matching the one used in the OPTIONS handshake).
+            if (!string.IsNullOrWhiteSpace(webHookRequestOrigin))
+                request.Headers.TryAddWithoutValidation(
+                    WebhookHandshakeClient.RequestOriginHeader, webHookRequestOrigin);
 
             request.Headers.TryAddWithoutValidation(options.DeliveryIdHeaderName, deliveryId);
 

--- a/src/Hermodr.Publisher.Webhook/WebhookPublishOptions.cs
+++ b/src/Hermodr.Publisher.Webhook/WebhookPublishOptions.cs
@@ -55,6 +55,7 @@ namespace Hermodr
                 SignatureAlgorithm     = typedOptions.SignatureAlgorithm     ?? baseOptions.SignatureAlgorithm,
                 ScheduleDeliveryAt     = typedOptions.ScheduleDeliveryAt     ?? baseOptions.ScheduleDeliveryAt,
                 AdditionalHeaders      = mergedHeaders,
+                Discovery              = typedOptions.Discovery              ?? baseOptions.Discovery,
                 // Channel-structural — always from base
                 SignatureHeaderName         = baseOptions.SignatureHeaderName,
                 DeliveryIdHeaderName        = baseOptions.DeliveryIdHeaderName,
@@ -133,6 +134,24 @@ namespace Hermodr
         /// </summary>
         public IDictionary<string, string> AdditionalHeaders { get; set; }
             = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Optional
+        /// <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md">CloudEvents HTTP WebHooks</see>
+        /// abuse-protection discovery settings. When <c>null</c> (the default) no
+        /// validation handshake is performed and no
+        /// <c>WebHook-Request-Origin</c> header is attached to delivery requests.
+        /// </summary>
+        /// <remarks>
+        /// When set, the channel lazily issues an <c>OPTIONS</c> pre-flight
+        /// validation request to the endpoint before the first delivery (and
+        /// re-validates after a cached permission is evicted), and attaches
+        /// <c>WebHook-Request-Origin</c> to every delivery POST. The granted
+        /// <c>WebHook-Allowed-Rate</c> is logged and tagged on the publish
+        /// activity but not auto-enforced; the host can read it from the
+        /// <see cref="WebhookDiscoveryPermission"/> exposed by the channel.
+        /// </remarks>
+        public WebhookDiscoveryOptions? Discovery { get; set; }
 
         // ── Channel-structural settings — not overrideable per call ──────────
         // These are always taken from the channel-level defaults during the merge;

--- a/src/Hermodr.Publisher/CloudEventsBinarySerializer.cs
+++ b/src/Hermodr.Publisher/CloudEventsBinarySerializer.cs
@@ -1,0 +1,78 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using CloudNative.CloudEvents;
+using CloudNative.CloudEvents.SystemTextJson;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Serializes a <see cref="CloudEvent"/> into the body portion of a
+    /// <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md#321-binary-content-mode">CloudEvents binary HTTP content mode</see>
+    /// message — i.e. the raw <c>data</c> payload only.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This serializer is responsible solely for the request <b>body</b> in
+    /// binary content mode. The accompanying <c>ce-*</c> HTTP headers and the
+    /// per-event <c>Content-Type</c> (derived from <see cref="CloudEvent.DataContentType"/>)
+    /// are emitted by the webhook channel via the
+    /// <c>CloudEventHttpHeadersMapper</c> and the per-event content-type override,
+    /// since the <see cref="IEventSerializer"/> interface can only describe a
+    /// single static content type.
+    /// </para>
+    /// <para>
+    /// The <see cref="ContentType"/> and <see cref="BatchContentType"/> values
+    /// are fallback defaults used only when the event carries no
+    /// <see cref="CloudEvent.DataContentType"/>; the channel is expected to
+    /// substitute the event's <c>datacontenttype</c> when present.
+    /// </para>
+    /// <para>
+    /// Batch serialization is not supported — the CloudEvents HTTP binding
+    /// specification defines no binary batch mode — and
+    /// <see cref="SerializeBatch"/> throws <see cref="NotSupportedException"/>.
+    /// </para>
+    /// </remarks>
+    public class CloudEventsBinarySerializer : IEventSerializer
+    {
+        private static readonly JsonEventFormatter Formatter = new();
+
+        /// <summary>A shared singleton instance.</summary>
+        public static readonly CloudEventsBinarySerializer Default = new();
+
+        /// <inheritdoc/>
+        public string Format => EventMessageFormat.CloudEventsBinary;
+
+        /// <summary>
+        /// The fallback content type used when an event does not carry a
+        /// <see cref="CloudEvent.DataContentType"/>. The channel overrides this
+        /// with the event's <c>datacontenttype</c> when present.
+        /// </summary>
+        public string ContentType => "application/json; charset=utf-8";
+
+        /// <summary>
+        /// Binary content mode is not defined for batches; this value is unused.
+        /// </summary>
+        public string BatchContentType => "application/json; charset=utf-8";
+
+        /// <inheritdoc/>
+        /// <returns>
+        /// The raw <c>data</c> bytes of <paramref name="event"/> as produced by
+        /// <see cref="JsonEventFormatter.EncodeBinaryModeEventData"/>. Returns an
+        /// empty byte array when the event has no <c>data</c>.
+        /// </returns>
+        public byte[] Serialize(CloudEvent @event)
+            => Formatter.EncodeBinaryModeEventData(@event).ToArray();
+
+        /// <inheritdoc/>
+        /// <exception cref="NotSupportedException">
+        /// Always thrown — the CloudEvents HTTP binding specification defines
+        /// no binary content mode for batches.
+        /// </exception>
+        public byte[] SerializeBatch(IReadOnlyList<CloudEvent> events)
+            => throw new NotSupportedException(
+                "Binary content mode is not defined for batches by the CloudEvents HTTP binding specification.");
+    }
+}

--- a/src/Hermodr.Publisher/EventMessageFormat.cs
+++ b/src/Hermodr.Publisher/EventMessageFormat.cs
@@ -43,6 +43,19 @@ namespace Hermodr
         /// (<c>application/cloudevents+xml</c>).
         /// </summary>
         public const string CloudEventsXml = "cloudevents+xml";
+
+        /// <summary>
+        /// CloudEvents binary HTTP content mode
+        /// (<see href="https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md#321-binary-content-mode">HTTP binding §3.2.1</see>).
+        /// The event context attributes are emitted as <c>ce-*</c> HTTP headers and
+        /// the <c>data</c> field alone forms the request body, transmitted with the
+        /// native <c>datacontenttype</c> as <c>Content-Type</c>.
+        /// <para>
+        /// Binary content mode is defined only for single-event delivery; the
+        /// CloudEvents HTTP binding specification has no binary batch mode.
+        /// </para>
+        /// </summary>
+        public const string CloudEventsBinary = "cloudevents+binary";
     }
 }
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -48,6 +48,15 @@
     <!-- Microsoft.Extensions packages – version-aligned with the target framework -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
+    <!--
+      Security override: forces SQLitePCLRaw.lib.e_sqlite3 to 2.1.12 (bundles
+      SQLite >= 3.50.2, fixing CVE-2025-6965 / GHSA-2m69-gcr7-jv3q) for the test
+      projects that pull in Microsoft.EntityFrameworkCore.Sqlite transitively
+      via SQLitePCLRaw.bundle_e_sqlite3 2.1.11. NuGet's nearest-wins rule
+      overrides the transitive pin. Remove once EF Sqlite ships a bundle that
+      references >= 2.1.12.
+    -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 
   <!-- MTP properties for test projects -->

--- a/test/Hermodr.Publisher.Webhook.XUnit/Unit/WebhookBinaryContentModeTests.cs
+++ b/test/Hermodr.Publisher.Webhook.XUnit/Unit/WebhookBinaryContentModeTests.cs
@@ -1,0 +1,413 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+using CloudNative.CloudEvents;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hermodr
+{
+    public class WebhookBinaryContentModeTests
+    {
+        private static readonly DateTimeOffset FixedNow =
+            new(2026, 01, 15, 12, 00, 00, TimeSpan.Zero);
+
+        private const string SigningSecret = "test-secret";
+        private const string EndpointUrl = "https://webhook.example.com/receive";
+
+        private static CloudEvent MakeEvent(
+            string type = "person.created",
+            string? dataContentType = "application/json",
+            string? data = """{"name":"John Doe"}""",
+            string? subject = null) => new(CloudEventsSpecVersion.V1_0)
+        {
+            Type = type,
+            Source = new Uri("https://api.example.com/svc"),
+            Id = Guid.NewGuid().ToString("N"),
+            DataContentType = dataContentType,
+            Data = data,
+            Time = FixedNow,
+            Subject = subject
+        };
+
+        private static IBatchEventPublishChannel BuildChannel(
+            HttpMessageHandler handler,
+            Action<WebhookPublishOptions>? configure = null)
+        {
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseSystemTime<MutableSystemTime>()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = EndpointUrl;
+                    o.SigningSecret = SigningSecret;
+                    o.MaxRetryCount = 1;
+                    o.RetryDelay = TimeSpan.FromMilliseconds(10);
+                    o.MessageFormat = EventMessageFormat.CloudEventsBinary;
+                    o.SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha256;
+                    configure?.Invoke(o);
+                });
+
+            MutableSystemTime.UtcNowValue = FixedNow;
+
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => handler);
+
+            return services.BuildServiceProvider()
+                .GetRequiredService<IBatchEventPublishChannel>();
+        }
+
+        // --- ce-* header emission ------------------------------------------------
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_EmitsCeHeaders()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                return OK();
+            });
+
+            var evt = MakeEvent("user.signed.up");
+            await BuildChannel(handler).PublishAsync(evt, cancellationToken: cancellationToken);
+
+            Assert.NotNull(captured);
+            var headers = captured!.Headers;
+
+            Assert.Equal("1.0", headers.GetValues("ce-specversion").First());
+            Assert.Equal(evt.Id, headers.GetValues("ce-id").First());
+            Assert.Equal("user.signed.up", headers.GetValues("ce-type").First());
+            Assert.Equal("https://api.example.com/svc", headers.GetValues("ce-source").First());
+            Assert.Equal(FixedNow.ToString("O"), headers.GetValues("ce-time").First());
+            Assert.Equal("application/json", headers.GetValues("ce-datacontenttype").First());
+        }
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_EmitsSubjectHeaderWhenPresent()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                return OK();
+            });
+
+            await BuildChannel(handler)
+                .PublishAsync(MakeEvent(subject: "usr-123"), cancellationToken: cancellationToken);
+
+            Assert.Equal("usr-123", captured!.Headers.GetValues("ce-subject").First());
+        }
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_OmitsSubjectHeaderWhenAbsent()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                return OK();
+            });
+
+            await BuildChannel(handler).PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+
+            Assert.False(captured!.Headers.Contains("ce-subject"));
+        }
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_ExtensionAttributesMappedToCeHeaders()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                return OK();
+            });
+
+            var evt = MakeEvent();
+            evt["traceparent"] = "00-abc-def-01";
+            evt["dataschema"] = new Uri("https://schemas.example.com/person");
+
+            await BuildChannel(handler).PublishAsync(evt, cancellationToken: cancellationToken);
+
+            Assert.Equal("00-abc-def-01", captured!.Headers.GetValues("ce-traceparent").First());
+            Assert.Equal("https://schemas.example.com/person",
+                captured.Headers.GetValues("ce-dataschema").First());
+        }
+
+        // --- Content-Type / body -------------------------------------------------
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_ContentTypeIsDataContentType()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                return OK();
+            });
+
+            await BuildChannel(handler).PublishAsync(
+                MakeEvent(dataContentType: "application/vnd.custom+json"),
+                cancellationToken: cancellationToken);
+
+            Assert.Equal("application/vnd.custom+json",
+                captured!.Content!.Headers.ContentType!.MediaType);
+        }
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_DataContentTypeNull_FallsBackToJson()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                return OK();
+            });
+
+            await BuildChannel(handler).PublishAsync(
+                MakeEvent(dataContentType: null),
+                cancellationToken: cancellationToken);
+
+            Assert.Equal("application/json",
+                captured!.Content!.Headers.ContentType!.MediaType);
+        }
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_BodyIsDataOnly_NotEnvelope()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            byte[]? bytes = null;
+            var handler = new FakeHandler(req =>
+            {
+                bytes = req.Content!.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+                return OK();
+            });
+
+            var data = """{"name":"John Doe"}""";
+            await BuildChannel(handler).PublishAsync(MakeEvent(data: data), cancellationToken: cancellationToken);
+
+            Assert.NotNull(bytes);
+            var body = Encoding.UTF8.GetString(bytes!);
+
+            // The CloudEvents SDK serializes a string-typed Data value as a JSON
+            // string token (the spec's binary-mode data encoding for
+            // application/json data): the body is a quoted JSON string whose
+            // value is the original data. Parse and assert the round-trip.
+            using var doc = JsonDocument.Parse(body);
+            Assert.Equal(JsonValueKind.String, doc.RootElement.ValueKind);
+            Assert.Equal(data, doc.RootElement.GetString());
+
+            // The body must not embed the CloudEvents structured envelope: a
+            // structured envelope would be a JSON object with a "specversion"
+            // property. The binary-mode body here is a JSON string, never an
+            // object — so specversion cannot be present.
+            Assert.False(doc.RootElement.ValueKind == JsonValueKind.Object &&
+                         doc.RootElement.TryGetProperty("specversion", out _),
+                "Binary-mode body must not embed the CloudEvents envelope.");
+        }
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_NullData_ProducesEmptyBody()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            byte[]? bytes = null;
+            var handler = new FakeHandler(req =>
+            {
+                bytes = req.Content!.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+                return OK();
+            });
+
+            await BuildChannel(handler).PublishAsync(
+                MakeEvent(data: null, dataContentType: null),
+                cancellationToken: cancellationToken);
+
+            Assert.NotNull(bytes);
+            Assert.Empty(bytes!);
+        }
+
+        // --- Signing semantics ---------------------------------------------------
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_SignatureOverBodyBytes()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            byte[]? capturedBody = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                capturedBody = req.Content!.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+                return OK();
+            });
+
+            await BuildChannel(handler).PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+
+            Assert.NotNull(captured);
+            Assert.NotNull(capturedBody);
+
+            var sigHeader = captured!.Headers.GetValues(WebhookDefaults.SignatureHeaderName).First();
+            Assert.StartsWith("sha256=", sigHeader);
+
+            // Recompute HMAC over "{timestamp}.{body}" using the same scheme as
+            // HmacWebhookSignatureProvider and compare.
+            var timestamp = FixedNow.ToUnixTimeSeconds();
+            var message = Encoding.UTF8.GetBytes($"{timestamp}.")
+                .Concat(capturedBody!).ToArray();
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(SigningSecret));
+            var expected = "sha256=" +
+                Convert.ToHexString(hmac.ComputeHash(message)).ToLowerInvariant();
+
+            Assert.Equal(expected, sigHeader);
+        }
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_LegacyHeadersStillPresent()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                return OK();
+            });
+
+            await BuildChannel(handler).PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+
+            Assert.True(captured!.Headers.Contains(WebhookDefaults.DeliveryIdHeaderName));
+            Assert.True(captured.Headers.Contains(WebhookDefaults.TimestampHeaderName));
+            Assert.True(captured.Headers.Contains(WebhookDefaults.SignatureAlgorithmHeaderName));
+            Assert.Equal("person.created",
+                captured.Headers.GetValues(WebhookDefaults.EventTypeHeaderName).First());
+        }
+
+        // --- Batch ----------------------------------------------------------------
+
+        [Fact]
+        public async Task PublishBatchAsync_BinaryMode_Throws()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = new FakeHandler(_ => OK());
+
+            var channel = BuildChannel(handler);
+            var batch = new[] { MakeEvent(), MakeEvent() };
+
+            await Assert.ThrowsAsync<NotSupportedException>(() =>
+                channel.PublishBatchAsync(batch, cancellationToken: cancellationToken));
+        }
+
+        // --- Per-call override ---------------------------------------------------
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_PerCallMessageFormatOverride()
+        {
+            // Channel configured for plain JSON; per-call override selects binary.
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                return OK();
+            });
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseSystemTime<MutableSystemTime>()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = EndpointUrl;
+                    o.SigningSecret = SigningSecret;
+                    o.MaxRetryCount = 1;
+                    o.MessageFormat = EventMessageFormat.Json;
+                });
+            MutableSystemTime.UtcNowValue = FixedNow;
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => handler);
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IBatchEventPublishChannel>();
+
+            await channel.PublishAsync(MakeEvent(),
+                new WebhookPublishOptions { MessageFormat = EventMessageFormat.CloudEventsBinary },
+                cancellationToken);
+
+            Assert.NotNull(captured);
+            Assert.True(captured!.Headers.Contains("ce-type"));
+            Assert.Equal("application/json",
+                captured.Content!.Headers.ContentType!.MediaType);
+        }
+
+        // --- Regression: default behaviour unchanged -----------------------------
+
+        [Fact]
+        public async Task PublishAsync_DefaultFormat_DoesNotEmitCeHeaders()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+            var handler = new FakeHandler(req =>
+            {
+                captured = req;
+                return OK();
+            });
+
+            // Channel explicitly on the legacy default format.
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseSystemTime<MutableSystemTime>()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = EndpointUrl;
+                    o.SigningSecret = SigningSecret;
+                    o.MaxRetryCount = 1;
+                    o.MessageFormat = EventMessageFormat.Json;
+                });
+            MutableSystemTime.UtcNowValue = FixedNow;
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => handler);
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IBatchEventPublishChannel>();
+
+            await channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+
+            Assert.NotNull(captured);
+            Assert.False(captured!.Headers.Contains("ce-type"),
+                "Legacy default format must not emit ce-* headers.");
+            Assert.Equal("application/json",
+                captured.Content!.Headers.ContentType!.MediaType);
+        }
+
+        // --- Helpers -----------------------------------------------------------
+
+        private static HttpResponseMessage OK() => new(HttpStatusCode.OK);
+
+        private sealed class FakeHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+            public FakeHandler(Func<HttpRequestMessage, HttpResponseMessage> h) => _handler = h;
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(_handler(request));
+        }
+
+        private sealed class MutableSystemTime : IEventSystemTime
+        {
+            public static DateTimeOffset UtcNowValue { get; set; }
+            public DateTimeOffset UtcNow => UtcNowValue;
+        }
+    }
+}

--- a/test/Hermodr.Publisher.Webhook.XUnit/Unit/WebhookCoverageTests.cs
+++ b/test/Hermodr.Publisher.Webhook.XUnit/Unit/WebhookCoverageTests.cs
@@ -1,0 +1,975 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reflection;
+
+using CloudNative.CloudEvents;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Hermodr
+{
+    /// <summary>
+    /// Targeted tests that close the remaining coverage gaps in the webhook
+    /// publisher: channel metadata, options merging (all branches), the
+    /// Retry-After parser (HTTP-date / invalid / negative), the retry
+    /// ShouldHandle null-result branch, the handshake cache API, the typed
+    /// config-section DI overload, exception getters, and edge cases of the
+    /// CloudEvent header mapper.
+    /// </summary>
+    [Trait("Channel", "Webhook")]
+    [Trait("Function", "Coverage")]
+    public class WebhookCoverageTests
+    {
+        // ── IChannelMetadataSource.GetChannelMetadata ───────────────────────
+
+        [Fact]
+        public void GetChannelMetadata_WithEndpointUrl_IncludesUrlProperty()
+        {
+            var options = new WebhookPublishOptions
+            {
+                ChannelName = "orders",
+                EndpointUrl = "https://hook.example.com/r"
+            };
+
+            var metadata = ((IChannelMetadataSource)options).GetChannelMetadata();
+
+            Assert.Equal("orders", metadata.ChannelName);
+            Assert.Equal(EventTransports.Webhook, metadata.Transport);
+            Assert.Equal("https://hook.example.com/r", metadata.Properties["url"]);
+        }
+
+        [Fact]
+        public void GetChannelMetadata_WithoutEndpointUrl_OmitsUrlProperty()
+        {
+            // Exercises the null/empty cleanup loop that removes the url key.
+            var options = new WebhookPublishOptions { ChannelName = "anon" };
+
+            var metadata = ((IChannelMetadataSource)options).GetChannelMetadata();
+
+            Assert.Equal("anon", metadata.ChannelName);
+            Assert.Empty(metadata.Properties);
+        }
+
+        [Fact]
+        public void GetChannelMetadata_WithEmptyEndpointUrl_OmitsUrlProperty()
+        {
+            var options = new WebhookPublishOptions
+            {
+                ChannelName = "empty",
+                EndpointUrl = ""
+            };
+
+            var metadata = ((IChannelMetadataSource)options).GetChannelMetadata();
+
+            Assert.False(metadata.Properties.ContainsKey("url"));
+        }
+
+        // ── WebhookPublishOptions.Merge (full matrix) ───────────────────────
+
+        [Fact]
+        public void Merge_TypedOptionsNullFields_InheritFromBase()
+        {
+            var baseOpts = new WebhookPublishOptions
+            {
+                EndpointUrl = "https://base/hook",
+                SigningSecret = "base-secret",
+                MaxRetryCount = 5,
+                RetryDelay = TimeSpan.FromSeconds(2),
+                RetryBackoffMultiplier = 3.0,
+                RequestTimeout = TimeSpan.FromSeconds(45),
+                MessageFormat = EventMessageFormat.CloudEventsJson,
+                SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha512,
+                ScheduleDeliveryAt = DateTimeOffset.UtcNow,
+                Discovery = new WebhookDiscoveryOptions { RequestOrigin = "base" }
+            };
+            baseOpts.AdditionalHeaders["X-Base"] = "base";
+
+            var typed = new WebhookPublishOptions
+            {
+                EndpointUrl = "https://typed/hook",
+                SigningSecret = "typed-secret"
+            };
+            typed.AdditionalHeaders["X-Typed"] = "typed";
+
+            var merged = WebhookPublishOptions.Merge(baseOpts, typed);
+
+            Assert.Equal("https://typed/hook", merged.EndpointUrl);
+            Assert.Equal("typed-secret", merged.SigningSecret);
+            // Inherited from base because null in typed.
+            Assert.Equal(5, merged.MaxRetryCount);
+            Assert.Equal(TimeSpan.FromSeconds(2), merged.RetryDelay);
+            Assert.Equal(3.0, merged.RetryBackoffMultiplier);
+            Assert.Equal(TimeSpan.FromSeconds(45), merged.RequestTimeout);
+            Assert.Equal(EventMessageFormat.CloudEventsJson, merged.MessageFormat);
+            Assert.Equal(WebhookSignatureAlgorithm.HmacSha512, merged.SignatureAlgorithm);
+            Assert.Equal(baseOpts.ScheduleDeliveryAt, merged.ScheduleDeliveryAt);
+            Assert.Equal("base", merged.Discovery!.RequestOrigin);
+            // Channel-structural always from base.
+            Assert.Equal(baseOpts.SignatureHeaderName, merged.SignatureHeaderName);
+            Assert.Equal(baseOpts.DeliveryIdHeaderName, merged.DeliveryIdHeaderName);
+            Assert.Equal(baseOpts.EventTypeHeaderName, merged.EventTypeHeaderName);
+            Assert.Equal(baseOpts.TimestampHeaderName, merged.TimestampHeaderName);
+            Assert.Equal(baseOpts.SignatureAlgorithmHeaderName, merged.SignatureAlgorithmHeaderName);
+            Assert.Same(baseOpts.RetryableStatusCodes, merged.RetryableStatusCodes);
+            Assert.Equal(baseOpts.HttpClientName, merged.HttpClientName);
+            // Headers merged: both present, typed wins on collision.
+            Assert.Equal("base", merged.AdditionalHeaders["X-Base"]);
+            Assert.Equal("typed", merged.AdditionalHeaders["X-Typed"]);
+        }
+
+        [Fact]
+        public void Merge_TypedHeadersOverrideBaseOnCollision()
+        {
+            var baseOpts = new WebhookPublishOptions();
+            baseOpts.AdditionalHeaders["X-Shared"] = "base";
+
+            var typed = new WebhookPublishOptions();
+            typed.AdditionalHeaders["X-Shared"] = "typed";
+
+            var merged = WebhookPublishOptions.Merge(baseOpts, typed);
+
+            Assert.Equal("typed", merged.AdditionalHeaders["X-Shared"]);
+        }
+
+        [Fact]
+        public void Merge_TypedDiscoveryOverridesBaseDiscovery()
+        {
+            var baseOpts = new WebhookPublishOptions
+            {
+                Discovery = new WebhookDiscoveryOptions { RequestOrigin = "base" }
+            };
+            var typed = new WebhookPublishOptions
+            {
+                Discovery = new WebhookDiscoveryOptions { RequestOrigin = "typed" }
+            };
+
+            var merged = WebhookPublishOptions.Merge(baseOpts, typed);
+
+            Assert.Equal("typed", merged.Discovery!.RequestOrigin);
+        }
+
+        // ── WebhookPublishChannel.MergeOptions (per-call path) ──────────────
+
+        [Fact]
+        public async Task PublishAsync_PerCallOverride_InheritsNullFieldsFromDefaults()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://hook.example.com/r";
+                    o.SigningSecret = "channel-secret";
+                    o.MaxRetryCount = 1;
+                    o.MessageFormat = EventMessageFormat.CloudEventsJson;
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((req, _) =>
+                {
+                    captured = req;
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IEventPublishChannel>();
+
+            // Per-call override: only EndpointUrl is set; everything else null
+            // → inherited from channel defaults (exercises the MergeOptions
+            // null-coalescing branches for every field).
+            await channel.PublishAsync(
+                new CloudEvent(CloudEventsSpecVersion.V1_0)
+                {
+                    Type = "t", Source = new Uri("https://x"), Id = "1",
+                    DataContentType = "application/json", Data = "{}"
+                },
+                new WebhookPublishOptions { EndpointUrl = "https://override.example.com/r" },
+                cancellationToken);
+
+            Assert.NotNull(captured);
+            Assert.Equal("https://override.example.com/r", captured!.RequestUri!.ToString());
+            // Format inherited from channel default (cloudevents+json).
+            Assert.Equal("application/cloudevents+json",
+                captured.Content!.Headers.ContentType!.MediaType);
+        }
+
+        [Fact]
+        public async Task PublishAsync_PerCallDiscoveryOverrideWins()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var optionsSeen = new ConcurrentBag<string>();
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://hook.example.com/r";
+                    o.MaxRetryCount = 1;
+                    // Channel-level: no Discovery.
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((req, _) =>
+                {
+                    if (req.Method == HttpMethod.Options)
+                        optionsSeen.Add(req.Headers.GetValues("WebHook-Request-Origin").First());
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Headers = { { "WebHook-Allowed-Origin", "*" } }
+                    };
+                }));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IEventPublishChannel>();
+
+            await channel.PublishAsync(
+                new CloudEvent(CloudEventsSpecVersion.V1_0)
+                {
+                    Type = "t", Source = new Uri("https://x"), Id = "1",
+                    DataContentType = "application/json", Data = "{}"
+                },
+                new WebhookPublishOptions
+                {
+                    EndpointUrl = "https://hook.example.com/r",
+                    Discovery = new WebhookDiscoveryOptions { RequestOrigin = "per-call-origin" }
+                },
+                cancellationToken);
+
+            Assert.Contains("per-call-origin", optionsSeen);
+        }
+
+        // ── TryGetRetryAfterDelay (HTTP-date + invalid + negative) ──────────
+
+        [Fact]
+        public async Task PublishAsync_429WithRetryAfterHttpDate_HonorsDateDelay()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var attempts = 0;
+            var firstAt = DateTimeOffset.MinValue;
+            var secondAt = DateTimeOffset.MinValue;
+
+            var retryAfterDate = DateTimeOffset.UtcNow.AddSeconds(2);
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://hook.example.com/r";
+                    o.MaxRetryCount = 1;
+                    o.RetryDelay = TimeSpan.FromMilliseconds(10);
+                    o.RetryBackoffMultiplier = 1.0;
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((req, _) =>
+                {
+                    var n = Interlocked.Increment(ref attempts);
+                    if (n == 1)
+                    {
+                        firstAt = DateTimeOffset.UtcNow;
+                        return new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+                        {
+                            Headers = { { "Retry-After", retryAfterDate.ToString("R") } }
+                        };
+                    }
+                    secondAt = DateTimeOffset.UtcNow;
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IEventPublishChannel>();
+
+            await channel.PublishAsync(
+                new CloudEvent(CloudEventsSpecVersion.V1_0)
+                {
+                    Type = "t", Source = new Uri("https://x"), Id = "1",
+                    DataContentType = "application/json", Data = "{}"
+                }, null, cancellationToken);
+
+            Assert.Equal(2, attempts);
+            var observed = secondAt - firstAt;
+            Assert.True(observed >= TimeSpan.FromSeconds(1),
+                $"HTTP-date Retry-After should dominate backoff; observed {observed.TotalMilliseconds}ms.");
+        }
+
+        [Fact]
+        public async Task PublishAsync_429WithUnparseableRetryAfter_FallsBackToBackoff()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var attempts = 0;
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://hook.example.com/r";
+                    o.MaxRetryCount = 1;
+                    o.RetryDelay = TimeSpan.FromMilliseconds(20);
+                    o.RetryBackoffMultiplier = 1.0;
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((req, _) =>
+                {
+                    var n = Interlocked.Increment(ref attempts);
+                    if (n == 1)
+                    {
+                        var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+                        resp.Headers.TryAddWithoutValidation("Retry-After", "not-a-date");
+                        return resp;
+                    }
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IEventPublishChannel>();
+
+            await channel.PublishAsync(
+                new CloudEvent(CloudEventsSpecVersion.V1_0)
+                {
+                    Type = "t", Source = new Uri("https://x"), Id = "1",
+                    DataContentType = "application/json", Data = "{}"
+                }, null, cancellationToken);
+
+            // Unparseable Retry-After → falls back to configured backoff, still retries.
+            Assert.Equal(2, attempts);
+        }
+
+        // ── Retry OnRetry status-code branch + ShouldHandle null outcome ─────
+        // (The status-code retry-log branch is covered by existing tests; the
+        // null-result ShouldHandle branch is unreachable in practice because
+        // Polly only delivers null outcomes via custom strategies, so we don't
+        // force it here — it's a defensive guard.)
+
+        // ── WebhookHandshakeClient cache API + ctor guard ───────────────────
+
+        [Fact]
+        public void WebhookHandshakeClient_Constructor_NullFactory_Throws()
+        {
+            // The ctor is internal; reach it via reflection. The real
+            // ArgumentNullException is wrapped in TargetInvocationException.
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                HandshakeClientReflector.CreateInstance(null!));
+
+            Assert.IsType<ArgumentNullException>(HandshakeClientReflector.Unwrap(ex));
+        }
+
+        [Fact]
+        public async Task HandshakeClient_GetCachedAndEvict_RoundTrip()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handshakeCount = 0;
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://hook.example.com/r";
+                    o.MaxRetryCount = 1;
+                    o.Discovery = new WebhookDiscoveryOptions { RequestOrigin = "origin" };
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((req, _) =>
+                {
+                    if (req.Method == HttpMethod.Options)
+                    {
+                        Interlocked.Increment(ref handshakeCount);
+                        return new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Headers = { { "WebHook-Allowed-Origin", "*" } }
+                        };
+                    }
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }));
+
+            var provider = services.BuildServiceProvider();
+            // Resolve the concrete channel (not the decorated IEventPublishChannel)
+            // so publish and reflection share the same handshake-client instance.
+            // The channel type is internal — resolve it reflectively via the
+            // service provider's non-generic GetService.
+            var channelType = typeof(WebhookPublishOptions).Assembly
+                .GetType("Hermodr.WebhookPublishChannel", throwOnError: true)!;
+            var channel = provider.GetService(channelType)
+                ?? throw new InvalidOperationException("WebhookPublishChannel not registered.");
+            var handshakeClient = HandshakeClientReflector.GetClientFromProvider(provider);
+
+            // GetCached returns null before any handshake.
+            Assert.Null(HandshakeClientReflector.InvokeGetCached(handshakeClient, "https://hook.example.com/r"));
+
+            // PublishAsync is part of the public IEventPublishChannel interface,
+            // so the public cast works without internal access.
+            var ev = new CloudEvent(CloudEventsSpecVersion.V1_0)
+            {
+                Type = "t", Source = new Uri("https://x"), Id = "1",
+                DataContentType = "application/json", Data = "{}"
+            };
+            await ((IEventPublishChannel)channel).PublishAsync(ev, null, cancellationToken);
+            Assert.Equal(1, handshakeCount);
+
+            // Cache now populated.
+            var cached = HandshakeClientReflector.InvokeGetCached(handshakeClient, "https://hook.example.com/r");
+            Assert.NotNull(cached);
+            Assert.Equal("*", HandshakeClientReflector.GetAllowedOrigin(cached!));
+
+            // Second delivery reuses the cache (no new handshake).
+            await ((IEventPublishChannel)channel).PublishAsync(ev, null, cancellationToken);
+            Assert.Equal(1, handshakeCount);
+
+            // Evict → next delivery re-handshakes.
+            HandshakeClientReflector.InvokeEvict(handshakeClient, "https://hook.example.com/r");
+            Assert.Null(HandshakeClientReflector.InvokeGetCached(handshakeClient, "https://hook.example.com/r"));
+
+            await ((IEventPublishChannel)channel).PublishAsync(ev, null, cancellationToken);
+            Assert.Equal(2, handshakeCount);
+        }
+
+        // ── WebhookHandshakeException getters ───────────────────────────────
+
+        [Fact]
+        public void WebhookHandshakeException_PreservesEndpointAndStatusCode()
+        {
+            var inner = new InvalidOperationException("boom");
+            var ex = new WebhookHandshakeException("refused", "https://x/hook", 405, inner);
+
+            Assert.Equal("refused", ex.Message);
+            Assert.Equal("https://x/hook", ex.EndpointUrl);
+            Assert.Equal(405, ex.StatusCode);
+            Assert.Same(inner, ex.InnerException);
+        }
+
+        [Fact]
+        public void WebhookHandshakeException_DefaultStatusCode_Null()
+        {
+            var ex = new WebhookHandshakeException("refused", "https://x/hook");
+            Assert.Null(ex.StatusCode);
+        }
+
+        // ── WebhookDiscoveryPermission GrantedAt ────────────────────────────
+
+        [Fact]
+        public void WebhookDiscoveryPermission_GrantedAt_IsRecentUtc()
+        {
+            var before = DateTimeOffset.UtcNow;
+
+            var permission = new WebhookDiscoveryPermission("origin", 100);
+
+            var after = DateTimeOffset.UtcNow;
+            Assert.Equal("origin", permission.AllowedOrigin);
+            Assert.Equal(100, permission.AllowedRate);
+            Assert.InRange(permission.GrantedAt, before, after);
+        }
+
+        [Fact]
+        public void WebhookDiscoveryPermission_NullOrigin_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new WebhookDiscoveryPermission(null!, 100));
+        }
+
+        // ── AddWebhooks<TEvent>(string sectionPath) DI overload ─────────────
+
+        [Fact]
+        public void AddWebhooks_Typed_FromConfigSection_BindsOptions()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Webhook:EndpointUrl"] = "https://cfg.example.com/hook",
+                    ["Webhook:SigningSecret"] = "cfg-secret",
+                    ["Webhook:MaxRetryCount"] = "7"
+                })
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<IConfiguration>(config);
+            services.AddEventPublisher(o => o.Source = new Uri("https://example.com"))
+                    .AddWebhooks<OrderCreated>("Webhook");
+
+            var sp = services.BuildServiceProvider();
+            var typed = sp.GetRequiredService<IOptions<WebhookPublishOptions<OrderCreated>>>().Value;
+
+            Assert.Equal("https://cfg.example.com/hook", typed.EndpointUrl);
+            Assert.Equal("cfg-secret", typed.SigningSecret);
+            Assert.Equal(7, typed.MaxRetryCount);
+        }
+
+        // ── AddWebhooks(string sectionPath) non-typed overload ──────────────
+
+        [Fact]
+        public void AddWebhooks_FromConfigSection_BindsOptions()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Webhook:EndpointUrl"] = "https://cfg.example.com/base",
+                    ["Webhook:MessageFormat"] = EventMessageFormat.CloudEventsJson
+                })
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<IConfiguration>(config);
+            services.AddEventPublisher(o => o.Source = new Uri("https://example.com"))
+                    .AddWebhooks("Webhook");
+
+            var sp = services.BuildServiceProvider();
+            var opts = sp.GetRequiredService<IOptions<WebhookPublishOptions>>().Value;
+
+            Assert.Equal("https://cfg.example.com/base", opts.EndpointUrl);
+            Assert.Equal(EventMessageFormat.CloudEventsJson, opts.MessageFormat);
+        }
+
+        // ── CloudEventHttpHeadersMapper edge cases ──────────────────────────
+
+        [Fact]
+        public async Task CloudEventHttpHeadersMapper_MinimalEvent_ReturnsOnlyCoreHeaders()
+        {
+            // The mapper is internal; reach it through the binary publish path
+            // by sending an event with no populated attributes other than the
+            // required ones. We assert the absence of extension headers.
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://hook.example.com/r";
+                    o.MaxRetryCount = 1;
+                    o.MessageFormat = EventMessageFormat.CloudEventsBinary;
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((req, _) =>
+                {
+                    captured = req;
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IEventPublishChannel>();
+
+            // Minimal event: only required attributes (specversion/id/type/source).
+            // No datacontenttype, no subject, no extensions → exercises the
+            // null-skip branches in Map.
+            await channel.PublishAsync(
+                new CloudEvent(CloudEventsSpecVersion.V1_0)
+                {
+                    Type = "t", Source = new Uri("https://x"), Id = "1"
+                }, null, cancellationToken);
+
+            Assert.NotNull(captured);
+            Assert.False(captured!.Headers.Contains("ce-datacontenttype"));
+            Assert.False(captured.Headers.Contains("ce-subject"));
+            // No extension ce-* headers beyond the core ones.
+            var ceHeaders = captured.Headers
+                .Where(h => h.Key.StartsWith("ce-", StringComparison.OrdinalIgnoreCase))
+                .Select(h => h.Key)
+                .ToList();
+            Assert.Contains("ce-specversion", ceHeaders);
+            Assert.Contains("ce-id", ceHeaders);
+            Assert.Contains("ce-type", ceHeaders);
+            Assert.Contains("ce-source", ceHeaders);
+            // Exactly the four core attributes, no time/datacontenttype/subject/extensions.
+            Assert.Equal(4, ceHeaders.Count);
+        }
+
+        [Fact]
+        public async Task PublishAsync_BinaryMode_DataschemaExtension_MappedToCeHeader()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://hook.example.com/r";
+                    o.MaxRetryCount = 1;
+                    o.MessageFormat = EventMessageFormat.CloudEventsBinary;
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((req, _) =>
+                {
+                    captured = req;
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IEventPublishChannel>();
+
+            var ev = new CloudEvent(CloudEventsSpecVersion.V1_0)
+            {
+                Type = "t", Source = new Uri("https://x"), Id = "1",
+                DataContentType = "application/json", Data = "{}"
+            };
+            ev["dataschema"] = new Uri("https://schemas.example.com/evt");
+
+            await channel.PublishAsync(ev, null, cancellationToken);
+
+            Assert.NotNull(captured);
+            Assert.Equal("https://schemas.example.com/evt",
+                captured!.Headers.GetValues("ce-dataschema").First());
+        }
+
+        // ── WebhookPublishOptions.EndpointUrl getter + defaults sanity ──────
+
+        [Fact]
+        public void WebhookPublishOptions_Defaults_AreExpected()
+        {
+            var opts = new WebhookPublishOptions();
+
+            Assert.Null(opts.EndpointUrl);
+            Assert.Equal(WebhookDefaults.SignatureHeaderName, opts.SignatureHeaderName);
+            Assert.Equal(WebhookDefaults.DeliveryIdHeaderName, opts.DeliveryIdHeaderName);
+            Assert.Equal(WebhookDefaults.EventTypeHeaderName, opts.EventTypeHeaderName);
+            Assert.Equal(WebhookDefaults.TimestampHeaderName, opts.TimestampHeaderName);
+            Assert.Equal(WebhookDefaults.SignatureAlgorithmHeaderName, opts.SignatureAlgorithmHeaderName);
+            Assert.Null(opts.HttpClientName);
+            Assert.Null(opts.Discovery);
+            Assert.Equal(new[] { 429, 500, 502, 503, 504 }, opts.RetryableStatusCodes.Order());
+        }
+
+        // ── Merge with all typed fields set (flips every ?? branch in Merge) ─
+
+        [Fact]
+        public void Merge_AllTypedFieldsSet_OverridesEveryBaseField()
+        {
+            var baseOpts = new WebhookPublishOptions
+            {
+                EndpointUrl = "https://base/hook",
+                SigningSecret = "base-secret",
+                MaxRetryCount = 5,
+                RetryDelay = TimeSpan.FromSeconds(2),
+                RetryBackoffMultiplier = 3.0,
+                RequestTimeout = TimeSpan.FromSeconds(45),
+                MessageFormat = EventMessageFormat.CloudEventsJson,
+                SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha512,
+                ScheduleDeliveryAt = DateTimeOffset.UtcNow,
+                ChannelName = "base-name",
+                Discovery = new WebhookDiscoveryOptions { RequestOrigin = "base" }
+            };
+
+            var typed = new WebhookPublishOptions
+            {
+                EndpointUrl = "https://typed/hook",
+                SigningSecret = "typed-secret",
+                MaxRetryCount = 1,
+                RetryDelay = TimeSpan.FromMilliseconds(50),
+                RetryBackoffMultiplier = 1.5,
+                RequestTimeout = TimeSpan.FromSeconds(10),
+                MessageFormat = EventMessageFormat.CloudEventsBinary,
+                SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha256,
+                ScheduleDeliveryAt = DateTimeOffset.UtcNow.AddMinutes(5),
+                ChannelName = "typed-name",
+                Discovery = new WebhookDiscoveryOptions { RequestOrigin = "typed" }
+            };
+
+            var merged = WebhookPublishOptions.Merge(baseOpts, typed);
+
+            Assert.Equal("https://typed/hook", merged.EndpointUrl);
+            Assert.Equal("typed-secret", merged.SigningSecret);
+            Assert.Equal(1, merged.MaxRetryCount);
+            Assert.Equal(TimeSpan.FromMilliseconds(50), merged.RetryDelay);
+            Assert.Equal(1.5, merged.RetryBackoffMultiplier);
+            Assert.Equal(TimeSpan.FromSeconds(10), merged.RequestTimeout);
+            Assert.Equal(EventMessageFormat.CloudEventsBinary, merged.MessageFormat);
+            Assert.Equal(WebhookSignatureAlgorithm.HmacSha256, merged.SignatureAlgorithm);
+            Assert.Equal(typed.ScheduleDeliveryAt, merged.ScheduleDeliveryAt);
+            Assert.Equal("typed-name", merged.ChannelName);
+            Assert.Equal("typed", merged.Discovery!.RequestOrigin);
+        }
+
+        // ── MergeOptions (per-call) with all per-call fields set ─────────────
+
+        [Fact]
+        public async Task PublishAsync_PerCallAllFieldsSet_OverridesChannelDefaults()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? captured = null;
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://base.example.com/r";
+                    o.SigningSecret = "base-secret";
+                    o.MaxRetryCount = 1;
+                    o.MessageFormat = EventMessageFormat.Json;
+                    o.SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha512;
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((req, _) =>
+                {
+                    captured = req;
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IEventPublishChannel>();
+
+            await channel.PublishAsync(
+                new CloudEvent(CloudEventsSpecVersion.V1_0)
+                {
+                    Type = "t", Source = new Uri("https://x"), Id = "1",
+                    DataContentType = "application/json", Data = "{}"
+                },
+                new WebhookPublishOptions
+                {
+                    EndpointUrl = "https://override.example.com/r",
+                    SigningSecret = "override-secret",
+                    MessageFormat = EventMessageFormat.CloudEventsBinary,
+                    SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha256
+                },
+                cancellationToken);
+
+            Assert.NotNull(captured);
+            Assert.Equal("https://override.example.com/r", captured!.RequestUri!.ToString());
+            // Binary format → ce-* headers present and content-type from data.
+            Assert.True(captured.Headers.Contains("ce-type"));
+            Assert.Equal("application/json", captured.Content!.Headers.ContentType!.MediaType);
+            // HmacSha256 override → sha256 signature prefix.
+            Assert.StartsWith("sha256=",
+                captured.Headers.GetValues(WebhookDefaults.SignatureHeaderName).First());
+        }
+
+        // ── TryGetRetryAfterDelay: past HTTP-date → TimeSpan.Zero ────────────
+
+        [Fact]
+        public async Task PublishAsync_429WithPastRetryAfterDate_RetriesImmediately()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var attempts = 0;
+            var firstAt = DateTimeOffset.MinValue;
+            var secondAt = DateTimeOffset.MinValue;
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://hook.example.com/r";
+                    o.MaxRetryCount = 1;
+                    o.RetryDelay = TimeSpan.FromMilliseconds(10);
+                    o.RetryBackoffMultiplier = 1.0;
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((req, _) =>
+                {
+                    var n = Interlocked.Increment(ref attempts);
+                    if (n == 1)
+                    {
+                        firstAt = DateTimeOffset.UtcNow;
+                        // A past date → clamped to TimeSpan.Zero (immediate retry).
+                        var past = DateTimeOffset.UtcNow.AddMinutes(-5);
+                        var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+                        resp.Headers.TryAddWithoutValidation("Retry-After", past.ToString("R"));
+                        return resp;
+                    }
+                    secondAt = DateTimeOffset.UtcNow;
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IEventPublishChannel>();
+
+            await channel.PublishAsync(
+                new CloudEvent(CloudEventsSpecVersion.V1_0)
+                {
+                    Type = "t", Source = new Uri("https://x"), Id = "1",
+                    DataContentType = "application/json", Data = "{}"
+                }, null, cancellationToken);
+
+            Assert.Equal(2, attempts);
+            // Past Retry-After → immediate retry (clamped to zero), well under 900ms.
+            var observed = secondAt - firstAt;
+            Assert.True(observed < TimeSpan.FromMilliseconds(500),
+                $"Past Retry-After should retry immediately; observed {observed.TotalMilliseconds}ms.");
+        }
+
+        // ── GetSignatureProvider: unknown algorithm throws ───────────────────
+
+        [Fact]
+        public async Task PublishAsync_UnknownSignatureAlgorithm_Throws()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = "https://hook.example.com/r";
+                    o.MaxRetryCount = 1;
+                    // An enum value with no registered provider.
+                    o.SignatureAlgorithm = (WebhookSignatureAlgorithm)999;
+                });
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler((_, _) =>
+                    new HttpResponseMessage(HttpStatusCode.OK)));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IEventPublishChannel>();
+
+            await Assert.ThrowsAsync<NotSupportedException>(() =>
+                channel.PublishAsync(
+                    new CloudEvent(CloudEventsSpecVersion.V1_0)
+                    {
+                        Type = "t", Source = new Uri("https://x"), Id = "1",
+                        DataContentType = "application/json", Data = "{}"
+                    }, null, cancellationToken));
+        }
+
+        // ── WebhookHandshakeClient.EnsureHandshakeAsync arg validation ──────
+
+        [Fact]
+        public async Task HandshakeClient_EnsureHandshakeAsync_NullOptions_Throws()
+        {
+            using var factory = new DummyHttpClientFactory();
+            var client = HandshakeClientReflector.CreateInstance(factory);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                HandshakeClientReflector.InvokeEnsureHandshakeAsync(
+                    client, "https://x", null!, null, default));
+        }
+
+        [Fact]
+        public async Task HandshakeClient_EnsureHandshakeAsync_EmptyEndpoint_Throws()
+        {
+            using var factory = new DummyHttpClientFactory();
+            var client = HandshakeClientReflector.CreateInstance(factory);
+            var opts = new WebhookDiscoveryOptions { RequestOrigin = "o" };
+
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                HandshakeClientReflector.InvokeEnsureHandshakeAsync(
+                    client, "  ", opts, null, default));
+        }
+
+        // ── Helpers ─────────────────────────────────────────────────────────
+
+        private sealed class LambdaHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _fn;
+            public LambdaHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> fn) => _fn = fn;
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(_fn(request, cancellationToken));
+        }
+
+        /// <summary>
+        /// A minimal <see cref="IHttpClientFactory"/> that returns a plain
+        /// <see cref="HttpClient"/>; used for direct handshake-client tests
+        /// that don't go through the channel DI surface.
+        /// </summary>
+        private sealed class DummyHttpClientFactory : IHttpClientFactory, IDisposable
+        {
+            private readonly HttpClient _client = new();
+            public HttpClient CreateClient(string name) => _client;
+            public void Dispose() => _client.Dispose();
+        }
+
+        private sealed class OrderCreated { }
+    }
+
+    /// <summary>
+    /// Test-only reflection accessor for the internal
+    /// <c>Hermodr.WebhookHandshakeClient</c> owned by the internal
+    /// <c>Hermodr.WebhookPublishChannel</c>. No <c>InternalsVisibleTo</c>
+    /// attribute is used: every member is reached via reflection so the
+    /// production assembly stays sealed.
+    /// </summary>
+    internal static class HandshakeClientReflector
+    {
+        // The webhook assembly is reached through a *public* type so the
+        // reflector does not depend on internal accessibility.
+        private static readonly Assembly WebhookAssembly = typeof(WebhookPublishOptions).Assembly;
+
+        private static readonly Type ChannelType =
+            WebhookAssembly.GetType("Hermodr.WebhookPublishChannel", throwOnError: true)!;
+
+        private static readonly Type ClientType =
+            WebhookAssembly.GetType("Hermodr.WebhookHandshakeClient", throwOnError: true)!;
+
+        private static readonly Type PermissionType =
+            WebhookAssembly.GetType("Hermodr.WebhookDiscoveryPermission", throwOnError: true)!;
+
+        /// <summary>
+        /// Resolves the concrete <c>WebhookPublishChannel</c> singleton from
+        /// the provider (not the decorated IEventPublishChannel) so the
+        /// returned handshake client is the same instance used for delivery.
+        /// </summary>
+        public static object GetClientFromProvider(IServiceProvider provider)
+        {
+            var channel = provider.GetRequiredService(ChannelType);
+            var field = ChannelType.GetField(
+                "_handshakeClient",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            return field!.GetValue(channel)
+                ?? throw new InvalidOperationException("_handshakeClient field was null.");
+        }
+
+        /// <summary>Reflectively invokes the parameterless <c>GetCached</c>.</summary>
+        public static object? InvokeGetCached(object client, string endpointUrl)
+            => ClientType.GetMethod("GetCached")!.Invoke(client, new object[] { endpointUrl });
+
+        /// <summary>Reflectively invokes the parameterless <c>Evict</c>.</summary>
+        public static void InvokeEvict(object client, string endpointUrl)
+            => ClientType.GetMethod("Evict")!.Invoke(client, new object[] { endpointUrl });
+
+        /// <summary>Reads the <c>AllowedOrigin</c> property off a permission.</summary>
+        public static string GetAllowedOrigin(object permission)
+            => (string)PermissionType.GetProperty("AllowedOrigin")!.GetValue(permission)!;
+
+        /// <summary>
+        /// Constructs a <c>WebhookHandshakeClient</c> via reflection. Pass
+        /// <c>null</c> for <paramref name="factory"/> to exercise the ctor's
+        /// null-argument guard. The underlying constructor throws
+        /// <see cref="TargetInvocationException"/> wrapping the real
+        /// exception; callers should use <see cref="Unwrap"/> to inspect it.
+        /// </summary>
+        public static object CreateInstance(IHttpClientFactory? factory)
+        {
+            // Bind the ctor explicitly so a null factory is typed correctly
+            // (Activator.CreateInstance cannot infer the parameter type from null).
+            var ctor = ClientType.GetConstructors().Single();
+            return ctor.Invoke(new object?[] { factory, null })!;
+        }
+
+        /// <summary>
+        /// Reflectively invokes <c>EnsureHandshakeAsync</c>. Because the method
+        /// is async, argument-validation exceptions are captured into the
+        /// returned task (not thrown synchronously by <c>Invoke</c>); this
+        /// helper awaits the task and rethrows the real exception unwrapped,
+        /// so callers can assert on the concrete exception type directly.
+        /// </summary>
+        public static async Task InvokeEnsureHandshakeAsync(
+            object client, string endpointUrl, object options, string? httpClientName, CancellationToken ct)
+        {
+            var method = ClientType.GetMethod("EnsureHandshakeAsync")!;
+            // The async method returns Task<WebhookDiscoveryPermission?>; we
+            // only need to await it for its side effect / exception.
+            var task = (Task)method.Invoke(client, new object?[] { endpointUrl, options, httpClientName, ct })!;
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (TargetInvocationException tie)
+            {
+                // Synchronous throw from Invoke (rare for async) — unwrap once.
+                throw tie.InnerException!;
+            }
+            // If the task faulted, await already rethrew the real exception
+            // (Argument*Exception), not TargetInvocationException.
+        }
+
+        /// <summary>Unwraps the real exception from a reflective invocation.</summary>
+        public static Exception Unwrap(Exception ex) =>
+            ex is TargetInvocationException tie && tie.InnerException != null
+                ? tie.InnerException
+                : ex;
+    }
+}

--- a/test/Hermodr.Publisher.Webhook.XUnit/Unit/WebhookDiscoveryTests.cs
+++ b/test/Hermodr.Publisher.Webhook.XUnit/Unit/WebhookDiscoveryTests.cs
@@ -1,0 +1,375 @@
+//
+// Copyright (c) Antonello Provenzano and other contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.Net;
+
+using CloudNative.CloudEvents;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hermodr
+{
+    public class WebhookDiscoveryTests
+    {
+        private static readonly DateTimeOffset FixedNow =
+            new(2026, 01, 15, 12, 00, 00, TimeSpan.Zero);
+
+        private const string SigningSecret = "test-secret";
+        private const string EndpointUrl = "https://webhook.example.com/receive";
+        private const string RequestOrigin = "eventemitter.example.com";
+
+        private static CloudEvent MakeEvent(string type = "person.created") => new(CloudEventsSpecVersion.V1_0)
+        {
+            Type = type,
+            Source = new Uri("https://api.example.com/svc"),
+            Id = Guid.NewGuid().ToString("N"),
+            DataContentType = "application/json",
+            Data = """{"name":"John Doe"}""",
+            Time = FixedNow
+        };
+
+        private static (IBatchEventPublishChannel channel, List<HttpRequestMessage> requests) BuildChannel(
+            Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> send,
+            Action<WebhookPublishOptions>? configure = null)
+        {
+            var requests = new List<HttpRequestMessage>();
+
+            var services = new ServiceCollection();
+            services.AddEventPublisher()
+                .UseSystemTime<MutableSystemTime>()
+                .AddWebhooks(o =>
+                {
+                    o.EndpointUrl = EndpointUrl;
+                    o.SigningSecret = SigningSecret;
+                    o.MaxRetryCount = 1;
+                    o.RetryDelay = TimeSpan.FromMilliseconds(10);
+                    o.MessageFormat = EventMessageFormat.Json;
+                    o.SignatureAlgorithm = WebhookSignatureAlgorithm.HmacSha256;
+                    configure?.Invoke(o);
+                });
+
+            MutableSystemTime.UtcNowValue = FixedNow;
+
+            services.AddHttpClient(WebhookDefaults.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new LambdaHandler(send, requests));
+
+            var channel = services.BuildServiceProvider()
+                .GetRequiredService<IBatchEventPublishChannel>();
+            return (channel, requests);
+        }
+
+        // --- OPTIONS handshake --------------------------------------------------
+
+        [Fact]
+        public async Task PublishAsync_WithDiscovery_IssuesOptionsHandshakeBeforePost()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+
+            var (channel, requests) = BuildChannel((req, _) =>
+            {
+                if (req.Method == HttpMethod.Options)
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Headers =
+                        {
+                            { "WebHook-Allowed-Origin", RequestOrigin },
+                            { "WebHook-Allowed-Rate", "100" }
+                        }
+                    };
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o => o.Discovery = new WebhookDiscoveryOptions { RequestOrigin = RequestOrigin });
+
+            await channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+
+            // The OPTIONS pre-flight must precede the POST.
+            Assert.True(requests.Count >= 2);
+            Assert.Equal(HttpMethod.Options, requests[0].Method);
+            Assert.Equal(HttpMethod.Post, requests[1].Method);
+        }
+
+        [Fact]
+        public async Task PublishAsync_WithDiscovery_SendsRequestOriginAndRateInHandshake()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? optionsRequest = null;
+
+            var (channel, _) = BuildChannel((req, _) =>
+            {
+                if (req.Method == HttpMethod.Options)
+                {
+                    optionsRequest = req;
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Headers = { { "WebHook-Allowed-Origin", "*" } }
+                    };
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o => o.Discovery = new WebhookDiscoveryOptions
+            {
+                RequestOrigin = RequestOrigin,
+                RequestRate = 120,
+                RequestCallback = "https://callback.example.com/grant?id=1"
+            });
+
+            await channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+
+            Assert.NotNull(optionsRequest);
+            Assert.Equal(RequestOrigin,
+                optionsRequest!.Headers.GetValues("WebHook-Request-Origin").First());
+            Assert.Equal("120",
+                optionsRequest.Headers.GetValues("WebHook-Request-Rate").First());
+            Assert.Equal("https://callback.example.com/grant?id=1",
+                optionsRequest.Headers.GetValues("WebHook-Request-Callback").First());
+        }
+
+        [Fact]
+        public async Task PublishAsync_WithDiscovery_AttachesRequestOriginToDeliveryPost()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            HttpRequestMessage? postRequest = null;
+
+            var (channel, _) = BuildChannel((req, _) =>
+            {
+                if (req.Method == HttpMethod.Options)
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Headers = { { "WebHook-Allowed-Origin", RequestOrigin } }
+                    };
+                postRequest = req;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o => o.Discovery = new WebhookDiscoveryOptions { RequestOrigin = RequestOrigin });
+
+            await channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+
+            Assert.NotNull(postRequest);
+            Assert.Equal(RequestOrigin,
+                postRequest!.Headers.GetValues("WebHook-Request-Origin").First());
+        }
+
+        // --- Cache: handshake issued once per endpoint --------------------------
+
+        [Fact]
+        public async Task PublishAsync_TwiceToSameEndpoint_HandshakeIssuedOnce()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handshakeCount = 0;
+
+            var (channel, _) = BuildChannel((req, _) =>
+            {
+                if (req.Method == HttpMethod.Options)
+                {
+                    Interlocked.Increment(ref handshakeCount);
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Headers = { { "WebHook-Allowed-Origin", "*" } }
+                    };
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o => o.Discovery = new WebhookDiscoveryOptions { RequestOrigin = RequestOrigin });
+
+            await channel.PublishAsync(MakeEvent("a"), cancellationToken: cancellationToken);
+            await channel.PublishAsync(MakeEvent("b"), cancellationToken: cancellationToken);
+
+            Assert.Equal(1, handshakeCount);
+        }
+
+        // --- Refused handshake --------------------------------------------------
+
+        [Fact]
+        public async Task PublishAsync_HandshakeRefused_BestEffort_StillDelivers()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var postSeen = false;
+
+            var (channel, _) = BuildChannel((req, _) =>
+            {
+                if (req.Method == HttpMethod.Options)
+                    return new HttpResponseMessage(HttpStatusCode.OK); // no Allowed-Origin
+                postSeen = true;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o => o.Discovery = new WebhookDiscoveryOptions
+            {
+                RequestOrigin = RequestOrigin,
+                RequireSuccessfulHandshake = false
+            });
+
+            // Best-effort: delivery proceeds despite refusal.
+            await channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+            Assert.True(postSeen);
+        }
+
+        [Fact]
+        public async Task PublishAsync_HandshakeRefused_Strict_ThrowsAndDoesNotDeliver()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var postSeen = false;
+
+            var (channel, _) = BuildChannel((req, _) =>
+            {
+                if (req.Method == HttpMethod.Options)
+                    return new HttpResponseMessage(HttpStatusCode.OK); // no Allowed-Origin
+                postSeen = true;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o => o.Discovery = new WebhookDiscoveryOptions
+            {
+                RequestOrigin = RequestOrigin,
+                RequireSuccessfulHandshake = true
+            });
+
+            await Assert.ThrowsAsync<WebhookHandshakeException>(() =>
+                channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken));
+
+            Assert.False(postSeen, "Delivery POST must not be sent when strict handshake fails.");
+        }
+
+        [Fact]
+        public async Task PublishAsync_HandshakeRequestFaults_Strict_Throws()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+
+            var (channel, _) = BuildChannel((req, _) =>
+            {
+                if (req.Method == HttpMethod.Options)
+                    throw new HttpRequestException("connection reset");
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o => o.Discovery = new WebhookDiscoveryOptions
+            {
+                RequestOrigin = RequestOrigin,
+                RequireSuccessfulHandshake = true
+            });
+
+            await Assert.ThrowsAsync<WebhookHandshakeException>(() =>
+                channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken));
+        }
+
+        [Fact]
+        public async Task PublishAsync_HandshakeRequestFaults_BestEffort_Proceeds()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var postSeen = false;
+
+            var (channel, _) = BuildChannel((req, _) =>
+            {
+                if (req.Method == HttpMethod.Options)
+                    throw new HttpRequestException("dns failure");
+                postSeen = true;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o => o.Discovery = new WebhookDiscoveryOptions { RequestOrigin = RequestOrigin });
+
+            await channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+            Assert.True(postSeen);
+        }
+
+        // --- WebHook-Allowed-Rate parsing ---------------------------------------
+
+        [Fact]
+        public async Task PublishAsync_AllowedRateAsterisk_ParsedAsNull()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+
+            var (channel, _) = BuildChannel((req, _) =>
+            {
+                if (req.Method == HttpMethod.Options)
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Headers =
+                        {
+                            { "WebHook-Allowed-Origin", "*" },
+                            { "WebHook-Allowed-Rate", "*" }
+                        }
+                    };
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o => o.Discovery = new WebhookDiscoveryOptions { RequestOrigin = RequestOrigin });
+
+            // Guards that an asterisk allowed-rate doesn't throw and delivery
+            // completes normally.
+            await channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+        }
+
+        // --- No Discovery → no handshake, no origin header ----------------------
+
+        [Fact]
+        public async Task PublishAsync_NoDiscovery_NoOptionsRequest()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var (channel, requests) = BuildChannel((_, _) => new HttpResponseMessage(HttpStatusCode.OK));
+
+            await channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+
+            Assert.All(requests, r => Assert.Equal(HttpMethod.Post, r.Method));
+            Assert.DoesNotContain(requests,
+                r => r.Headers.Contains("WebHook-Request-Origin"));
+        }
+
+        // --- Retry-After on 429 -------------------------------------------------
+
+        [Fact]
+        public async Task PublishAsync_429WithRetryAfter_RetriesAfterSpecifiedDelay()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var attempts = 0;
+            var firstAttemptAt = DateTimeOffset.MinValue;
+            var secondAttemptAt = DateTimeOffset.MinValue;
+
+            var (channel, _) = BuildChannel((req, _) =>
+            {
+                var n = Interlocked.Increment(ref attempts);
+                if (n == 1)
+                {
+                    firstAttemptAt = DateTimeOffset.UtcNow;
+                    return new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+                    {
+                        Headers = { { "Retry-After", "1" } }
+                    };
+                }
+
+                secondAttemptAt = DateTimeOffset.UtcNow;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }, o =>
+            {
+                o.MaxRetryCount = 1;
+                o.RetryDelay = TimeSpan.FromMilliseconds(10);
+                o.RetryBackoffMultiplier = 1.0;
+            });
+
+            await channel.PublishAsync(MakeEvent(), cancellationToken: cancellationToken);
+
+            Assert.Equal(2, attempts);
+            var observed = secondAttemptAt - firstAttemptAt;
+            // Retry-After=1s must dominate the configured 10ms backoff.
+            Assert.True(observed >= TimeSpan.FromMilliseconds(900),
+                $"Expected ≥900ms between attempts due to Retry-After, observed {observed.TotalMilliseconds}ms.");
+        }
+
+        // --- Handlers -----------------------------------------------------------
+
+        private sealed class LambdaHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _send;
+            private readonly List<HttpRequestMessage> _requests;
+
+            public LambdaHandler(
+                Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> send,
+                List<HttpRequestMessage> requests)
+            {
+                _send = send;
+                _requests = requests;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _requests.Add(request);
+                return Task.FromResult(_send(request, cancellationToken));
+            }
+        }
+
+        private sealed class MutableSystemTime : IEventSystemTime
+        {
+            public static DateTimeOffset UtcNowValue { get; set; }
+            public DateTimeOffset UtcNow => UtcNowValue;
+        }
+    }
+}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,10 +8,10 @@
       "name": "hermodr-website",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/faster": "3.10.1",
-        "@docusaurus/plugin-client-redirects": "^3.10.1",
-        "@docusaurus/preset-classic": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/faster": "3.10.2",
+        "@docusaurus/plugin-client-redirects": "^3.10.2",
+        "@docusaurus/preset-classic": "3.10.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -19,9 +19,9 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/tsconfig": "3.10.1",
-        "@docusaurus/types": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/tsconfig": "3.10.2",
+        "@docusaurus/types": "3.10.2",
         "@types/react": "^19.0.0",
         "typescript": "~6.0.2"
       },
@@ -29,47 +29,62 @@
         "node": ">=20.0"
       }
     },
-    "node_modules/@algolia/abtesting": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.19.0.tgz",
-      "integrity": "sha512-Lhnez3hhXHk25lfxLAMxvkP4fmN3+1RgADhD2ssMDBYuAsDVReeyP+3SGRx+ntq8ijMrLqUyfvO72TB6jsTteQ==",
+    "node_modules/@11ty/gray-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/gray-matter/-/gray-matter-1.0.0.tgz",
+      "integrity": "sha512-7mJJl+wf1AByoT0PknQiQfOPnVNT4fevGrUBVWO4HXsnYn1aQPyRyrELYrNUFleUBM++KzMKN6QaxHPk0t/6/g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "js-yaml": "^4.1.0",
+        "kind-of": "^6.0.3",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
+      "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.8.tgz",
-      "integrity": "sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA==",
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.9.tgz",
+      "integrity": "sha512-4U2JKLMWlDu0CotYyUkWakDxr8AIav3QtIUXXRpfavYN29aVWfzlwJp9T0rPKEf/dO2QCPAUc0Kq1Tj1GJxo2A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.8",
-        "@algolia/autocomplete-shared": "1.19.8"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.9",
+        "@algolia/autocomplete-shared": "1.19.9"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.8.tgz",
-      "integrity": "sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA==",
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.9.tgz",
+      "integrity": "sha512-6mExC6X7762s2SV3eJy3QOkB8bdMmnUhQ2agvGVDuzwoGyr3PquGSY/0vPQXCfiAiCaXUz1rXn+lwghgSi0l0w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.19.8"
+        "@algolia/autocomplete-shared": "1.19.9"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz",
-      "integrity": "sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==",
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.9.tgz",
+      "integrity": "sha512-YosP9Uoek6y/Ur1r1qeogk4biMe/hzkyNcgMCciw0//3XpCM7VlYLSHnyt/vOnEOGhCCc0+3v+unEiH6zz+Z1A==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -77,99 +92,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.53.0.tgz",
-      "integrity": "sha512-0ZjA5Hcmaoz5Lj6OG0zhfIyeqzJZnLW2CRJA1W17UwMFGRtZAJ9yJKRvPEDA6gkpsIoQxORTSW6sWFiuYncPNQ==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
+      "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.53.0.tgz",
-      "integrity": "sha512-kWNodP75iiEaOtemC9F/hlxNBG5E2QUjN1BusnE6m2b4l7Qh/BUO3fGCVsmKJI65VO4VKGGmT43ICvHtTcJ2JQ==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
+      "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.53.0.tgz",
-      "integrity": "sha512-YPN45TXD9Wrse185t/Ta7nktZsqpv97oOjCzp2sblHnCL6rBc9TDeJAg1IGl2UpdwnSD05Zu/5wLB4watOUMyg==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
+      "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.53.0.tgz",
-      "integrity": "sha512-qAcYTDJE6m924FDDUQvdD6vh7DYaqOeSpFS74IP37/JRV0v4cGBauyxTF2WzDnokUylQDbqreoFIJZfg0Fitmw==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
+      "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.53.0.tgz",
-      "integrity": "sha512-fQaY+DkSJOpuUVUe8MQTwrdiKAqkJGhpDarB08duBn/sUv7Bkib6MDRQauCcWTWTe4HIW+EbwQP9R4kci1V/Yw==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
+      "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.53.0.tgz",
-      "integrity": "sha512-o72tsiEZGfeS/dxL9IADfzcZWGEwKDEe5CvtrBuT//3JR+SHuTtHRI2ZTf7D7bcKagcbojvO8hnkHdfoakSlYg==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
+      "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.53.0.tgz",
-      "integrity": "sha512-Ds16IyPm/dNJPCU8OzApo2gwGrgWT5BYHhE3NFwZbpCveqyvPDB9sZDDkJ5DsdOGT2aC+R3i0/M1OVXF2qdgPg==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
+      "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -182,81 +197,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.53.0.tgz",
-      "integrity": "sha512-oNbT6z4NwD8Pou9VPINGlN/tlG1afESh2EbxqnP6rwl95xKVD/Zlciis1PpNeO/9U/rrajc1+7DcfKi03tX1KQ==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
+      "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.53.0.tgz",
-      "integrity": "sha512-G+KZb/yd+qAOFn/cEvTGeLxQm8aP3a0od50l3z/ylccY+/o4YG3TNcjU1tFQHW4mXC137GPyR7W70R0kRQDLnA==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
+      "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.53.0.tgz",
-      "integrity": "sha512-6aVfYd55Un6IUgPLbo84WfgFZlS3L0vA1ttzXL5vahHewUJ8jYgd89TzlWRTeej7w70mb9RWsVlFYGmJ/diQww==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
+      "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.53.0.tgz",
-      "integrity": "sha512-ke27DqgzCOlt+RbeEdCxtXxMQOnAOi8ujr2wid0DmDKzR95Kw/f9sBsuhBxtjevCqJRJszfRTLY0B1pbO6IhkA==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
+      "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0"
+        "@algolia/client-common": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.53.0.tgz",
-      "integrity": "sha512-GngiOqt2Gq4oLno6yXQVj9om+qSO9SWAoduoTOEg79dKZ62brB8OOIvSJG/vDNoanYi6a7Al9uDZwXvi+bcVTg==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
+      "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0"
+        "@algolia/client-common": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.53.0.tgz",
-      "integrity": "sha512-6mF9LZMUk0QqWvrnxkxBqhswwz6Xfiwy6/gmTzL5HrlhdVG3ITAqGV2k3XmVThP1h0Ulc3VQwiNCD7/Nr4JNlQ==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
+      "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.53.0"
+        "@algolia/client-common": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -325,13 +340,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -624,12 +639,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1230,15 +1245,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
-      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.8.tgz",
+      "integrity": "sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/traverse": "^7.29.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1534,9 +1549,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
-      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.8.tgz",
+      "integrity": "sha512-0UpIXPtdDtMXfnV2OJAVMLpj3H/92vmkA6lpSRakmycJvj3VUy6Xs1dM8tXRugupykr5WB+LpiVl0J8LMVg2mg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1624,9 +1639,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
-      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.8.tgz",
+      "integrity": "sha512-4S9ksMGVWUshvgK0mKfvZky7leuG5/uoFVwMpAomJ8bMoDJiNHRVmc1EglwW/CmGVSqqWpEbXm9FmbRit22qoA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
@@ -1950,17 +1965,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1968,9 +1983,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -2224,9 +2239,9 @@
       }
     },
     "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -2645,9 +2660,9 @@
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -3092,9 +3107,9 @@
       }
     },
     "node_modules/@csstools/postcss-scope-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -3316,9 +3331,9 @@
       }
     },
     "node_modules/@docsearch/core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.3.tgz",
-      "integrity": "sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.7.0.tgz",
+      "integrity": "sha512-p/9xVKmPDj3FPvMfPf5naVO3Ej8SCbcUugGvx1+8GgkuBNbqxqN2Irx3WLBv8VY0jH7XpRwKWdlmjXLZsmTLsg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3338,20 +3353,20 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
-      "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.7.0.tgz",
+      "integrity": "sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.3.tgz",
-      "integrity": "sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-x6oedjJ8O8/pIDBsMo5Orca3/6cQCz616/CwthVe68l43mqnj2lrJ9kFQITBqy8hMsS3nWeBWFoVO5dJ1DCFKA==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "4.6.3",
-        "@docsearch/css": "4.6.3"
+        "@docsearch/core": "4.7.0",
+        "@docsearch/css": "4.7.0"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3407,9 +3422,9 @@
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.1.tgz",
-      "integrity": "sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.2.tgz",
+      "integrity": "sha512-aJ1hpGyvfkte3dDAfNbWM4biW4yWZBVz7TIGLZP+v+tWOBgxX3e0N5ZIXHIvmfNNXTI77pcHUx3KmtOk05Ze3Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3421,8 +3436,8 @@
         "@babel/preset-typescript": "^7.25.9",
         "@babel/runtime": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3432,17 +3447,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.1.tgz",
-      "integrity": "sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.2.tgz",
+      "integrity": "sha512-i0ZNcy0f0WhaOlYVgzLsWhIoEXO9kS3HRoKPtgE6vQtZUq7arKZaYdNBudr3mqCmd+TyOkwtwfHgs1ENj07r5g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.10.1",
-        "@docusaurus/cssnano-preset": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/babel": "3.10.2",
+        "@docusaurus/cssnano-preset": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -3475,18 +3490,18 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
-      "integrity": "sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.2.tgz",
+      "integrity": "sha512-EYByj6nk+aD9KeVxV6Hmo2/nAAT79P21Y82ycTBOBtrmqilloIbIEhgL2/8Xpt2Jz/pgNqHAwyusOGwmbKeJmA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.10.1",
-        "@docusaurus/bundler": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/babel": "3.10.2",
+        "@docusaurus/bundler": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3494,7 +3509,7 @@
         "combine-promises": "^1.1.0",
         "commander": "^5.1.0",
         "core-js": "^3.31.1",
-        "detect-port": "^1.5.1",
+        "detect-port": "^2.1.0",
         "escape-html": "^1.0.3",
         "eta": "^2.2.0",
         "eval": "^0.1.8",
@@ -3542,9 +3557,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz",
-      "integrity": "sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.2.tgz",
+      "integrity": "sha512-4gCnHRbJLTloiwfvFAa92tgb2gI4KYhvjfQVYnEaiMO/EgvWfCo1LwytHXen+1oZAN0VAlS0JAPxp3MsvKDa3A==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3557,15 +3572,15 @@
       }
     },
     "node_modules/@docusaurus/faster": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.10.1.tgz",
-      "integrity": "sha512-XTZhE5C1gZ/DaYYMlSk02dwP5vhpQON5QHVz1s3892mSESAywgWanURpXEDAvt4GvGuq7s+XP8rTWHZvfaJmdQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.10.2.tgz",
+      "integrity": "sha512-p/5E5/RyHv+QWusJMPN5i3OMJTqTgkhuwzVbB1AReDWTUHXQCmf5mlTFzGiDrWeQWIDOKsuOPn1jJh0s9LUOHA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.10.1",
+        "@docusaurus/types": "3.10.2",
         "@rspack/core": "^1.7.10",
-        "@swc/core": "^1.7.39",
-        "@swc/html": "^1.13.5",
+        "@swc/core": "^1.15.40",
+        "@swc/html": "^1.15.40",
         "browserslist": "^4.24.2",
         "lightningcss": "^1.27.0",
         "semver": "^7.5.4",
@@ -3581,9 +3596,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
-      "integrity": "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.2.tgz",
+      "integrity": "sha512-gSEwqtPfCAnC3ZSJY6xL7tcIfgg0vFD39jbv93eakuweyvO2864xR0K+kmKwBhkTCtWRNjuGGnb5rdmkD/ndqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3594,14 +3609,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz",
-      "integrity": "sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.2.tgz",
+      "integrity": "sha512-9Fd4V/SFjfrVQ0JH5EN0+iPWyFunvTeQE3gfyFeetqPaXMP0OylIjOw16dCuXG4NZJrYdBqwzjh18/h3gRi47w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3633,12 +3648,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
-      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
+      "integrity": "sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.10.1",
+        "@docusaurus/types": "3.10.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3652,16 +3667,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
-      "integrity": "sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.2.tgz",
+      "integrity": "sha512-z5I5ttCXw+8y2gHVZvqAMmUw4Rb0ZzKA5eCPk87SfM/jCKOTvE24yDpPAwwipvug96ij7mOwEHXWw8G4LlWdGA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -3676,19 +3691,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz",
-      "integrity": "sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.2.tgz",
+      "integrity": "sha512-0cbEnNKf0InmLkhj/+nVRmqEnWEoOE8Mh+2x1qOXI0qYpCnphq4RXknVJ8BvybKRXqYVvbmdMfiJSup+k4tm5w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "cheerio": "1.0.0-rc.12",
         "combine-promises": "^1.1.0",
         "feed": "^4.2.2",
@@ -3711,20 +3726,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
-      "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.2.tgz",
+      "integrity": "sha512-Sqwl4FPoZBDrlY8I2VU2H8O0M91CHp9T8ToMSkTZmjvHCif+1laqfXi6sTk8IfyVS/trN5yNjcWd1bFsGB6W5Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -3743,39 +3758,17 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
-      "integrity": "sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.2.tgz",
+      "integrity": "sha512-h5R12sZ/vV9EPiVjvIl9YFCOwkpwXes7dQMYt3EvP6Pphu4amHxxTqWxf08Fl5DR8h+oZMbWpFTNw5vKEYfvzQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -3789,15 +3782,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
-      "integrity": "sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.2.tgz",
+      "integrity": "sha512-UkdvQby5OQUKWrw3lLnSTJXQ6VETaUVTuPQX9AABtmFm5h+ifEBx1OQ+LN726Q4byuwBf2ElHkf4qU4hTxdvRg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3805,14 +3798,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.1.tgz",
-      "integrity": "sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.2.tgz",
+      "integrity": "sha512-8vbZNOSCpnsT57EY6CgN7sgRVmx3KTYwO8Uvo2pbxOyb8tbqAwtT9SslqaQ41HbA1v1hpn5RP7u5s2KvRwAFpQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
@@ -3826,14 +3819,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
-      "integrity": "sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.2.tgz",
+      "integrity": "sha512-kMHMBK9j4VAtgd5owwrRLRIi0EjkrpXlX7ePj1+y68XfVZV9I1T4S+koPDm+Hfw2TtnyHvh0uNrDvjz+DjQGVA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3845,15 +3838,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.1.tgz",
-      "integrity": "sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.2.tgz",
+      "integrity": "sha512-Vt90nNFhtAChRe9+it1hcHFgFvETdSnOkL5Bma+p6E/yU2tAYrvvyk+gv+LJGM2ZUkyKuKXLRsZ2Lb0bO7+Vog==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
-        "@types/gtag.js": "^0.0.20",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3865,14 +3857,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
-      "integrity": "sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.2.tgz",
+      "integrity": "sha512-MLCffCldysi/R0nzJQP7ZWd0xAoGNnSTiVOo6TTR6mKVGFhE+/XArGe67ZcaZv1uytgQXoXs92VJrgVDrz80rQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3884,17 +3876,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
-      "integrity": "sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.2.tgz",
+      "integrity": "sha512-PODkwg5XetLML3hU/3xpCKJUZ9cqExLaBnD/Fzzwj2VHogLeqnDisLIujae87zuze7T4mCm2A6KEqZkyiz07EQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3908,15 +3900,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
-      "integrity": "sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.2.tgz",
+      "integrity": "sha512-JgfT3jWM0TJ8Uw0cEcqxHpybngQY1vlBYpuuNO+gEh5iPh5Ar+vxq/u9CFrYsWeXy48BN7Db76Pzp2edNXUQ8A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -3931,26 +3923,26 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz",
-      "integrity": "sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.2.tgz",
+      "integrity": "sha512-a4B3VczmDl99zK0EufDQYomdJ186WDingjmDXxhN2PNPS9Ty/Y2M5CLFX1KQMRKqRTLiRDKfutzG5IY1FC/ceg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/plugin-content-blog": "3.10.1",
-        "@docusaurus/plugin-content-docs": "3.10.1",
-        "@docusaurus/plugin-content-pages": "3.10.1",
-        "@docusaurus/plugin-css-cascade-layers": "3.10.1",
-        "@docusaurus/plugin-debug": "3.10.1",
-        "@docusaurus/plugin-google-analytics": "3.10.1",
-        "@docusaurus/plugin-google-gtag": "3.10.1",
-        "@docusaurus/plugin-google-tag-manager": "3.10.1",
-        "@docusaurus/plugin-sitemap": "3.10.1",
-        "@docusaurus/plugin-svgr": "3.10.1",
-        "@docusaurus/theme-classic": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/theme-search-algolia": "3.10.1",
-        "@docusaurus/types": "3.10.1"
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/plugin-content-blog": "3.10.2",
+        "@docusaurus/plugin-content-docs": "3.10.2",
+        "@docusaurus/plugin-content-pages": "3.10.2",
+        "@docusaurus/plugin-css-cascade-layers": "3.10.2",
+        "@docusaurus/plugin-debug": "3.10.2",
+        "@docusaurus/plugin-google-analytics": "3.10.2",
+        "@docusaurus/plugin-google-gtag": "3.10.2",
+        "@docusaurus/plugin-google-tag-manager": "3.10.2",
+        "@docusaurus/plugin-sitemap": "3.10.2",
+        "@docusaurus/plugin-svgr": "3.10.2",
+        "@docusaurus/theme-classic": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/theme-search-algolia": "3.10.2",
+        "@docusaurus/types": "3.10.2"
       },
       "engines": {
         "node": ">=20.0"
@@ -3961,24 +3953,24 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz",
-      "integrity": "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.2.tgz",
+      "integrity": "sha512-JqTSLQmqmA9uKWZsD5iwBGJ4JyKB4/yTw6PsSXVPRJG/6GAm/u+add9Iip+hvwP12/AnPNztrdxsI14NJW4KeA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/plugin-content-blog": "3.10.1",
-        "@docusaurus/plugin-content-docs": "3.10.1",
-        "@docusaurus/plugin-content-pages": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/theme-translations": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/plugin-content-blog": "3.10.2",
+        "@docusaurus/plugin-content-docs": "3.10.2",
+        "@docusaurus/plugin-content-pages": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/theme-translations": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -4002,15 +3994,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
-      "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.2.tgz",
+      "integrity": "sha512-R9b/vMpK1yye6hNZTA6x/ivRv+at6GhxnXcxkpzCGzO1R1RwiquqiFg2wMFh6aqlJTpWRFKpFD2TzCDQcyOU0A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4030,20 +4022,20 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
-      "integrity": "sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.2.tgz",
+      "integrity": "sha512-1msxllyhi/5m77JukXtp5UFnUAriwZIC1oJ7MTnpQpCwLTbclJi5BK5n28CTZuSXpQN2ewbbnqRgAhMM6c6ihg==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "^1.19.2",
         "@docsearch/react": "^3.9.0 || ^4.3.2",
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/plugin-content-docs": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/theme-translations": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/plugin-content-docs": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/theme-translations": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "algoliasearch": "^5.37.0",
         "algoliasearch-helper": "^3.26.0",
         "clsx": "^2.0.0",
@@ -4062,9 +4054,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.1.tgz",
-      "integrity": "sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.2.tgz",
+      "integrity": "sha512-iv20wrxnyXkY89LM3TzRlzGlt5fIGO5UnaR6UL1ZVfB9RRFjxQFQ6awDrwAc6Km8Y5gD8pInuwYPF+6/TiCxXA==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -4075,16 +4067,16 @@
       }
     },
     "node_modules/@docusaurus/tsconfig": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.1.tgz",
-      "integrity": "sha512-rYvB7yqkdqWIpAbDzQljGfM4cDBkLTbhmagZBEcsyj6oPUsz47lmW2pYdN1j+7sGFgltbAmQH62xfbrij4Eh6Q==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.2.tgz",
+      "integrity": "sha512-5GiB7h/nFsMFPO9mCqcRNE1yA5TSXXNCshNIgHPL6fCPOjcTDixs6qjQBu8ddkgPcicwCvOA7n3jeK2rGdJk6g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4118,21 +4110,21 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
-      "integrity": "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.2.tgz",
+      "integrity": "sha512-xx0W3eav2uW1NRIpuHJWNwLTC15xPNjU4Uxi9NSnd3swYC96BE3vFiT93SD8s24kmAAWNwgZwfZ2fghGZ01Lcw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
+        "@11ty/gray-matter": "^1.0.0",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
         "escape-string-regexp": "^4.0.0",
         "execa": "^5.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "github-slugger": "^1.5.0",
         "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
         "jiti": "^1.20.0",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
@@ -4150,12 +4142,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
-      "integrity": "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.2.tgz",
+      "integrity": "sha512-x3Dz6jv6iQKBNjBmVTu8p57abMp/VNTUgKBMgRVXJc5444orBTsArv0+cdfrXTiz/VMmHfDRVkPbL7GH2B7T7w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.10.1",
+        "@docusaurus/types": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4163,14 +4155,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
-      "integrity": "sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.2.tgz",
+      "integrity": "sha512-sn8unbDfUL585NtR3cwHefPicOyaHvPaX7VD0aOg/siIxUBoKyKKaGEqzJZDS64mM43TnxurkYDtmB1wsJlZsw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4179,50 +4171,6 @@
       },
       "engines": {
         "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/utils-validation/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@docusaurus/utils-validation/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@emnapi/core": {
@@ -5350,9 +5298,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -5636,14 +5584,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
-      "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
+      "integrity": "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.26"
+        "@swc/types": "^0.1.27"
       },
       "engines": {
         "node": ">=10"
@@ -5653,18 +5601,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.40",
-        "@swc/core-darwin-x64": "1.15.40",
-        "@swc/core-linux-arm-gnueabihf": "1.15.40",
-        "@swc/core-linux-arm64-gnu": "1.15.40",
-        "@swc/core-linux-arm64-musl": "1.15.40",
-        "@swc/core-linux-ppc64-gnu": "1.15.40",
-        "@swc/core-linux-s390x-gnu": "1.15.40",
-        "@swc/core-linux-x64-gnu": "1.15.40",
-        "@swc/core-linux-x64-musl": "1.15.40",
-        "@swc/core-win32-arm64-msvc": "1.15.40",
-        "@swc/core-win32-ia32-msvc": "1.15.40",
-        "@swc/core-win32-x64-msvc": "1.15.40"
+        "@swc/core-darwin-arm64": "1.15.47",
+        "@swc/core-darwin-x64": "1.15.47",
+        "@swc/core-linux-arm-gnueabihf": "1.15.47",
+        "@swc/core-linux-arm64-gnu": "1.15.47",
+        "@swc/core-linux-arm64-musl": "1.15.47",
+        "@swc/core-linux-ppc64-gnu": "1.15.47",
+        "@swc/core-linux-s390x-gnu": "1.15.47",
+        "@swc/core-linux-x64-gnu": "1.15.47",
+        "@swc/core-linux-x64-musl": "1.15.47",
+        "@swc/core-win32-arm64-msvc": "1.15.47",
+        "@swc/core-win32-ia32-msvc": "1.15.47",
+        "@swc/core-win32-x64-msvc": "1.15.47"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -5676,9 +5624,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
-      "integrity": "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.47.tgz",
+      "integrity": "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==",
       "cpu": [
         "arm64"
       ],
@@ -5692,9 +5640,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
-      "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.47.tgz",
+      "integrity": "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==",
       "cpu": [
         "x64"
       ],
@@ -5708,9 +5656,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
-      "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.47.tgz",
+      "integrity": "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==",
       "cpu": [
         "arm"
       ],
@@ -5724,9 +5672,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
-      "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.47.tgz",
+      "integrity": "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==",
       "cpu": [
         "arm64"
       ],
@@ -5743,9 +5691,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
-      "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.47.tgz",
+      "integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
       "cpu": [
         "arm64"
       ],
@@ -5762,9 +5710,9 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
-      "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.47.tgz",
+      "integrity": "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==",
       "cpu": [
         "ppc64"
       ],
@@ -5781,9 +5729,9 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
-      "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.47.tgz",
+      "integrity": "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==",
       "cpu": [
         "s390x"
       ],
@@ -5800,9 +5748,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
-      "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.47.tgz",
+      "integrity": "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==",
       "cpu": [
         "x64"
       ],
@@ -5819,9 +5767,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
-      "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.47.tgz",
+      "integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
       "cpu": [
         "x64"
       ],
@@ -5838,9 +5786,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
-      "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.47.tgz",
+      "integrity": "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==",
       "cpu": [
         "arm64"
       ],
@@ -5854,9 +5802,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
-      "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.47.tgz",
+      "integrity": "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==",
       "cpu": [
         "ia32"
       ],
@@ -5870,9 +5818,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
-      "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.47.tgz",
+      "integrity": "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==",
       "cpu": [
         "x64"
       ],
@@ -5892,9 +5840,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/html": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.15.40.tgz",
-      "integrity": "sha512-YVWNrh3wZWH2oXz7uL+s1WZbFIsnAp9cCl/b+C7ufDJqhsOvbr0un9IOYZ/CxRIRdnHGfhVD199n8baD/kRQew==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.15.47.tgz",
+      "integrity": "sha512-Olu/8OORvYB+43v2/85nHe1EA8WSvWp8D3kctEAput/o4F+EWCK0nr4yGTqvWB7Z+ODz0k+vnxpvHQYzsKP2LA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -5903,24 +5851,24 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@swc/html-darwin-arm64": "1.15.40",
-        "@swc/html-darwin-x64": "1.15.40",
-        "@swc/html-linux-arm-gnueabihf": "1.15.40",
-        "@swc/html-linux-arm64-gnu": "1.15.40",
-        "@swc/html-linux-arm64-musl": "1.15.40",
-        "@swc/html-linux-ppc64-gnu": "1.15.40",
-        "@swc/html-linux-s390x-gnu": "1.15.40",
-        "@swc/html-linux-x64-gnu": "1.15.40",
-        "@swc/html-linux-x64-musl": "1.15.40",
-        "@swc/html-win32-arm64-msvc": "1.15.40",
-        "@swc/html-win32-ia32-msvc": "1.15.40",
-        "@swc/html-win32-x64-msvc": "1.15.40"
+        "@swc/html-darwin-arm64": "1.15.47",
+        "@swc/html-darwin-x64": "1.15.47",
+        "@swc/html-linux-arm-gnueabihf": "1.15.47",
+        "@swc/html-linux-arm64-gnu": "1.15.47",
+        "@swc/html-linux-arm64-musl": "1.15.47",
+        "@swc/html-linux-ppc64-gnu": "1.15.47",
+        "@swc/html-linux-s390x-gnu": "1.15.47",
+        "@swc/html-linux-x64-gnu": "1.15.47",
+        "@swc/html-linux-x64-musl": "1.15.47",
+        "@swc/html-win32-arm64-msvc": "1.15.47",
+        "@swc/html-win32-ia32-msvc": "1.15.47",
+        "@swc/html-win32-x64-msvc": "1.15.47"
       }
     },
     "node_modules/@swc/html-darwin-arm64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.15.40.tgz",
-      "integrity": "sha512-A9oxSh60pMEsX/4VBpn3e6s8DfGWsHzAeG+Vd9mXgkTqt/ouX12owP6RyqfqK8v0WuEsBKkGY0+MbwLvlOG8NQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.15.47.tgz",
+      "integrity": "sha512-Qe3FXNLO/k2WN7xmBP8SzBrtLvlIbyqa8cceUOI0opE4gk+myk5qIk022MiGJOgiF1B21/wMXgA08gYjQ2lP2Q==",
       "cpu": [
         "arm64"
       ],
@@ -5934,9 +5882,9 @@
       }
     },
     "node_modules/@swc/html-darwin-x64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.15.40.tgz",
-      "integrity": "sha512-GZ5KxJ/1pqnpOAjaa9hnkSk3M1LHjc5ci5GCt5/llAgDKFLDHzydIflHXTOIaS4nRCtfVMmD0joKX+ZWruSkJw==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.15.47.tgz",
+      "integrity": "sha512-khCOiWmqlqi8yz+F/ePExhht/+3/cz1XzKV7raPKVynzd6sPxYtFQlNubj305s2soEXgkYYIH0zVVLwiMOVn6Q==",
       "cpu": [
         "x64"
       ],
@@ -5950,9 +5898,9 @@
       }
     },
     "node_modules/@swc/html-linux-arm-gnueabihf": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.15.40.tgz",
-      "integrity": "sha512-Bbwtl0G6vYcWlDQmjeuyFx8YIvqi1StlQWjRNB1ZtvrRNL3JadFARhijBONiUIyTK9MgUbWtTV3QU69qzjNENQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.15.47.tgz",
+      "integrity": "sha512-7VRqaOEQEFPHSbUcnobmI59WbFK9M35Sse8TFN3hHxOlK9fINJ9yN5FuE9XEeRQAk+PFdR6WrIcF1Xwx1Cpi8A==",
       "cpu": [
         "arm"
       ],
@@ -5966,9 +5914,9 @@
       }
     },
     "node_modules/@swc/html-linux-arm64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.15.40.tgz",
-      "integrity": "sha512-buu4fGyCIhkwmCetI4CfWOPn7cphJHwQ9ksK685hlL0R0PUaDCNdIxo+JAz0mK2JgPhoGqnKsVEmV6gLIL5GBw==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.15.47.tgz",
+      "integrity": "sha512-Ri9MmQqVRiEWuRfpkSTqz0bguvejXQcqQAkoW1Hke6+DColfzETcgNWa/Kw/ii5A/SS9Nb7acKaYdIw1vMBPwA==",
       "cpu": [
         "arm64"
       ],
@@ -5985,9 +5933,9 @@
       }
     },
     "node_modules/@swc/html-linux-arm64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.15.40.tgz",
-      "integrity": "sha512-BwWtpAGEHIP1QwKExWqBIjGpAHMahjT26ORZv3+TbwW4IuEl2QP5FrcYc30O8abCG5J1lWRl1vXKYDpzbIDz1A==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.15.47.tgz",
+      "integrity": "sha512-NyXRQiVBkeutgCwCxUUaFqZdDmpZONs7Zz3AZGoY35s9GwXF412Nt22fK/e7lO/sM6G/+S3rOom/0xTmUQSK6A==",
       "cpu": [
         "arm64"
       ],
@@ -6004,9 +5952,9 @@
       }
     },
     "node_modules/@swc/html-linux-ppc64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-ppc64-gnu/-/html-linux-ppc64-gnu-1.15.40.tgz",
-      "integrity": "sha512-wLtHgwmZu5K7PvuTROklgWJO6D+KwywpYR1geI8dSWX/AYnx/KCGVK9ncPzWVfnLXWhXbkgua3Ujdrfoxf+qSw==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-ppc64-gnu/-/html-linux-ppc64-gnu-1.15.47.tgz",
+      "integrity": "sha512-rQ+XLJHFzu0e4M5p1+8kF2FKzI7WO9KPPji87OuicHZVrDCEqg7/jSGu3hys9CjIQIYVfR+tAFuZz3Q1/jOoNA==",
       "cpu": [
         "ppc64"
       ],
@@ -6023,9 +5971,9 @@
       }
     },
     "node_modules/@swc/html-linux-s390x-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-s390x-gnu/-/html-linux-s390x-gnu-1.15.40.tgz",
-      "integrity": "sha512-WbWzQBCmvECZG6ep9D5SMMZTFCbFmRSCc7lPD3YhhaK16BNqr1AybvybZYOgxX9Ot5tq7gTWCgjFZXLDOn6Y/g==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-s390x-gnu/-/html-linux-s390x-gnu-1.15.47.tgz",
+      "integrity": "sha512-w6bitHrllrE3lqmf14cT3spmWhZHGts1O08O4adzxztSPto7O5GM3IerqZm/NtsqlxNsfbVHnhaNXxXWe/8Q+Q==",
       "cpu": [
         "s390x"
       ],
@@ -6042,9 +5990,9 @@
       }
     },
     "node_modules/@swc/html-linux-x64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.15.40.tgz",
-      "integrity": "sha512-i+/JqL5j9mTGMcVshWLMzciqyE3Np+gN5+UqMyO1D5zSmniJD5MHRlGXCtLaWx/MIKX0Q4Xkre33o56fmxp+uA==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.15.47.tgz",
+      "integrity": "sha512-FTA7E29gcyadd71prg8sJUVacYrIhAXS8L7p48yCfgcNOKquofN1TDOrHVOyYMoxplL3FUwwbN+AZxWO7QfWPQ==",
       "cpu": [
         "x64"
       ],
@@ -6061,9 +6009,9 @@
       }
     },
     "node_modules/@swc/html-linux-x64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.15.40.tgz",
-      "integrity": "sha512-mroZnb5omFc4iE01UsJgta+Nm0sIFWpGfTPk+BHfH165MZAM4wNndeczX5RpGZbQSF1nNpCoNgqJyT7l3hITMg==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.15.47.tgz",
+      "integrity": "sha512-g+K1GKUrj+S9o8Qsgii2g7ooMzZ750R4IAqH5CVElIA5FTMAx7KGnu9ga6aEnRwwLYxY3s1k/nN+ls0NEk240g==",
       "cpu": [
         "x64"
       ],
@@ -6080,9 +6028,9 @@
       }
     },
     "node_modules/@swc/html-win32-arm64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.15.40.tgz",
-      "integrity": "sha512-qg1LXRrsY9FXy0S7vouSF0kkn1vdkTD//FW66iuezH7HMm5/DJGwEj7oc1zTKPWU0HnwOINOUbl6rUHrRuXHAQ==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.15.47.tgz",
+      "integrity": "sha512-5Iw3i00JdTySi+ccc2CM5bxY+8TZivQmcTqUC6mUdAY0/KYBgSe1/L294UJQ4OTLQqNDOYXY9jdb070zZUX7jg==",
       "cpu": [
         "arm64"
       ],
@@ -6096,9 +6044,9 @@
       }
     },
     "node_modules/@swc/html-win32-ia32-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.15.40.tgz",
-      "integrity": "sha512-5NwMmgt9A70LQzcYOl4OiIJk5AhsGP69fNRfkmXXop+iIcAGUmYy+d6F2/Gc0u05j9G0R04NPWcHBQrHQhr0Gw==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.15.47.tgz",
+      "integrity": "sha512-YkKd0hbIOeuFC1Sg7uGKkU2JhL+c9vAJlT6P0nRbWCAL71n01IPbdtbW6PmvgVmI7pxRYucXpr4pg839nX5+9Q==",
       "cpu": [
         "ia32"
       ],
@@ -6112,9 +6060,9 @@
       }
     },
     "node_modules/@swc/html-win32-x64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.15.40.tgz",
-      "integrity": "sha512-WUNZqCZ+8WY1pr8t3X3fq4gI5+FL/tCCzlrJ2lLn0s+TyA2SLm/RPfXxQIr94EnjJWcIV21G//6/uXeBN8cPzw==",
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.15.47.tgz",
+      "integrity": "sha512-w9Ug+VB9hlHT4hTWIJSB40AdF+qs5w07CYq/+ef1vQRjT5naN6/SKuXmr9/CKLn3T7A9z3lRMPKE4+lmtUkBOQ==",
       "cpu": [
         "x64"
       ],
@@ -6128,9 +6076,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
-      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
+      "integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -6244,16 +6192,10 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/gtag.js": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
-      "integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
-      "license": "MIT"
-    },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -6511,9 +6453,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
     },
     "node_modules/@webassemblyjs/ast": {
@@ -6763,12 +6705,12 @@
       }
     },
     "node_modules/address": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
-      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
+      "integrity": "sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -6830,34 +6772,34 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.53.0.tgz",
-      "integrity": "sha512-OGW1q6b91CRSSeiOnM8LxuR5NYJ2esvw66jUZ4IIvdv+ItNkx3pwLuyR+jaCdbGee4ov5WgUnyPryyh11xvByQ==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
+      "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.19.0",
-        "@algolia/client-abtesting": "5.53.0",
-        "@algolia/client-analytics": "5.53.0",
-        "@algolia/client-common": "5.53.0",
-        "@algolia/client-insights": "5.53.0",
-        "@algolia/client-personalization": "5.53.0",
-        "@algolia/client-query-suggestions": "5.53.0",
-        "@algolia/client-search": "5.53.0",
-        "@algolia/ingestion": "1.53.0",
-        "@algolia/monitoring": "1.53.0",
-        "@algolia/recommend": "5.53.0",
-        "@algolia/requester-browser-xhr": "5.53.0",
-        "@algolia/requester-fetch": "5.53.0",
-        "@algolia/requester-node-http": "5.53.0"
+        "@algolia/abtesting": "1.22.0",
+        "@algolia/client-abtesting": "5.56.0",
+        "@algolia/client-analytics": "5.56.0",
+        "@algolia/client-common": "5.56.0",
+        "@algolia/client-insights": "5.56.0",
+        "@algolia/client-personalization": "5.56.0",
+        "@algolia/client-query-suggestions": "5.56.0",
+        "@algolia/client-search": "5.56.0",
+        "@algolia/ingestion": "1.56.0",
+        "@algolia/monitoring": "1.56.0",
+        "@algolia/recommend": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.1.tgz",
-      "integrity": "sha512-6ck2YFudF2Pje7szQoPBiRFTGfd+1I+0I/WfLPGn0bj1kvrFoOQmNyedNiDxTk3/r4IfSLDYk+RA4G7u8H6+yA==",
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.3.tgz",
+      "integrity": "sha512-gVOMbbPVrCO3Xs+B+BLAIGFqIQow6qHMTYCEeBqLQB9m4ZmKUqMwkEumlal2iyyezHEd4Y0FvFTLbCRutCutIQ==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -6959,6 +6901,15 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -6998,9 +6949,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7017,8 +6968,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.2",
-        "caniuse-lite": "^1.0.30001787",
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -7031,6 +6982,69 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/update-browserslist-db": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/babel-loader": {
@@ -7124,9 +7138,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.34",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
-      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7460,9 +7474,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001797",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
-      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -8066,16 +8080,82 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
-      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.50.0.tgz",
+      "integrity": "sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1"
+        "browserslist": "^4.28.7"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-js-compat/node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/core-js-compat/node_modules/update-browserslist-db": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/core-util-is": {
@@ -8108,28 +8188,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -8199,9 +8257,9 @@
       }
     },
     "node_modules/css-blank-pseudo/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8273,9 +8331,9 @@
       }
     },
     "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8796,20 +8854,19 @@
       "license": "MIT"
     },
     "node_modules/detect-port": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
-      "integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-2.1.0.tgz",
+      "integrity": "sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==",
       "license": "MIT",
       "dependencies": {
-        "address": "^1.0.1",
-        "debug": "4"
+        "address": "^2.0.1"
       },
       "bin": {
-        "detect": "bin/detect-port.js",
-        "detect-port": "bin/detect-port.js"
+        "detect": "dist/commonjs/bin/detect-port.js",
+        "detect-port": "dist/commonjs/bin/detect-port.js"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/devlop": {
@@ -8980,9 +9037,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.368",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
-      "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
+      "version": "1.5.403",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
+      "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -10054,43 +10111,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/gray-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -11217,6 +11237,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -11333,9 +11366,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -11348,23 +11381,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -11382,9 +11415,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -11402,9 +11435,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -11422,9 +11455,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -11442,9 +11475,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -11462,9 +11495,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -11485,9 +11518,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -11508,9 +11541,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -11531,9 +11564,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -11554,9 +11587,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -11574,9 +11607,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -14166,9 +14199,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -14224,9 +14257,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -14822,9 +14855,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -14841,7 +14874,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -14875,9 +14908,9 @@
       }
     },
     "node_modules/postcss-attribute-case-insensitive/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15119,9 +15152,9 @@
       }
     },
     "node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15157,9 +15190,9 @@
       }
     },
     "node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15285,9 +15318,9 @@
       }
     },
     "node_modules/postcss-focus-visible/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15323,9 +15356,9 @@
       }
     },
     "node_modules/postcss-focus-within/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15612,9 +15645,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15640,9 +15673,9 @@
       }
     },
     "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15739,9 +15772,9 @@
       }
     },
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16102,9 +16135,9 @@
       }
     },
     "node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16195,9 +16228,9 @@
       }
     },
     "node_modules/postcss-selector-not/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16208,9 +16241,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16856,9 +16889,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
-      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.1.0"
@@ -17313,9 +17346,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -17467,9 +17500,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
-      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"

--- a/website/package.json
+++ b/website/package.json
@@ -15,10 +15,10 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.10.1",
-    "@docusaurus/faster": "3.10.1",
-    "@docusaurus/plugin-client-redirects": "^3.10.1",
-    "@docusaurus/preset-classic": "3.10.1",
+    "@docusaurus/core": "3.10.2",
+    "@docusaurus/faster": "3.10.2",
+    "@docusaurus/plugin-client-redirects": "^3.10.2",
+    "@docusaurus/preset-classic": "3.10.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -26,9 +26,9 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.10.1",
-    "@docusaurus/tsconfig": "3.10.1",
-    "@docusaurus/types": "3.10.1",
+    "@docusaurus/module-type-aliases": "3.10.2",
+    "@docusaurus/tsconfig": "3.10.2",
+    "@docusaurus/types": "3.10.2",
     "@types/react": "^19.0.0",
     "typescript": "~6.0.2"
   },
@@ -47,7 +47,8 @@
   "overrides": {
     "joi": "^17.13.4",
     "http-proxy-middleware": "^2.0.10",
-    "js-yaml": "^3.15.0",
+    "js-yaml": "3.15.1",
+    "nanoid": "3.3.18",
     "serialize-javascript": "^7.0.7",
     "uuid": "^11.1.1",
     "webpack-dev-server": "^5.2.6"


### PR DESCRIPTION
## Summary

Brings the existing Webhook publisher into full [CloudEvents HTTP binding](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md) and [HTTP WebHooks](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md) specification compliance — structured and binary content modes, plus the abuse-protection discovery handshake — **without changing existing delivery semantics**.

Closes #24.

## Changes

### Phase 1 — Wire-format compliance (binary content mode)

Binary content mode is **opt-in** via `MessageFormat = "cloudevents+binary"`. The legacy `json` default wire format is preserved byte-for-byte (regression-guarded).

- **`EventMessageFormat.CloudEventsBinary`** — new format constant (`src/Hermodr.Publisher/EventMessageFormat.cs`)
- **`CloudEventsBinarySerializer`** (new, `src/Hermodr.Publisher/CloudEventsBinarySerializer.cs`) — emits the raw event `data` as the body via `JsonEventFormatter.EncodeBinaryModeEventData`; batch throws `NotSupportedException` (no binary batch in spec)
- **`CloudEventHttpHeadersMapper`** (new, internal, `src/Hermodr.Publisher.Webhook/CloudEventHttpHeadersMapper.cs`) — projects CloudEvent context attributes onto `ce-*` HTTP headers (`specversion`/`id`/`type`/`source`/`time`/`datacontenttype`/`subject` + every populated extension)
- **`WebhookPublishChannel`** — detects binary mode in `PublishCoreAsync`, overrides `Content-Type` with the event's `datacontenttype`, maps `ce-*` headers, and emits them in `BuildRequest` before the `X-Webhook-*` headers; `PublishBatchAsync` rejects binary early
- **`EventPublisherBuilderExtensions`** — registers `CloudEventsBinarySerializer` as `IEventSerializer`

Per the spec (§3.1.1), `ce-datacontenttype` is **not** emitted as a header in binary mode — the `Content-Type` header carries that value. The signature is still computed over the raw body bytes only; `IWebhookSignatureProvider` is unchanged.

### Phase 2 — WebHook discovery / abuse protection

Implements the [CloudEvents HTTP WebHooks](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md) handshake. Opt-in via `WebhookPublishOptions.Discovery`. The publisher does **not** host the `WebHook-Request-Callback` endpoint — it only advertises the URL for the receiver to call.

- **`WebhookDiscoveryOptions`** (new) — `RequestOrigin`, `RequestCallback`, `RequestRate`, `RequestTimeout`, `RequireSuccessfulHandshake`
- **`WebhookDiscoveryPermission`** (new) — cached handshake result (`AllowedOrigin`, `AllowedRate`, `GrantedAt`)
- **`WebhookHandshakeException`** (new) — thrown in strict mode when the target refuses or the request faults
- **`WebhookHandshakeClient`** (new, internal) — performs the `OPTIONS` pre-flight, caches the granted permission per endpoint in a `ConcurrentDictionary`, and gates concurrent first deliveries to a single round-trip via a per-endpoint `SemaphoreSlim`. Parses `WebHook-Allowed-Origin` (incl. `*`) and `WebHook-Allowed-Rate` (incl. `*`)
- **`WebhookPublishChannel.DeliverAsync`** — lazily handshakes before the first delivery, attaches `WebHook-Request-Origin` to every POST (§2.1), and tags the publish `Activity` with the granted `webhook.allowed_origin` / `webhook.allowed_rate`
- **Retry-After on 429** (§2.2) — the retry pipeline `DelayGenerator` now reads the `Retry-After` header (delta-seconds **or** HTTP-date) and uses it as the next retry delay, overriding the configured exponential backoff. Falls back to backoff when the header is absent or unparseable
- **`WebhookPublishOptions.Merge`** — propagates `Discovery` through both the static `Merge` and the channel `MergeOptions` paths (per-call override wins)
- **3 new `[LoggerMessage]` events** (4009–4011): handshake granted / refused / failed

Best-effort vs strict handshake is configurable via `RequireSuccessfulHandshake`:
- `false` (default) — a refused/faulted handshake is logged and the delivery proceeds
- `true` — throws `WebhookHandshakeException` and suppresses the delivery POST

The granted `WebHook-Allowed-Rate` is **parsed and exposed** (via the handshake cache + activity tags) but **not auto-enforced**; the host can apply its own throttling policy.

## Zero breaking change

- Default `MessageFormat` is still `json` → `application/json` flat envelope (regression test `PublishAsync_DefaultFormat_DoesNotEmitCeHeaders`)
- `Discovery` defaults to `null` → no handshake, no `WebHook-Request-Origin` header (regression test `PublishAsync_NoDiscovery_NoOptionsRequest`)
- HMAC signing, retry policy, subscriber management, and all `X-Webhook-*` headers are preserved across both modes

## Tests

161 passing across `net8.0` / `net9.0` / `net10.0`:

| File | Tests | Coverage |
|------|-------|----------|
| `WebhookBinaryContentModeTests.cs` (new) | 13 | `ce-*` headers, content-type from `datacontenttype`, body-is-data-only, signing over body bytes, batch rejection, per-call override, legacy regression |
| `WebhookDiscoveryTests.cs` (new) | 11 | OPTIONS-before-POST, request headers, per-delivery origin, cache-once-per-endpoint, refused/faulted × best-effort/strict, `*` allowed-rate, no-Discovery regression, Retry-After timing |
| `WebhookCoverageTests.cs` (new) | 28 | `GetChannelMetadata`, full `Merge`/`MergeOptions` matrices, `TryGetRetryAfterDelay` (HTTP-date/past/invalid), `GetSignatureProvider` throw, handshake cache `GetCached`/`Evict`, ctor arg validation, exception getters, config-section DI bindings, `CloudEventHttpHeadersMapper` edge cases |
| existing | 109 | unchanged |

**Webhook source coverage: 92.6% line / 96.6% block** (measured via `Microsoft.Testing.Extensions.CodeCoverage`).

Internal members (`WebhookHandshakeClient`, `WebhookPublishChannel`) are tested via **reflection only** — no `InternalsVisibleTo` attribute is used, so the production assembly stays sealed.

## Verification

- `dotnet build Hermodr.sln` — 0 errors
- `dotnet test Hermodr.Publisher.Webhook.XUnit` — 161/161 passed across all 3 TFMs
- `dotnet test Hermodr.Publisher.XUnit` — 251/251 passed (no regressions in consumers)

## Files

**New (6):** `CloudEventsBinarySerializer.cs`, `CloudEventHttpHeadersMapper.cs`, `WebhookDiscoveryOptions.cs`, `WebhookDiscoveryPermission.cs`, `WebhookHandshakeClient.cs`, `WebhookHandshakeException.cs`

**Modified (5):** `EventMessageFormat.cs`, `WebhookPublishChannel.cs`, `WebhookPublishOptions.cs`, `EventPublisherBuilderExtensions.cs`, `LoggerExtensions.cs`

**New tests (3):** `WebhookBinaryContentModeTests.cs`, `WebhookDiscoveryTests.cs`, `WebhookCoverageTests.cs`

## Out of scope

- Auto-throttling deliveries to the granted `WebHook-Allowed-Rate` (host decides; rate is exposed but not enforced)
- Hosting the `WebHook-Request-Callback` endpoint (belongs to the receiver/subscription layer)